### PR TITLE
Debug: reduce default program buffer size since impebreak is an option

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -121,7 +121,7 @@ import DebugAbstractCommandType._
 
 case class DebugModuleParams (
   nDMIAddrSize  : Int = 7,
-  nProgramBufferWords: Int = 16,
+  nProgramBufferWords: Int = 2,
   nAbstractDataWords : Int = 4,
   nScratch : Int = 1,
   //TODO: Use diplomacy to decide if you want this.
@@ -135,7 +135,7 @@ case class DebugModuleParams (
   supportHartArray   : Boolean = false,
   hartIdToHartSel : (UInt) => UInt = (x:UInt) => x,
   hartSelToHartId : (UInt) => UInt = (x:UInt) => x,
-  hasImplicitEbreak : Boolean = false
+  hasImplicitEbreak : Boolean = true
 ) {
 
   if (hasBusMaster == false){

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -121,7 +121,7 @@ import DebugAbstractCommandType._
 
 case class DebugModuleParams (
   nDMIAddrSize  : Int = 7,
-  nProgramBufferWords: Int = 2,
+  nProgramBufferWords: Int = 4,
   nAbstractDataWords : Int = 4,
   nScratch : Int = 1,
   //TODO: Use diplomacy to decide if you want this.


### PR DESCRIPTION
Turn down the program buffer words to 2 and use implicit ebreak.

@timsifive is 2 program buffer words enough ?