### PR TITLE
devices: maskrom has helper object attach instead of trait

### DIFF
--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -56,8 +56,6 @@ class TLMaskROM(c: MaskROMParams)(implicit p: Parameters) extends LazyModule {
   }
 }
 
-case object PeripheryMaskROMKey extends Field[Seq[MaskROMParams]](Nil)
-
 object MaskROM {
   def attach(params: MaskROMParams, bus: TLBusWrapper)(implicit p: Parameters): TLMaskROM = {
     val maskROM = LazyModule(new TLMaskROM(params))


### PR DESCRIPTION
MaskROM can be attached via a helper object to any bus (instead of via a trait to the `cbus` only).