### PR TITLE
Fix URL in README.md in FPGA section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ You can generate synthesizable Verilog with the following commands:
 
 The Verilog used for the FPGA tools will be generated in
 vsim/generated-src. Please proceed further with the directions shown in
-the [README](https://github.com/sifive/freedom/README.md)
+the [README](https://github.com/sifive/freedom/blob/master/README.md)
 of the freedom repository. You can also run Rocket Chip on Amazon EC2 F1
 with [FireSim](https://github.com/firesim/firesim).
 


### PR DESCRIPTION
Fixes a broken URL in the `README.md` which was supposed to be pointing at the SiFive Freedom README.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

