### PR TITLE
Plic clint optional

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -293,6 +293,11 @@ class WithNExtTopInterrupts(nExtInts: Int) extends Config((site, here, up) => {
   case NExtTopInterrupts => nExtInts
 })
 
+class WithoutPlic() extends Config((site, here, up) => {
+  case PLICKey => None
+  case NExtTopInterrupts => 0
+})
+
 class WithoutClint() extends Config((site, here, up) => {
   case CLINTKey => None
 })

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -293,6 +293,10 @@ class WithNExtTopInterrupts(nExtInts: Int) extends Config((site, here, up) => {
   case NExtTopInterrupts => nExtInts
 })
 
+class WithoutClint() extends Config((site, here, up) => {
+  case CLINTKey => None
+})
+
 class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {
   case ExtMem => up(ExtMem, site).map(_.copy(nMemoryChannels = n))
 })

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -103,7 +103,7 @@ trait HasTiles { this: BaseSubsystem =>
     //    From CLINT: "msip" and "mtip"
     tile.crossIntIn() :=
       clintOpt.map { _.intnode }
-        .getOrElse { NullIntSource(sources = CLINTConsts.ints) }
+        .getOrElse { NullIntSource() }
 
     //    From PLIC: "meip"
     tile.crossIntIn() :=


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable --> None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
-->
Add explicit config option `WithoutPlic()` which both configures `PLICKEY` and `NExtTopInterrupts`. Thus one could remove the PLIC from the core completely if no interrupt controller needed or extern interrupt controller is used.   
Fix bug in `connectInterrupts` when Clint is absent. Since no clint is implemented, no intsource should be connected to the intnode.  
Add explicit config option `WithoutClint()` for easy use. 