### PR TITLE
fix configs in system/configs.scala (pt. 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,18 +401,6 @@ BaseConfig. You can change those numbers to get a Rocket core with different
 cache parameters. For example, by changing L1I, NWays to 4, you will get
 a 32KB 4-way set-associative L1 instruction cache rather than a 16KB 2-way
 set-associative L1 instruction cache.
-
-Further down, you will be able to see two FPGA configurations:
-DefaultFPGAConfig and DefaultFPGASmallConfig. DefaultFPGAConfig inherits from
-BaseConfig, but overrides the low-performance memory port (i.e., backup
-memory port) to be turned off. This is because the high-performance memory
-port is directly connected to the high-performance AXI interface on the ZYNQ
-FPGA. DefaultFPGASmallConfig inherits from DefaultFPGAConfig, but changes the
-cache sizes, disables the FPU, turns off the fast early-out multiplier and
-divider, and reduces the number of TLB entries (all defined in SmallConfig).
-This small configuration is used for the Zybo FPGA board, which has the
-smallest ZYNQ part.
-
 Towards the end, you can also find that DefaultSmallConfig inherits all
 parameters from BaseConfig but overrides the same parameters of
 WithNSmallCores.

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -82,9 +82,25 @@ CONFIGS += $(CONFIGS_32)
 CONFIGS += $(CONFIGS_64)
 endif
 
+# Miscellaneous configs cover any remaining configurations not tested
+# above, but are included in the freechips.rocketchip.system package.
+# These are here to prevent regressions at the compilation level and
+# expected to be built, but not executed.
 ifeq ($(SUITE), Miscellaneous)
 PROJECT=freechips.rocketchip.system
-CONFIGS=RoccExampleConfig
+CONFIGS=\
+	DefaultSmallConfig \
+	DualBankConfig \
+	DualChannelConfig \
+	DualChannelDualBankConfig \
+	RoccExampleConfig \
+	Edge128BitConfig \
+	Edge32BitConfig \
+	QuadChannelBenchmarkConfig \
+	EightChannelConfig \
+	DualCoreConfig \
+	MemPortOnlyConfig \
+	MMIOPortOnlyConfig
 endif
 
 # These are the named regression targets.  While it's expected you run them in

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -55,7 +55,7 @@ class MemoryBus(params: MemoryBusParams)(implicit p: Parameters)
 
   private val xbar = LazyModule(new TLXbar).suggestName(busName + "_xbar")
   def inwardNode: TLInwardNode =
-    if (params.replicatorMask == 0) xbar.node else { xbar.node :*= RegionReplicator(params.replicatorMask) }
+    if (params.replicatorMask == 0) xbar.node else { xbar.node :=* RegionReplicator(params.replicatorMask) }
   def outwardNode: TLOutwardNode = ProbePicker() :*= xbar.node
   def busView: TLEdge = xbar.node.edges.in.head
   attachBuiltInDevices(params)

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -64,6 +64,6 @@ class MemoryBus(params: MemoryBusParams)(implicit p: Parameters)
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[ TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle, D,U,E,B] =
         TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
-    to("memory_controller" named name) { gen := TLWidthWidget(params.beatBytes) := TLBuffer(buffer) := outwardNode }
+    to("memory_controller" named name) { gen :*= TLWidthWidget(params.beatBytes) :*= TLBuffer(buffer) :*= outwardNode }
   }
 }

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -52,8 +52,10 @@ trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
         beatBytes = memPortParams.beatBytes)
     })
 
-    memAXI4Node := mbus.toDRAMController(Some(portName)) {
-      AXI4UserYanker() := AXI4IdIndexer(memPortParams.idBits) := TLToAXI4()
+    (0 until nMemoryChannels).map { i => 
+      memAXI4Node := mbus.toDRAMController(Some(portName)) {
+        AXI4UserYanker() := AXI4IdIndexer(memPortParams.idBits) := TLToAXI4()
+      }
     }
 
     memAXI4Node

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -52,10 +52,8 @@ trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
         beatBytes = memPortParams.beatBytes)
     })
 
-    (0 until nMemoryChannels).map { i => 
-      memAXI4Node := mbus.toDRAMController(Some(portName)) {
-        AXI4UserYanker() := AXI4IdIndexer(memPortParams.idBits) := TLToAXI4()
-      }
+    memAXI4Node :*= mbus.toDRAMController(Some(portName)) {
+      AXI4UserYanker() :*= AXI4IdIndexer(memPortParams.idBits) :*= TLToAXI4()
     }
 
     memAXI4Node

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -80,6 +80,4 @@ class MMIOPortOnlyConfig extends Config(
 )
 
 class BaseFPGAConfig extends Config(new BaseConfig)
-
 class DefaultFPGAConfig extends Config(new WithNSmallCores(1) ++ new BaseFPGAConfig)
-class DefaultFPGASmallConfig extends Config(new DefaultFPGAConfig)

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -31,13 +31,13 @@ class DefaultSmallConfig extends Config(new WithNSmallCores(1) ++ new BaseConfig
 class DefaultRV32Config extends Config(new WithRV32 ++ new DefaultConfig)
 
 class DualBankConfig extends Config(
-  new WithNBanks(2) ++ new BaseConfig)
+  new WithNBanks(2) ++ new DefaultConfig)
 
 class DualChannelConfig extends Config(new WithNMemoryChannels(2) ++ new DefaultConfig)
 
 class DualChannelDualBankConfig extends Config(
   new WithNMemoryChannels(2) ++
-  new WithNBanks(4) ++ new BaseConfig)
+  new WithNBanks(4) ++ new DefaultConfig)
 
 class RoccExampleConfig extends Config(new WithRoccExample ++ new DefaultConfig)
 
@@ -51,7 +51,7 @@ class DualChannelBenchmarkConfig extends Config(new WithNMemoryChannels(2) ++ ne
 class QuadChannelBenchmarkConfig extends Config(new WithNMemoryChannels(4) ++ new SingleChannelBenchmarkConfig)
 class OctoChannelBenchmarkConfig extends Config(new WithNMemoryChannels(8) ++ new SingleChannelBenchmarkConfig)
 
-class EightChannelConfig extends Config(new WithNMemoryChannels(8) ++ new BaseConfig)
+class EightChannelConfig extends Config(new WithNMemoryChannels(8) ++ new DefaultConfig)
 
 class DualCoreConfig extends Config(
   new WithNBigCores(2) ++ new BaseConfig)

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -33,7 +33,7 @@ class DefaultRV32Config extends Config(new WithRV32 ++ new DefaultConfig)
 class DualBankConfig extends Config(
   new WithNBanks(2) ++ new BaseConfig)
 
-class DualChannelConfig extends Config(new WithNMemoryChannels(2) ++ new BaseConfig)
+class DualChannelConfig extends Config(new WithNMemoryChannels(2) ++ new DefaultConfig)
 
 class DualChannelDualBankConfig extends Config(
   new WithNMemoryChannels(2) ++
@@ -42,9 +42,9 @@ class DualChannelDualBankConfig extends Config(
 class RoccExampleConfig extends Config(new WithRoccExample ++ new DefaultConfig)
 
 class Edge128BitConfig extends Config(
-  new WithEdgeDataBits(128) ++ new BaseConfig)
+  new WithEdgeDataBits(128) ++ new DefaultConfig)
 class Edge32BitConfig extends Config(
-  new WithEdgeDataBits(32) ++ new BaseConfig)
+  new WithEdgeDataBits(32) ++ new DefaultConfig)
 
 class SingleChannelBenchmarkConfig extends Config(new DefaultConfig)
 class DualChannelBenchmarkConfig extends Config(new WithNMemoryChannels(2) ++ new SingleChannelBenchmarkConfig)

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -24,7 +24,7 @@ class BaseConfig extends Config(
 
 class DefaultConfig extends Config(new WithNBigCores(1) ++ new BaseConfig)
 
-class DefaultBufferlessConfig extends Config(new WithBufferlessBroadcastHub ++ DefaultConfig)
+class DefaultBufferlessConfig extends Config(new WithBufferlessBroadcastHub ++ new DefaultConfig)
 class DefaultSmallConfig extends Config(new WithNSmallCores(1) ++ new BaseConfig)
 class DefaultRV32Config extends Config(new WithRV32 ++ new DefaultConfig)
 

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -24,16 +24,14 @@ class BaseConfig extends Config(
 
 class DefaultConfig extends Config(new WithNBigCores(1) ++ new BaseConfig)
 
-class DefaultBufferlessConfig extends Config(
-  new WithBufferlessBroadcastHub ++ new WithNBigCores(1) ++ new BaseConfig)
-
+class DefaultBufferlessConfig extends Config(new WithBufferlessBroadcastHub ++ DefaultConfig)
 class DefaultSmallConfig extends Config(new WithNSmallCores(1) ++ new BaseConfig)
 class DefaultRV32Config extends Config(new WithRV32 ++ new DefaultConfig)
 
-class DualBankConfig extends Config(
-  new WithNBanks(2) ++ new DefaultConfig)
-
+class DualBankConfig extends Config(new WithNBanks(2) ++ new DefaultConfig)
+class DualCoreConfig extends Config( new WithNBigCores(2) ++ new BaseConfig)
 class DualChannelConfig extends Config(new WithNMemoryChannels(2) ++ new DefaultConfig)
+class EightChannelConfig extends Config(new WithNMemoryChannels(8) ++ new DefaultConfig)
 
 class DualChannelDualBankConfig extends Config(
   new WithNMemoryChannels(2) ++
@@ -50,11 +48,6 @@ class SingleChannelBenchmarkConfig extends Config(new DefaultConfig)
 class DualChannelBenchmarkConfig extends Config(new WithNMemoryChannels(2) ++ new SingleChannelBenchmarkConfig)
 class QuadChannelBenchmarkConfig extends Config(new WithNMemoryChannels(4) ++ new SingleChannelBenchmarkConfig)
 class OctoChannelBenchmarkConfig extends Config(new WithNMemoryChannels(8) ++ new SingleChannelBenchmarkConfig)
-
-class EightChannelConfig extends Config(new WithNMemoryChannels(8) ++ new DefaultConfig)
-
-class DualCoreConfig extends Config(
-  new WithNBigCores(2) ++ new BaseConfig)
 
 class TinyConfig extends Config(
   new WithNoMemPort ++


### PR DESCRIPTION
**Related issue**: Closes #1779 Closes #1788 Closes #1785 

@codelec thanks for your contribution, I expanded upon it somewhat:
- I used the `:*=` flexible cardinality operator to allow the left-hand-side of the adapter chain to set the number of ports from the blind terminal node all the way through to the memory bus crossbar.
- There were a few more cases where `BaseConfig` was being used instead of `DefaultConfig`
- I removed the vestigial `DefaultFPGASmallConfig`; use `DefaultFPGAConfig` instead, or just write your own :)

@seldridge I did not adjust the testing plan at this time 🙇 forgive me. Can you open a new issue along the lines of "Actually test all the configs in `system/configs.scala`"

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: API modification; removed defunct `DefaultFPGASmallConfig`, fixed broken multi-channel configs, updated readme

<!-- choose one -->
**Development Phase**:  implementation
