### PR TITLE
subsystem: add MaskROM to RocketSubsystem

### DIFF
--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -1,0 +1,27 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.subsystem
+
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+trait HasHierarchicalBusTopology { this: BaseSubsystem =>
+  // The sbus masters the cbus; here we convert TL-UH -> TL-UL
+  sbus.crossToBus(cbus, NoCrossing)
+
+  // The cbus masters the pbus; which might be clocked slower
+  cbus.crossToBus(pbus, SynchronousCrossing())
+
+  // The fbus masters the sbus; both are TL-UH or TL-C
+  FlipRendering { implicit p =>
+    sbus.crossFromBus(fbus, SynchronousCrossing())
+  }
+
+  // The sbus masters the mbus; here we convert TL-C -> TL-UH
+  private val BankedL2Params(nBanks, coherenceManager) = p(BankedL2Key)
+  private val (in, out, halt) = coherenceManager(this)
+  if (nBanks != 0) {
+    sbus.coupleTo("coherence_manager") { in :*= _ }
+    mbus.coupleFrom("coherence_manager") { _ :=* BankBinder(mbus.blockBytes * (nBanks-1)) :*= out }
+  }
+}

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -65,7 +65,7 @@ trait HasRocketTilesModuleImp extends HasTilesModuleImp
 }
 
 // Field for specifying MaskROM addition to subsystem
-case object Periphery extends Field[Seq[MaskROMParams]](Nil)
+case object PeripheryMaskROMKey extends Field[Seq[MaskROMParams]](Nil)
 
 class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
     with HasRocketTiles {

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -65,14 +65,14 @@ trait HasRocketTilesModuleImp extends HasTilesModuleImp
 }
 
 // Field for specifying MaskROM addition to subsystem
-case object PeripheryMaskROMKey extends Field[Seq[MaskROMParams]](Nil)
+case object Periphery extends Field[Seq[MaskROMParams]](Nil)
 
 class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
     with HasRocketTiles {
   val tiles = rocketTiles
         
   // add Mask ROM devices
-  val maskROMs = p(SubsystemMaskROMKey).map { MaskROM.attach(_, cbus) }
+  val maskROMs = p(PeripheryMaskROMKey).map { MaskROM.attach(_, cbus) }
 
   override lazy val module = new RocketSubsystemModuleImp(this)
 }

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -12,7 +12,6 @@ import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
 import freechips.rocketchip.diplomaticobjectmodel.model._
 import freechips.rocketchip.tile._
 
-
 // TODO: how specific are these to RocketTiles?
 case class TileMasterPortParams(buffers: Int = 0, cork: Option[Boolean] = None)
 case class TileSlavePortParams(buffers: Int = 0, blockerCtrlAddr: Option[BigInt] = None)
@@ -65,9 +64,16 @@ trait HasRocketTilesModuleImp extends HasTilesModuleImp
   val outer: HasRocketTiles
 }
 
+// Field for specifying MaskROM addition to subsystem
+case object PeripheryMaskROMKey extends Field[Seq[MaskROMParams]](Nil)
+
 class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
     with HasRocketTiles {
   val tiles = rocketTiles
+        
+  // add Mask ROM devices
+  val maskROMs = p(SubsystemMaskROMKey).map { MaskROM.attach(_, cbus) }
+
   override lazy val module = new RocketSubsystemModuleImp(this)
 }
 

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -5,38 +5,19 @@ package freechips.rocketchip.system
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util.DontTouch
 
 /** Example Top with periphery devices and ports, and a Rocket subsystem */
 class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
+    with HasHierarchicalBusTopology
     with HasAsyncExtInterrupts
     with CanHaveMasterAXI4MemPort
     with CanHaveMasterAXI4MMIOPort
     with CanHaveSlaveAXI4Port
     with HasPeripheryBootROM {
   override lazy val module = new ExampleRocketSystemModuleImp(this)
-
-  // The sbus masters the cbus; here we convert TL-UH -> TL-UL
-  sbus.crossToBus(cbus, NoCrossing)
-
-  // The cbus masters the pbus; which might be clocked slower
-  cbus.crossToBus(pbus, SynchronousCrossing())
-
-  // The fbus masters the sbus; both are TL-UH or TL-C
-  FlipRendering { implicit p =>
-    sbus.crossFromBus(fbus, SynchronousCrossing())
-  }
-
-  // The sbus masters the mbus; here we convert TL-C -> TL-UH
-  private val BankedL2Params(nBanks, coherenceManager) = p(BankedL2Key)
-  private val (in, out, halt) = coherenceManager(this)
-  if (nBanks != 0) {
-    sbus.coupleTo("coherence_manager") { in :*= _ }
-    mbus.coupleFrom("coherence_manager") { _ :=* BankBinder(mbus.blockBytes * (nBanks-1)) :*= out }
-  }
 }
 
 class ExampleRocketSystemModuleImp[+L <: ExampleRocketSystem](_outer: L) extends RocketSubsystemModuleImp(_outer)


### PR DESCRIPTION
Unify the addition of MaskROMs to all subsystem classes that inherit from `RocketSubsystem`

Factor out bus interconnections in `HasHierarchicalBusTopology`