### PR TITLE
PSD: Ensure that PSD is connected to dmactive-derived reset 

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -96,6 +96,9 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
   // TODO in inheriting traits: Set this to something meaningful, e.g. "component is in reset or powered down"
   outer.debug.module.io.ctrl.debugUnavail.foreach { _ := Bool(false) }
 
+  val psd = debug.psd.getOrElse(Wire(new PSDTestMode).fromBits(0.U))
+  outer.debug.module.io.psd <> psd
+
   def instantiateJtagDTM(sj: SystemJTAGIO): DebugTransportModuleJTAG = {
 
     val dtm = Module(new DebugTransportModuleJTAG(p(DebugModuleParams).nDMIAddrSize, p(JtagDTMKey)))
@@ -110,8 +113,6 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
     outer.debug.module.io.dmi.get.dmi <> dtm.io.dmi
     outer.debug.module.io.dmi.get.dmiClock := sj.jtag.TCK
 
-    val psd = debug.psd.getOrElse(Wire(new PSDTestMode).fromBits(0.U))
-    outer.debug.module.io.psd <> psd
     outer.debug.module.io.dmi.get.dmiReset := ResetCatchAndSync(sj.jtag.TCK, sj.reset, "dmiResetCatch", psd)
     dtm
   }

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -113,6 +113,7 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
     outer.debug.module.io.dmi.get.dmi <> dtm.io.dmi
     outer.debug.module.io.dmi.get.dmiClock := sj.jtag.TCK
 
+    val psd = debug.psd.getOrElse(Wire(new PSDTestMode).fromBits(0.U))
     outer.debug.module.io.dmi.get.dmiReset := ResetCatchAndSync(sj.jtag.TCK, sj.reset, "dmiResetCatch", psd)
     dtm
   }


### PR DESCRIPTION
When debug interface was APB, this was not getting connected up to the top level I/Os. Now this is connected up so that Post-Silicon-Debug controls can fully control the internal reset generated by `dmactive`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change
<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
