### PR TITLE
add BlackBox resource annotation to EICG_wrapper

### DIFF
--- a/src/main/scala/util/ClockGate.scala
+++ b/src/main/scala/util/ClockGate.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.util
 
 import chisel3._
+import chisel3.util.HasBlackBoxResource
 import freechips.rocketchip.config.{Field, Parameters}
 
 case object ClockGateImpl extends Field[() => ClockGate](() => new EICG_wrapper)
@@ -35,4 +36,6 @@ object ClockGate {
 }
 
 // behavioral model of Integrated Clock Gating cell
-class EICG_wrapper extends ClockGate
+class EICG_wrapper extends ClockGate with HasBlackBoxResource {
+  addResource("/vsrc/EICG_wrapper.v")
+}


### PR DESCRIPTION
The EICG_wrapper black box does not have a resource annotation, which breaks workflows that use it to pull in the verilog sources. 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
