### PR TITLE
APB userbits support

### DIFF
--- a/src/main/scala/amba/apb/Bundles.scala
+++ b/src/main/scala/amba/apb/Bundles.scala
@@ -20,6 +20,7 @@ class APBBundle(params: APBBundleParameters) extends APBBundleBase(params)
   val pprot     = UInt(OUTPUT, width = params.protBits)
   val pwdata    = UInt(OUTPUT, width = params.dataBits)
   val pstrb     = UInt(OUTPUT, width = params.dataBits/8)
+  val pauser    = if (params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
 
   val pready    = Bool(INPUT)
   val pslverr   = Bool(INPUT)
@@ -37,6 +38,7 @@ class APBBundle(params: APBBundleParameters) extends APBBundleBase(params)
         pprot   := APBParameters.PROT_DEFAULT
         pwdata  := UInt(0)
         pstrb   := UInt(0)
+        pauser.map {_ := UInt(0)}
       case _ =>
     }
   }

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -58,7 +58,15 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
       name        = "TLFragmenter",
       sourceId    = IdRange(0, if (minSize == maxSize) c.endSourceId else (c.endSourceId << addedBits)),
       requestFifo = true,
-      userBits    = c.clients.map( _.userBits).maxBy(_.length))))},
+      userBits    = {
+        require( c.clients.forall( _.userBits.length == c.clients(0).userBits.length ),
+          s"Length of userBits sequences of all clients must be equal.")
+        require( c.clients.forall( _.userBits.zip( c.clients(0).userBits ).forall { case (a, b) => a.width == b.width } ),
+          s"Width of corresponding userBits for all clients must match.")
+
+        c.clients(0).userBits
+      })))
+    },
     managerFn = { m => m.copy(managers = m.managers.map(mapManager)) })
 
   lazy val module = new LazyModuleImp(this) {

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -57,7 +57,8 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
     clientFn  = { c => c.copy(clients = Seq(TLClientParameters(
       name        = "TLFragmenter",
       sourceId    = IdRange(0, if (minSize == maxSize) c.endSourceId else (c.endSourceId << addedBits)),
-      requestFifo = true))) },
+      requestFifo = true,
+      userBits    = c.clients.map( _.userBits).maxBy(_.length))))},
     managerFn = { m => m.copy(managers = m.managers.map(mapManager)) })
 
   lazy val module = new LazyModuleImp(this) {
@@ -121,7 +122,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
          * get4    get4   0       ackD4   0      ackD4     0    0
          * get1    get1   0       ackD1   0      ackD1     0    0
          *
-         * put64   put16  6                                15   
+         * put64   put16  6                                15
          * put64   put16  6                                14
          * put64   put16  6                                13
          * put64   put16  6       ack16   6                12    12
@@ -252,7 +253,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         val maxLgPutPartial  = Mux1H(find, maxLgPutPartials)
         val maxLgHint        = Mux1H(find, maxLgHints)
 
-        val limit = if (alwaysMin) lgMinSize else 
+        val limit = if (alwaysMin) lgMinSize else
           MuxLookup(in_a.bits.opcode, lgMinSize, Array(
             TLMessages.PutFullData    -> maxLgPutFull,
             TLMessages.PutPartialData -> maxLgPutPartial,

--- a/src/main/scala/tilelink/ToAPB.scala
+++ b/src/main/scala/tilelink/ToAPB.scala
@@ -11,7 +11,7 @@ import APBParameters._
 
 case class TLToAPBNode()(implicit valName: ValName) extends MixedAdapterNode(TLImp, APBImp)(
   dFn = { case TLClientPortParameters(clients, minLatency) =>
-    val masters = clients.map { case c => APBMasterParameters(name = c.name, nodePath = c.nodePath) }
+    val masters = clients.map { case c => APBMasterParameters(name = c.name, nodePath = c.nodePath, userBits = c.userBits) }
     APBMasterPortParameters(masters)
   },
   uFn = { case APBSlavePortParameters(slaves, beatBytes) =>
@@ -78,6 +78,8 @@ class TLToAPB(val aFlow: Boolean = true)(implicit p: Parameters) extends LazyMod
       out.pprot   := PROT_DEFAULT
       out.pwdata  := a.bits.data
       out.pstrb   := Mux(a_write, a.bits.mask, UInt(0))
+
+      a.bits.user.map {i => out.pauser.map {_ := i}}
 
       a.ready := a_enable && out.pready
       d.valid := a_enable && out.pready


### PR DESCRIPTION
This PR adds a `pauser` optional field in APB bundles to propagate `UserBits` metadata from TileLink to APB dongles.
- Added `pauser` in `APBBundle`, and relevant support in APB port parameters
- Added support for userbits in `TLToAPB` adapter
- Added support for userbits in `TLFragmenter` node
- Verified propagation of userbits in waveform
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable --> #1931, #1939 

<!-- choose one -->
**Type of change**: feature add

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Added `UserBits` support in APB and `TLFragmenter`.