### PR TITLE
BankBinder should skip addresses with no intersecting address ranges

### DIFF
--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -33,16 +33,21 @@ case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCus
       supportsHint       = c.supportsHint       intersect maxXfer)})}
 
   def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] =
-    (p zip ids) map { case (mp, id) => mp.copy(managers = mp.managers.map { m => m.copy(
-      address            = m.address.flatMap { a => a.intersect(AddressSet(id, ~mask))},
-      supportsAcquireT   = m.supportsAcquireT   intersect maxXfer,
-      supportsAcquireB   = m.supportsAcquireB   intersect maxXfer,
-      supportsArithmetic = m.supportsArithmetic intersect maxXfer,
-      supportsLogical    = m.supportsLogical    intersect maxXfer,
-      supportsGet        = m.supportsGet        intersect maxXfer,
-      supportsPutFull    = m.supportsPutFull    intersect maxXfer,
-      supportsPutPartial = m.supportsPutPartial intersect maxXfer,
-      supportsHint       = m.supportsHint       intersect maxXfer)})}
+    (p zip ids) map { case (mp, id) => mp.copy(managers = mp.managers.flatMap { m =>
+      val addresses = m.address.flatMap(a => a.intersect(AddressSet(id, ~mask)))
+      if (addresses.nonEmpty)
+        Some(m.copy(
+          address            = addresses,
+          supportsAcquireT   = m.supportsAcquireT   intersect maxXfer,
+          supportsAcquireB   = m.supportsAcquireB   intersect maxXfer,
+          supportsArithmetic = m.supportsArithmetic intersect maxXfer,
+          supportsLogical    = m.supportsLogical    intersect maxXfer,
+          supportsGet        = m.supportsGet        intersect maxXfer,
+          supportsPutFull    = m.supportsPutFull    intersect maxXfer,
+          supportsPutPartial = m.supportsPutPartial intersect maxXfer,
+          supportsHint       = m.supportsHint       intersect maxXfer))
+      else None
+    })}
 }
 
 /* A BankBinder is used to divide contiguous memory regions into banks, suitable for a cache  */


### PR DESCRIPTION
The way BankBinder is currently written, it won't work if you connect it to managers which themselves have the blocks striped across them. You would get a requirement failure because the addresses of some of the managers would be empty, as the bank and channel would be for a mutually exclusive set of blocks. This commit makes the bank skip over managers with which it has no address range in common.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
