### PR TITLE
[Bugfix|UserBits|AHB] Fixed an issue where the UserBits were not in s…

### DIFF
--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -49,6 +49,7 @@ class AHBControlBundle(params: TLEdge) extends GenericParameterizedBundle(params
   val hburst = UInt(width = AHBParameters.burstBits)
   val addr   = UInt(width = params.bundle.addressBits)
   val data   = UInt(width = params.bundle.dataBits)
+  val hauser = if ( params.bundle.aUserBits > 0) Some(UInt(OUTPUT, width = params.bundle.aUserBits)) else None
 }
 
 // The input side has either a flow queue (aFlow=true) or a pipe queue (aFlow=false)
@@ -146,6 +147,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
           post.hburst:= Mux(a_singleBeat, BURST_SINGLE, (a_logBeats1<<1) | UInt(1))
           post.addr  := in.a.bits.address
           post.data  := in.a.bits.data
+          post.hauser.map { _ := in.a.bits.user.get }
         }
       }
 
@@ -161,7 +163,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
       out.hprot   := PROT_DEFAULT
       out.hwdata  := RegEnable(send.data, out.hready)
 
-      in.a.bits.user.map { i => out.hauser.map { _ := i} }
+      send.hauser.map { i => out.hauser.map { _ := i} }
 
       // We need a skidpad to capture D output:
       // We cannot know if the D response will be accepted until we have


### PR DESCRIPTION
…ync with the rest of the transaction bundle bits.
- Added hauser to AHBControlBundle.
- Passed the userbits through the FSM.

Cause: The userbits were not passed through the FSM, unlike the rest of the transaction bundle.
Fix: Ensured that the userbits passed through the FSM.
Test: Verified in waveform that the issue is fixed.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Fixes #2017 issue where the userbits are not in sync with the address in the TLToAHB out port.