### PR TITLE
ToAHB: fix a bug where a non-flow AHB adapter lowers hbusreq

### DIFF
--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -132,7 +132,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
         in.a.ready := !d_block && pre.write
       } .otherwise /* new burst */ {
         a_commit := in.a.fire() // every first beat commits to a D beat answer
-        in.a.ready := !d_block && granted
+        in.a.ready := !d_block && (granted || (Bool(!aFlow) && out.hgrant && out.hready))
         when (in.a.fire()) {
           post.full  := Bool(true)
           post.send  := Bool(true)


### PR DESCRIPTION
In non-flow mode, the following sequence of events could occur:

1. a.valid goes high with a request => hbusreq goes high
2. hgrant goes high (in the same cycle as 1 or much later)
3. granted goes high causing a.ready to go high
   ... and also lowers the hbusreq cause (a.valid && !granted)
4. the output request causes hbusreq to go high again

This change shortens the behaviour of the non-flow pipeline:

1. a.valid goes high with a request => hbusreq goes high
2. hgrant goes high ***causing a.ready to go high***
3. the output request keeps hbusreq high, despite granted high

@jchang0 Please run some VIP against this modified adapter...

The adapter still does not support the AHB SPLIT or RETRY response codes.

**Type of change**: bug fix
**Impact**: no functional change
**Development Phase**: implementation
**Release Notes**
Fixed a bug in TLToAHB when used with arbitration.