### PR TITLE
Drive extTrigger.out.req directly from register

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -828,7 +828,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
       // For each hg that has fired, assert trigger out for all external triggers in that hg
       io.extTrigger.foreach {extTrigger =>
-        val extTriggerOutReq = Wire(Vec(cfg.nExtTriggers, Bool()))
+        val extTriggerOutReq = RegInit(Vec.fill(cfg.nExtTriggers){false.B})
         for (trig <- 0 until nExtTriggers) {
           extTriggerOutReq(trig) := hgFired(hgParticipateTrig(trig))
         }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->


<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
CDC checking tools require that external trigger outputs feeding into a clock-crossing synchronizer be driven directly from a register in the source clock domain.