### PR TITLE
TileLink: UserUniformer

### DIFF
--- a/src/main/scala/amba/ahb/Parameters.scala
+++ b/src/main/scala/amba/ahb/Parameters.scala
@@ -6,7 +6,7 @@ import Chisel._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import scala.math.max
+import scala.math.{max, min}
 
 case class AHBSlaveParameters(
   address:       Seq[AddressSet],
@@ -22,6 +22,7 @@ case class AHBSlaveParameters(
     address.combinations(2).foreach { case Seq(x,y) => require (!x.overlaps(y)) }
 
   val name = nodePath.lastOption.map(_.lazyModule.name).getOrElse("disconnected")
+  val minMaxTransfer = min(supportsWrite.max, supportsRead.max)
   val maxTransfer = max(supportsWrite.max, supportsRead.max)
   val maxAddress = address.map(_.max).max
   val minAlignment = address.map(_.alignment).min
@@ -46,6 +47,7 @@ case class AHBSlavePortParameters(
   require (!slaves.isEmpty)
   require (isPow2(beatBytes))
 
+  val minMaxTransfer = slaves.map(_.minMaxTransfer).min // useful for fragmentation
   val maxTransfer = slaves.map(_.maxTransfer).max
   val maxAddress = slaves.map(_.maxAddress).max
 

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -318,7 +318,7 @@ object TLFragmenter
   def apply(minSize: Int, maxSize: Int, alwaysMin: Boolean = false, earlyAck: EarlyAck.T = EarlyAck.None, holdFirstDeny: Boolean = false)(implicit p: Parameters): TLNode =
   {
     val fragmenter = LazyModule(new TLFragmenter(minSize, maxSize, alwaysMin, earlyAck, holdFirstDeny))
-    fragmenter.node
+    if (minSize <= maxSize) fragmenter.node else TLEphemeralNode()(ValName("no_fragmenter"))
   }
 
   def apply(wrapper: TLBusWrapper)(implicit p: Parameters): TLNode = apply(wrapper.beatBytes, wrapper.blockBytes)

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -60,9 +60,9 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
       requestFifo = true,
       userBits    = {
         require( c.clients.forall( _.userBits.length == c.clients(0).userBits.length ),
-          s"Length of userBits sequences of all clients must be equal.")
+          s"Length of userBits sequences of all clients must be equal. ${c.clients.map(x => (x.name, x.userBits.length))}")
         require( c.clients.forall( _.userBits.zip( c.clients(0).userBits ).forall { case (a, b) => a.width == b.width } ),
-          s"Width of corresponding userBits for all clients must match.")
+          s"Width of corresponding userBits for all clients must match. ${c.clients.map(x => (x.name, x.userBits))}")
 
         c.clients(0).userBits
       })))

--- a/src/main/scala/tilelink/UserUniformer.scala
+++ b/src/main/scala/tilelink/UserUniformer.scala
@@ -28,13 +28,10 @@ class TLUserUniformer[T <: UserBits : ClassTag](default: UInt)(implicit p: Param
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out <> in
 
-      out.a.bits.user.foreach {
-        val prev = edgeIn.getUserOrElse[T](in.a.bits, 0.U)
-        val mux = edgeOut.putUser(
-          in.a.bits.user.getOrElse(default), 
-          prev.map { x: UInt => { (y: TLClientParameters) => x } }
-        )
-        _ := mux(out.a.bits.source)
+      out.a.bits.user.zip(in.a.bits.user).foreach { case (ouser, iuser) =>
+        val prev = edgeIn.getUserOrElse[T](in.a.bits, default)
+        val mux = edgeOut.putUser(iuser, prev.map { x: UInt => { (y: TLClientParameters) => x } })
+        ouser := mux(out.a.bits.source)
       }
     }
   }

--- a/src/main/scala/tilelink/UserUniformer.scala
+++ b/src/main/scala/tilelink/UserUniformer.scala
@@ -1,0 +1,41 @@
+// See LICENSE for license details.
+package freechips.rocketchip.tilelink
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import scala.reflect.ClassTag
+
+class TLUserUniformer[T <: UserBits : ClassTag](default: UInt)(implicit p: Parameters) extends LazyModule {
+  val node = TLAdapterNode(
+    clientFn  = { cp =>
+      val collected = cp.clients.map(_.userBits.collect { case x: T => x }) 
+      val longest = collected.sortBy(_.length).reverse.head
+      require(collected.forall(x => x.isEmpty || x.map(_.width).forall(y => y == longest.head.width)),
+        s"Cant make disjoint sets of user bits uniform $collected")
+      // TODO figure out how to support different widths, which is hard because
+      // they might missing or not or be in different orders per client
+      cp.copy(
+        clients = cp.clients.map { c =>
+          val diff = longest.filterNot(c.userBits.contains(_))
+          c.copy(userBits = c.userBits ++ diff) 
+        }
+      )
+    },
+    managerFn = { mp => mp })
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      out <> in
+
+      out.a.bits.user.foreach {
+        val prev = edgeIn.getUserOrElse[T](in.a.bits, 0.U)
+        val mux = edgeOut.putUser(
+          in.a.bits.user.getOrElse(default), 
+          prev.map { x: UInt => { (y: TLClientParameters) => x } }
+        )
+        _ := mux(out.a.bits.source)
+      }
+    }
+  }
+}

--- a/src/main/scala/tilelink/UserUser.scala
+++ b/src/main/scala/tilelink/UserUser.scala
@@ -17,9 +17,9 @@ class TLUserUser[T <: UserBits : ClassTag](meta: T, f: (TLBundleA, TLClientParam
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out <> in
 
-      out.a.bits.user.foreach {
+      out.a.bits.user.foreach { u =>
         val mux = edgeOut.putUser(in.a.bits.user.getOrElse(0.U), Seq(x => f(in.a.bits, x)))
-        _ := mux(out.a.bits.source)
+        u := mux(out.a.bits.source)
       }
     }
   }


### PR DESCRIPTION
`TLUserUniformer` adapter allows a default value of a particular type of TileLink user bits to be applied to all clients that were not supplying values for those types themselves. If a client does supply a value, this is passed through the adapter. As a result, all clients appear to supply the same number of the specified type of user bits. For clients that supply their own user bits, those bits will appear at the highest indexes, and any default values will appear at lower indexes.

The adapter currently requires the widths of all UserBits of the specified type to be the same, because I didn't want to have to handle all the cases where different clients have different subsets of the same type of user bits. This restriction could probably be relaxed with sufficient effort.

Other miscellaneous helper functions also added.

re: d9035b8, https://stackoverflow.com/a/15535342/2483329