### PR TITLE
Debug: interface and attachment parameterization

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -491,13 +491,13 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
 
   val dmiXbar = LazyModule (new TLXbar())
 
-  val dmi2tlOpt = (!p(ExportDebugAPB)).option({
+  val dmi2tlOpt = (!p(ExportDebug).apb).option({
     val dmi2tl = LazyModule(new DMIToTL())
     dmiXbar.node := dmi2tl.node
     dmi2tl
   })
 
-  val apbNodeOpt = p(ExportDebugAPB).option({
+  val apbNodeOpt = p(ExportDebug).apb.option({
     val apb2tl = LazyModule(new APBToTL())
     val apb2tlBuffer = LazyModule(new TLBuffer(BufferParams.pipe))
     val apbXbar = LazyModule(new APBFanout())
@@ -522,7 +522,7 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
     val nComponents = dmOuter.intnode.edges.out.size
 
     val io = IO(new Bundle {
-      val dmi   = (!p(ExportDebugAPB)).option(new DMIIO()(p).flip())
+      val dmi   = (!p(ExportDebug).apb).option(new DMIIO()(p).flip())
       // Optional APB Interface is fully diplomatic so is not listed here.
       val ctrl = new DebugCtrlBundle(nComponents)
       val innerCtrl = new AsyncBundle(new DebugInternalBundle(nComponents), AsyncQueueParams.singleton())
@@ -1468,9 +1468,9 @@ class TLDebugModule(beatBytes: Int)(implicit p: Parameters) extends LazyModule {
 
     val io = IO(new Bundle {
       val ctrl = new DebugCtrlBundle(nComponents)
-      val dmi = (!p(ExportDebugAPB)).option(new ClockedDMIIO().flip)
-      val apb_clock = p(ExportDebugAPB).option(Clock(INPUT))
-      val apb_reset = p(ExportDebugAPB).option(Bool(INPUT))
+      val dmi = (!p(ExportDebug).apb).option(new ClockedDMIIO().flip)
+      val apb_clock = p(ExportDebug).apb.option(Clock(INPUT))
+      val apb_reset = p(ExportDebug).apb.option(Bool(INPUT))
       val extTrigger = (p(DebugModuleParams).nExtTriggers > 0).option(new DebugExtTriggerIO())
       val psd = new PSDTestMode().asInput
     })

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -16,24 +16,38 @@ import freechips.rocketchip.jtag._
 import freechips.rocketchip.util._
 import freechips.rocketchip.tilelink._
 
+/** Protocols used for communicating with external debugging tools */
+sealed trait DebugExportProtocol
+case object DMI extends DebugExportProtocol
+case object JTAG extends DebugExportProtocol
+case object CJTAG extends DebugExportProtocol
+case object APB extends DebugExportProtocol
+
 /** Options for possible debug interfaces */
-case object ExportDebugDMI extends Field[Boolean](true)
-case object ExportDebugJTAG extends Field[Boolean](false)
-case object ExportDebugCJTAG extends Field[Boolean](false)
-case object ExportDebugAPB extends Field[Boolean](false)
-case object ExportDisableDebug extends Field[Boolean](false)
+case class DebugInterfaceParams(
+  protocol: DebugExportProtocol = DMI,
+  externalDisable: Boolean = false,
+  attachAsTile: Boolean =  false
+) {
+  def dmi   = protocol == DMI
+  def jtag  = protocol == JTAG
+  def cjtag = protocol == CJTAG
+  def apb   = protocol == APB
+}
+
+case object ExportDebug extends Field(DebugInterfaceParams())
 
 class ClockedAPBBundle(params: APBBundleParameters) extends APBBundle(params) with Clocked
 
 class DebugIO(implicit val p: Parameters) extends ParameterizedBundle()(p) with CanHavePSDTestModeIO {
-  val clockeddmi = p(ExportDebugDMI).option(new ClockedDMIIO().flip)
-  val systemjtag = p(ExportDebugJTAG).option(new SystemJTAGIO)
-  val apb = p(ExportDebugAPB).option(new ClockedAPBBundle(APBBundleParameters(addrBits=12, dataBits=32)).flip)
+  val clockeddmi = p(ExportDebug).dmi.option(new ClockedDMIIO().flip)
+  val systemjtag = p(ExportDebug).jtag.option(new SystemJTAGIO)
+  val apb = p(ExportDebug).apb.option(new ClockedAPBBundle(APBBundleParameters(addrBits=12, dataBits=32)).flip)
   //------------------------------
   val ndreset    = Bool(OUTPUT)
   val dmactive   = Bool(OUTPUT)
   val extTrigger = (p(DebugModuleParams).nExtTriggers > 0).option(new DebugExtTriggerIO())
-  val disableDebug = p(ExportDisableDebug).option(Bool(INPUT))
+  val disableDebug = p(ExportDebug).externalDisable.option(Bool(INPUT))
 }
 
 /** Either adds a JTAG DTM to system, and exports a JTAG interface,
@@ -50,13 +64,14 @@ trait HasPeripheryDebug { this: BaseSubsystem =>
   val debugCustomXbar = LazyModule( new DebugCustomXbar(outputRequiresInput = false))
   debug.dmInner.dmInner.customNode := debugCustomXbar.node
 
-  val apbDebugNodeOpt = p(ExportDebugAPB).option(APBMasterNode(Seq(APBMasterPortParameters(Seq(APBMasterParameters("debugAPB"))))))
+  val apbDebugNodeOpt = p(ExportDebug).apb.option(APBMasterNode(Seq(APBMasterPortParameters(Seq(APBMasterParameters("debugAPB"))))))
 
   (apbDebugNodeOpt zip debug.apbNodeOpt) foreach { case (master, slave) =>
     slave := master
   }
 
   debug.dmInner.dmInner.sb2tlOpt.foreach { sb2tl  =>
+    // TODO use p(ExportDebug).attachAsTile here
     fbus.fromPort(Some("debug_sb")){ FlipRendering { implicit p => TLWidthWidget(1) := sb2tl.node } }
   }
 }

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -25,15 +25,15 @@ case object APB extends DebugExportProtocol
 
 /** Options for possible debug interfaces */
 case class DebugAttachParams(
-  protocol: DebugExportProtocol = DMI,
+  protocols: Set[DebugExportProtocol] = Set(DMI),
   externalDisable: Boolean = false,
   masterWhere: BaseSubsystemBusAttachment = FBUS,
   slaveWhere: BaseSubsystemBusAttachment = CBUS
 ) {
-  def dmi   = protocol == DMI
-  def jtag  = protocol == JTAG
-  def cjtag = protocol == CJTAG
-  def apb   = protocol == APB
+  def dmi   = protocols.contains(DMI)
+  def jtag  = protocols.contains(JTAG)
+  def cjtag = protocols.contains(CJTAG)
+  def apb   = protocols.contains(APB)
 }
 
 case object ExportDebug extends Field(DebugAttachParams())

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -27,7 +27,7 @@ case object APB extends DebugExportProtocol
 case class DebugInterfaceParams(
   protocol: DebugExportProtocol = DMI,
   externalDisable: Boolean = false,
-  attachAsTile: Boolean =  false
+  masterAsIfTile: Boolean =  false
 ) {
   def dmi   = protocol == DMI
   def jtag  = protocol == JTAG
@@ -71,8 +71,11 @@ trait HasPeripheryDebug { this: BaseSubsystem =>
   }
 
   debug.dmInner.dmInner.sb2tlOpt.foreach { sb2tl  =>
-    // TODO use p(ExportDebug).attachAsTile here
-    fbus.fromPort(Some("debug_sb")){ FlipRendering { implicit p => TLWidthWidget(1) := sb2tl.node } }
+    if(p(ExportDebug).masterAsIfTile) {
+      sbus.fromTile(Some("debug_sb")){ FlipRendering { implicit p => TLWidthWidget(1) := sb2tl.node } }
+    } else {
+      fbus.fromPort(Some("debug_sb")){ FlipRendering { implicit p => TLWidthWidget(1) := sb2tl.node } }
+    }
   }
 }
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 
 
 import freechips.rocketchip.config._
-import freechips.rocketchip.devices.debug.{DebugModuleParams, ExportDebugCJTAG, ExportDebugDMI, ExportDebugJTAG, ExportDebugAPB}
+import freechips.rocketchip.devices.debug.{DebugModuleParams, ExportDebug}
 
 sealed trait OMDebugInterfaceType extends OMEnum
 case object JTAG extends OMDebugInterfaceType
@@ -60,10 +60,11 @@ case class OMDebug(
 
 object OMDebug {
   def getOMDebugInterfaceType(p: Parameters): OMDebugInterfaceType = {
-    if (p(ExportDebugJTAG)) { JTAG }
-    else if (p(ExportDebugCJTAG)) { CJTAG }
-    else if (p(ExportDebugDMI)) { DMI }
-    else if (p(ExportDebugAPB)) { DebugAPB }
+    val export = p(ExportDebug)
+    if (export.jtag) { JTAG }
+    else if (export.cjtag) { CJTAG }
+    else if (export.dmi) { DMI }
+    else if (export.apb) { DebugAPB }
     else { throw new IllegalArgumentException }
   }
 }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -37,7 +37,7 @@ abstract class BareSubsystemModuleImp[+L <: BareSubsystem](_outer: L) extends La
 }
 
 
-sealed trait BaseSubsystemBusAttachment
+trait BaseSubsystemBusAttachment
 case object SBUS extends BaseSubsystemBusAttachment
 case object PBUS extends BaseSubsystemBusAttachment
 case object FBUS extends BaseSubsystemBusAttachment
@@ -57,7 +57,7 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
   val mbus = LazyModule(new MemoryBus(p(MemoryBusKey)))
   val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
 
-  def attach(where: BaseSubsystemBusAttachment) = where match {
+  protected def attach(where: BaseSubsystemBusAttachment) = where match {
     case SBUS => sbus
     case PBUS => pbus
     case FBUS => fbus

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -36,6 +36,14 @@ abstract class BareSubsystemModuleImp[+L <: BareSubsystem](_outer: L) extends La
   println(outer.dts)
 }
 
+
+sealed trait BaseSubsystemBusAttachment
+case object SBUS extends BaseSubsystemBusAttachment
+case object PBUS extends BaseSubsystemBusAttachment
+case object FBUS extends BaseSubsystemBusAttachment
+case object MBUS extends BaseSubsystemBusAttachment
+case object CBUS extends BaseSubsystemBusAttachment
+
 /** Base Subsystem class with no peripheral devices or ports added */
 abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with HasLogicalTreeNode {
   override val module: BaseSubsystemModuleImp[BaseSubsystem]
@@ -48,6 +56,14 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
   val fbus = LazyModule(new FrontBus(p(FrontBusKey)))
   val mbus = LazyModule(new MemoryBus(p(MemoryBusKey)))
   val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
+
+  def attach(where: BaseSubsystemBusAttachment) = where match {
+    case SBUS => sbus
+    case PBUS => pbus
+    case FBUS => fbus
+    case MBUS => mbus
+    case CBUS => cbus
+  }
 
   // Collect information for use in DTS
   lazy val topManagers = sbus.unifyManagers

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -299,14 +299,11 @@ class WithEdgeDataBits(dataBits: Int) extends Config((site, here, up) => {
 })
 
 class WithJtagDTM extends Config ((site, here, up) => {
-  case ExportDebugDMI => false
-  case ExportDebugJTAG => true
+  case ExportDebug => up(ExportDebug, site).copy(protocol = JTAG)
 })
 
 class WithDebugAPB extends Config ((site, here, up) => {
-  case ExportDebugDMI => false
-  case ExportDebugJTAG => false
-  case ExportDebugAPB => true
+  case ExportDebug => up(ExportDebug, site).copy(protocol = APB)
 })
 
 

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -299,11 +299,11 @@ class WithEdgeDataBits(dataBits: Int) extends Config((site, here, up) => {
 })
 
 class WithJtagDTM extends Config ((site, here, up) => {
-  case ExportDebug => up(ExportDebug, site).copy(protocol = JTAG)
+  case ExportDebug => up(ExportDebug, site).copy(protocols = Set(JTAG))
 })
 
 class WithDebugAPB extends Config ((site, here, up) => {
-  case ExportDebug => up(ExportDebug, site).copy(protocol = APB)
+  case ExportDebug => up(ExportDebug, site).copy(protocols = Set(APB))
 })
 
 


### PR DESCRIPTION
API changes to more consistently describe how the debug unit interfaces with external ports and buses:
- `DebugExportProtocol` exhaustively enumerates port types (`DMI|JTAG|CJTAG|APB`) rather than being a collection of one-hot boolean fields
- `BaseSubsystemBusAttachment` exhaustively enumerates tilelink bus attachment locations (`SBUS|FBUS|CBUS|MBUS|PBUS`); this will be used by other attachment methods eventually
- Debug unit can be attached to different buses based on `ExportDebug` `Field` values

(might  rebase this one #2030 goes in)