### PR TITLE
Refactor BaseSubsystem into per-trait buses

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -10,6 +10,7 @@ import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.amba.apb._
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomaticobjectmodel.HasLogicalTreeNode
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalModuleTree
 import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 import freechips.rocketchip.jtag._
@@ -41,7 +42,7 @@ class DebugIO(implicit val p: Parameters) extends ParameterizedBundle()(p) with 
   * based on a global parameter.
   */
 
-trait HasPeripheryDebug { this: BaseSubsystem =>
+trait HasPeripheryDebug { this: BareSubsystem with CBus with FBus with HasLogicalTreeNode =>
   val debug = LazyModule(new TLDebugModule(cbus.beatBytes))
 
   LogicalModuleTree.add(logicalTreeNode, debug.logicalTreeNode)

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.devices.tilelink
 
 import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
-import freechips.rocketchip.subsystem.{BaseSubsystem, HasResetVectorWire}
+import freechips.rocketchip.subsystem.{BareSubsystem, CBus, HasResetVectorWire}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -59,7 +59,7 @@ class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], exec
 }
 
 /** Adds a boot ROM that contains the DTB describing the system's subsystem. */
-trait HasPeripheryBootROM { this: BaseSubsystem =>
+trait HasPeripheryBootROM { this: BareSubsystem with CBus =>
   val dtb: DTB
   private val params = p(BootROMParams)
   private lazy val contents = {

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -5,11 +5,12 @@ package freechips.rocketchip.devices.tilelink
 import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomaticobjectmodel.HasLogicalTreeNode
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
 import freechips.rocketchip.diplomaticobjectmodel.model._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem.BaseSubsystem
+import freechips.rocketchip.subsystem.{BareSubsystem, CBus}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
@@ -97,7 +98,7 @@ class CLINT(params: CLINTParams, beatBytes: Int)(implicit p: Parameters) extends
 }
 
 /** Trait that will connect a CLINT to a subsystem */
-trait CanHavePeripheryCLINT { this: BaseSubsystem =>
+trait CanHavePeripheryCLINT { this: BareSubsystem with CBus with HasLogicalTreeNode =>
   val clintOpt = p(CLINTKey).map { params =>
     val clint = LazyModule(new CLINT(params, cbus.beatBytes))
     def getCLINTLogicalTreeNode = clint.logicalTreeNode

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -16,6 +16,7 @@ import scala.math.max
 case object TileId extends Field[Int]
 
 class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
+    with CBus with FBus with IBus with PBus with MBus
     with CanHaveMasterAXI4MemPort {
   val tileParams = p(GroundTestTilesKey)
   val tiles = tileParams.zipWithIndex.map { case(c, i) => LazyModule(c.build(i, p)) }

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.subsystem
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 
-trait HasHierarchicalBusTopology { this: BaseSubsystem =>
+trait HasHierarchicalBusTopology { this: BaseSubsystem with CBus with FBus with MBus with PBus with SBus =>
   // The sbus masters the cbus; here we convert TL-UH -> TL-UL
   sbus.crossToBus(cbus, NoCrossing)
 

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.tile.{BaseTile, LookupByHartId, LookupByHartIdImpl, 
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-trait HasTiles extends HasCoreMonitorBundles { this: BaseSubsystem =>
+trait HasTiles extends HasCoreMonitorBundles { this: BareSubsystem with SBus with CBus with PBus =>
   implicit val p: Parameters
   val tiles: Seq[BaseTile]
   protected def tileParams: Seq[TileParams] = tiles.map(_.tileParams)

--- a/src/main/scala/subsystem/InterruptBus.scala
+++ b/src/main/scala/subsystem/InterruptBus.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 
-/** Collects interrupts from internal and external devices and feeds them into the PLIC */ 
+/** Collects interrupts from internal and external devices and feeds them into the PLIC */
 class InterruptBusWrapper(implicit p: Parameters) {
 
   val int_bus = LazyModule(new IntXbar)    // Interrupt crossbar
@@ -27,11 +27,11 @@ class InterruptBusWrapper(implicit p: Parameters) {
 /** Specifies the number of external interrupts */
 case object NExtTopInterrupts extends Field[Int](0)
 
-/** This trait adds externally driven interrupts to the system. 
+/** This trait adds externally driven interrupts to the system.
   * However, it should not be used directly; instead one of the below
   * synchronization wiring child traits should be used.
   */
-abstract trait HasExtInterrupts { this: BaseSubsystem =>
+abstract trait HasExtInterrupts { this: BareSubsystem =>
   private val device = new Device with DeviceInterrupts {
     def describe(resources: ResourceBindings): Description = {
       Description("soc/external-interrupts", describeInterrupts(resources))
@@ -45,7 +45,7 @@ abstract trait HasExtInterrupts { this: BaseSubsystem =>
 /** This trait should be used if the External Interrupts have NOT
   * already been synchronized to the Periphery (PLIC) Clock.
   */
-trait HasAsyncExtInterrupts extends HasExtInterrupts { this: BaseSubsystem =>
+trait HasAsyncExtInterrupts extends HasExtInterrupts { this: BareSubsystem with IBus =>
   if (nExtInterrupts > 0) {
     ibus.fromAsync := extInterrupts
   }
@@ -54,7 +54,7 @@ trait HasAsyncExtInterrupts extends HasExtInterrupts { this: BaseSubsystem =>
 /** This trait can be used if the External Interrupts have already been synchronized
   * to the Periphery (PLIC) Clock.
   */
-trait HasSyncExtInterrupts extends HasExtInterrupts { this: BaseSubsystem =>
+trait HasSyncExtInterrupts extends HasExtInterrupts { this: BareSubsystem with IBus =>
   if (nExtInterrupts > 0) {
     ibus.fromSync := extInterrupts
   }
@@ -70,7 +70,7 @@ trait HasExtInterruptsBundle {
 }
 
 /** This trait performs the translation from a UInt IO into Diplomatic Interrupts.
-  * The wiring must be done in the concrete LazyModuleImp. 
+  * The wiring must be done in the concrete LazyModuleImp.
   */
 trait HasExtInterruptsModuleImp extends LazyModuleImp with HasExtInterruptsBundle {
   val outer: HasExtInterrupts

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -23,7 +23,8 @@ case object BroadcastKey extends Field(BroadcastParams())
 /** L2 memory subsystem configuration */
 case class BankedL2Params(
   nBanks: Int = 1,
-  coherenceManager: BaseSubsystem => (TLInwardNode, TLOutwardNode, Option[IntOutwardNode]) = { subsystem =>
+  coherenceManager: BareSubsystem with MBus with SBus => (TLInwardNode, TLOutwardNode, Option[IntOutwardNode]) = {
+    subsystem =>
     implicit val p = subsystem.p
     val BroadcastParams(nTrackers, bufferless) = p(BroadcastKey)
     val bh = LazyModule(new TLBroadcast(subsystem.mbus.blockBytes, nTrackers, bufferless))

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -29,7 +29,7 @@ case object ExtIn extends Field[Option[SlavePortParams]](None)
 ///// The following traits add ports to the sytem, in some cases converting to different interconnect standards
 
 /** Adds a port to the system intended to master an AXI4 DRAM controller. */
-trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
+trait CanHaveMasterAXI4MemPort { this: BareSubsystem with MBus =>
   val module: CanHaveMasterAXI4MemPortModuleImp
 
   val memAXI4Node = p(ExtMem).map { case MemoryPortParams(memPortParams, nMemoryChannels) =>
@@ -80,7 +80,7 @@ trait CanHaveMasterAXI4MemPortModuleImp extends LazyModuleImp {
 }
 
 /** Adds a AXI4 port to the system intended to master an MMIO device bus */
-trait CanHaveMasterAXI4MMIOPort { this: BaseSubsystem =>
+trait CanHaveMasterAXI4MMIOPort { this: BareSubsystem with SBus =>
   private val mmioPortParamsOpt = p(ExtBus)
   private val portName = "mmio_port_axi4"
   private val device = new SimpleBus(portName.kebab, Nil)
@@ -124,7 +124,7 @@ trait CanHaveMasterAXI4MMIOPortModuleImp extends LazyModuleImp {
 }
 
 /** Adds an AXI4 port to the system intended to be a slave on an MMIO device bus */
-trait CanHaveSlaveAXI4Port { this: BaseSubsystem =>
+trait CanHaveSlaveAXI4Port { this: BareSubsystem with FBus =>
   private val slavePortParamsOpt = p(ExtIn)
   private val portName = "slave_port_axi4"
   private val fifoBits = 1
@@ -155,7 +155,7 @@ trait CanHaveSlaveAXI4PortModuleImp extends LazyModuleImp {
 }
 
 /** Adds a TileLink port to the system intended to master an MMIO device bus */
-trait CanHaveMasterTLMMIOPort { this: BaseSubsystem =>
+trait CanHaveMasterTLMMIOPort { this: BareSubsystem with SBus =>
   private val mmioPortParamsOpt = p(ExtBus)
   private val portName = "mmio_port_tl"
   private val device = new SimpleBus(portName.kebab, Nil)
@@ -190,7 +190,7 @@ trait CanHaveMasterTLMMIOPortModuleImp extends LazyModuleImp {
 /** Adds an TL port to the system intended to be a slave on an MMIO device bus.
   * NOTE: this port is NOT allowed to issue Acquires.
   */
-trait CanHaveSlaveTLPort { this: BaseSubsystem =>
+trait CanHaveSlaveTLPort { this: BareSubsystem with SBus =>
   private val slavePortParamsOpt = p(ExtIn)
   private val portName = "slave_port_tl"
 

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -28,7 +28,7 @@ case object RocketCrossingKey extends Field[Seq[RocketCrossingParams]](List(Rock
 trait HasRocketTiles extends HasTiles
     with CanHavePeripheryPLIC
     with CanHavePeripheryCLINT
-    with HasPeripheryDebug { this: BaseSubsystem =>
+    with HasPeripheryDebug { this: BaseSubsystem with CBus with FBus with IBus with PBus =>
   val module: HasRocketTilesModuleImp
 
   protected val rocketTileParams = p(RocketTilesKey)
@@ -68,9 +68,10 @@ trait HasRocketTilesModuleImp extends HasTilesModuleImp
 case object PeripheryMaskROMKey extends Field[Seq[MaskROMParams]](Nil)
 
 class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
+    with CBus with FBus with IBus with PBus
     with HasRocketTiles {
   val tiles = rocketTiles
-        
+
   // add Mask ROM devices
   val maskROMs = p(PeripheryMaskROMKey).map { MaskROM.attach(_, cbus) }
 

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.util.DontTouch
 
 /** Example Top with periphery devices and ports, and a Rocket subsystem */
 class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
+    with CBus with FBus with IBus with MBus with PBus
     with HasHierarchicalBusTopology
     with HasAsyncExtInterrupts
     with CanHaveMasterAXI4MemPort


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

I have a situation where I'd like to use a somewhat different system construction that deviates from `BaseSubsystem`.  Namely, I'd like to move buses around and have the flexibility of placing certain buses inside or outside of the system. I can always define my own subsystem and go from there, but I'd like to be able to use all the existing traits defined in the subsystem package. The current construction makes this difficult as most traits are self-typed on `BaseSubsystem` when they may only use a subset of the available buses.

This refactors `BaseSubsystem` into separate traits, e.g., `trait SBus` contains a system bus and `trait MBus` contains the memory bus. Traits which previously self-typed on `BaseSubsystem` are then modified to self-type more narrowly on what buses they require.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Breakup BaseSubsystem into separate per-bus traits