### PR TITLE
keep valid signal low while reset is high

### DIFF
--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -196,7 +196,7 @@ class TLFuzzer(
 
     // Wire up Fuzzer flow control
     val a_gen = if (nOperations>0) num_reqs =/= UInt(0) else Bool(true)
-    out.a.valid := a_gen && legal && (!a_first || idMap.io.alloc.valid)
+    out.a.valid := !reset && a_gen && legal && (!a_first || idMap.io.alloc.valid)
     idMap.io.alloc.ready := a_gen && legal && a_first && out.a.ready
     idMap.io.free.valid := d_first && out.d.fire()
     idMap.io.free.bits := out.d.bits.source


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Per the tilelink specification ver. 1.7.1 section 3.2.2, valid signals should be driven low while reset is asserted. In this case, TLFuzzer is the master and should drive a.valid low during a reset.