### PR TITLE
Fix regression introduced by #2029

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -535,7 +535,7 @@ class CSRFile(
     io_dec.system_illegal := reg_mstatus.prv < io_dec.csr(9,8) ||
       is_wfi && !allow_wfi ||
       is_ret && !allow_sret ||
-      is_ret && io.rw.addr(10) && !reg_debug ||
+      is_ret && io_dec.csr(10) && !reg_debug ||
       is_sfence && !allow_sfence_vma
   }
 


### PR DESCRIPTION
The CSR address from the wrong pipeline stage was used when detecting whether the DRET instruction was valid, causing spurious exceptions.


<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation
