### PR TITLE
tilelink: correct fragmenter helper

### DIFF
--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -317,8 +317,10 @@ object TLFragmenter
 {
   def apply(minSize: Int, maxSize: Int, alwaysMin: Boolean = false, earlyAck: EarlyAck.T = EarlyAck.None, holdFirstDeny: Boolean = false)(implicit p: Parameters): TLNode =
   {
-    val fragmenter = LazyModule(new TLFragmenter(minSize, maxSize, alwaysMin, earlyAck, holdFirstDeny))
-    if (minSize <= maxSize) fragmenter.node else TLEphemeralNode()(ValName("no_fragmenter"))
+    if (minSize <= maxSize) {
+      val fragmenter = LazyModule(new TLFragmenter(minSize, maxSize, alwaysMin, earlyAck, holdFirstDeny))
+      fragmenter.node
+    } else { TLEphemeralNode()(ValName("no_fragmenter")) }
   }
 
   def apply(wrapper: TLBusWrapper)(implicit p: Parameters): TLNode = apply(wrapper.beatBytes, wrapper.blockBytes)


### PR DESCRIPTION
Bug fix.

Fragmenter helper inserts an ephemeral node in cases where no fragmentation is required. I got the logic wrong before in that it would still try to build a fragmenter even in the negative case, which would fail.