### PR TITLE
Fix TraceGen issues and allow it to use NonBlockingDCache

### DIFF
--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -6,12 +6,13 @@ package freechips.rocketchip.groundtest
 import Chisel._
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.subsystem._
+import freechips.rocketchip.system.BaseConfig
 import freechips.rocketchip.rocket.{DCacheParams}
 import freechips.rocketchip.tile.{MaxHartIdBits, XLen}
 
 /** Actual testing target Configs */
 
-class TraceGenConfig extends Config(new WithTraceGen(List.fill(2){ DCacheParams(nSets = 16, nWays = 1) }) ++ new BaseSubsystemConfig)
+class TraceGenConfig extends Config(new WithTraceGen(List.fill(2){ DCacheParams(nSets = 16, nWays = 1) }) ++ new BaseConfig)
 
 class TraceGenBufferlessConfig extends Config(new WithBufferlessBroadcastHub ++ new TraceGenConfig)
 
@@ -23,17 +24,17 @@ class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192) extends Config(
     wordBits = site(XLen),
     addrBits = 32,
     addrBag = {
-      val nSets = 2
-      val nWays = 1
+      val nSets = dcp.nSets
+      val nWays = dcp.nWays
       val blockOffset = site(SystemBusKey).blockOffset
       val nBeats = site(SystemBusKey).blockBeats
-      List.tabulate(4 * nWays) { i =>
+      List.tabulate(nWays) { i =>
         Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
       }.flatten
     },
     maxRequests = nReqs,
     memStart = site(ExtMem).get.master.base,
     numGens = params.size)
-  }   
+  }
   case MaxHartIdBits => log2Up(params.size)
 })

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.rocket.{DCache, RocketCoreParams}
+import freechips.rocketchip.rocket.{DCache, NonBlockingDCache, RocketCoreParams}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import scala.collection.mutable.ListBuffer
@@ -41,7 +41,10 @@ abstract class GroundTestTile private (params: GroundTestTileParams, x: ClockCro
   val haltNode: IntOutwardNode = IntIdentityNode()
   val wfiNode: IntOutwardNode = IntIdentityNode()
 
-  val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0, crossing)) }
+  val dcacheOpt = params.dcache.map { dc => LazyModule(
+    if (dc.nMSHRs == 0) new DCache(hartId, crossing)
+    else new NonBlockingDCache(hartId))
+  }
 
   override lazy val module = new GroundTestTileModuleImp(this)
 }

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -825,6 +825,9 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
       lrsc_count := 0
     }
   }
+  when (s2_valid_masked && !s2_hit && s2_lrsc_addr_match) {
+    lrsc_count := 0
+  }
 
   val s2_data = Wire(Vec(nWays, Bits(width=encRowBits)))
   for (w <- 0 until nWays) {


### PR DESCRIPTION
The TraceGenConfig in groundtest is pretty outdated and currently doesn't work. These changes get it working again and also allow it to check the NonBlockingDCache. 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Fix TraceGen groundtest and allow it to use the NonBlockingDCache