### PR TITLE
parameterize watchpoint retirewidth

### DIFF
--- a/src/main/scala/rocket/Breakpoint.scala
+++ b/src/main/scala/rocket/Breakpoint.scala
@@ -47,8 +47,10 @@ class BP(implicit p: Parameters) extends CoreBundle()(p) {
     Mux(control.tmatch(1), rangeAddressMatch(x), pow2AddressMatch(x))
 }
 
-class BPWatch extends Bundle() {
-  val valid = Bool()
+class BPWatch (val n: Int) extends Bundle() {
+  val valid = Vec(n, Bool())
+  val dvalid = Vec(n, Bool())
+  val ivalid = Vec(n, Bool())
   val action = UInt(width = 3)
 }
 
@@ -64,7 +66,7 @@ class BreakpointUnit(n: Int)(implicit p: Parameters) extends CoreModule()(p) {
     val debug_if = Bool(OUTPUT)
     val debug_ld = Bool(OUTPUT)
     val debug_st = Bool(OUTPUT)
-    val bpwatch = Vec(n, new BPWatch).asOutput
+    val bpwatch = Vec(n, new BPWatch(1)).asOutput
   }
 
   io.xcpt_if := false
@@ -83,11 +85,13 @@ class BreakpointUnit(n: Int)(implicit p: Parameters) extends CoreModule()(p) {
     val action = bp.control.action
 
     bpw.action := action
-    bpw.valid := false.B
+    bpw.valid(0) := false.B
+    bpw.dvalid(0) := false.B
+    bpw.ivalid(0) := false.B
 
-    when (end && r && ri) { io.xcpt_ld := (action === 0.U); io.debug_ld := (action === 1.U); bpw.valid := true.B }
-    when (end && w && wi) { io.xcpt_st := (action === 0.U); io.debug_st := (action === 1.U); bpw.valid := true.B }
-    when (end && x && xi) { io.xcpt_if := (action === 0.U); io.debug_if := (action === 1.U); bpw.valid := true.B }
+    when (end && r && ri) { io.xcpt_ld := (action === 0.U); io.debug_ld := (action === 1.U); bpw.valid(0) := true.B; bpw.dvalid(0) := true.B }
+    when (end && w && wi) { io.xcpt_st := (action === 0.U); io.debug_st := (action === 1.U); bpw.valid(0) := true.B; bpw.dvalid(0) := true.B }
+    when (end && x && xi) { io.xcpt_if := (action === 0.U); io.debug_if := (action === 1.U); bpw.valid(0) := true.B; bpw.ivalid(0) := true.B }
 
     (end || r, end || w, end || x)
   }

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -190,7 +190,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val ex_reg_raw_inst = Reg(UInt())
   val ex_scie_unpipelined = Reg(Bool())
   val ex_scie_pipelined = Reg(Bool())
-  val ex_reg_bpwatch          = Reg(Vec(nBreakpoints, new BPWatch))
+  val ex_reg_wphit            = Reg(Vec(nBreakpoints, Bool()))
 
   val mem_reg_xcpt_interrupt  = Reg(Bool())
   val mem_reg_valid           = Reg(Bool())
@@ -214,7 +214,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val mem_reg_rs2 = Reg(Bits())
   val mem_br_taken = Reg(Bool())
   val take_pc_mem = Wire(Bool())
-  val mem_reg_bpwatch        = Reg(Vec(nBreakpoints, new BPWatch))
+  val mem_reg_wphit          = Reg(Vec(nBreakpoints, Bool()))
 
   val wb_reg_valid           = Reg(Bool())
   val wb_reg_xcpt            = Reg(Bool())
@@ -229,7 +229,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val wb_reg_wdata = Reg(Bits())
   val wb_reg_rs2 = Reg(Bits())
   val take_pc_wb = Wire(Bool())
-  val wb_reg_bpwatch         = Reg(Vec(nBreakpoints, new BPWatch))
+  val wb_reg_wphit           = Reg(Vec(nBreakpoints, Bool()))
 
   val take_pc_mem_wb = take_pc_wb || take_pc_mem
   val take_pc = take_pc_mem_wb
@@ -451,7 +451,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     ex_reg_raw_inst := id_raw_inst(0)
     ex_reg_pc := ibuf.io.pc
     ex_reg_btb_resp := ibuf.io.btb_resp
-    ex_reg_bpwatch := bpu.io.bpwatch
+    ex_reg_wphit := bpu.io.bpwatch.map { bpw => bpw.ivalid(0) }
   }
 
   // replay inst in ex stage?
@@ -510,7 +510,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     mem_reg_btb_resp := ex_reg_btb_resp
     mem_reg_flush_pipe := ex_reg_flush_pipe
     mem_reg_slow_bypass := ex_slow_bypass
-    mem_reg_bpwatch := ex_reg_bpwatch
+    mem_reg_wphit := ex_reg_wphit
 
     mem_reg_cause := ex_cause
     mem_reg_inst := ex_reg_inst
@@ -574,7 +574,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     wb_reg_raw_inst := mem_reg_raw_inst
     wb_reg_mem_size := mem_reg_mem_size
     wb_reg_pc := mem_reg_pc
-    wb_reg_bpwatch := mem_reg_bpwatch
+    wb_reg_wphit := mem_reg_wphit | bpu.io.bpwatch.map { bpw => bpw.dvalid(0) }
+
   }
 
   val (wb_xcpt, wb_cause) = checkExceptions(List(
@@ -671,7 +672,10 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   csr.io.rw.cmd := CSR.maskCmd(wb_reg_valid, wb_ctrl.csr)
   csr.io.rw.wdata := wb_reg_wdata
   io.trace := csr.io.trace
-  io.bpwatch := wb_reg_bpwatch
+  for (((iobpw, wphit), bp) <- io.bpwatch zip wb_reg_wphit zip csr.io.bp) {
+    iobpw.valid(0) := wphit
+    iobpw.action := bp.control.action
+  }
 
   val hazard_targets = Seq((id_ctrl.rxs1 && id_raddr1 =/= UInt(0), id_raddr1),
                            (id_ctrl.rxs2 && id_raddr2 =/= UInt(0), id_raddr2),

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -174,7 +174,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   val traceNode = BundleBroadcast[Vec[TracedInstruction]](Some("trace"))
   traceNode := traceSourceNode
 
-  val bpwatchSourceNode = BundleBridgeSource(() => Vec(tileParams.core.nBreakpoints, new BPWatch()))
+  val bpwatchSourceNode = BundleBridgeSource(() => Vec(tileParams.core.nBreakpoints, new BPWatch(tileParams.core.retireWidth)))
   val bpwatchNode = BundleBroadcast[Vec[BPWatch]](Some("bpwatch"))
   bpwatchNode := bpwatchSourceNode
 

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -107,7 +107,7 @@ trait HasCoreIO extends HasTileParameters {
     val fpu = new FPUCoreIO().flip
     val rocc = new RoCCCoreIO().flip
     val trace = Vec(coreParams.retireWidth, new TracedInstruction).asOutput
-    val bpwatch = Vec(coreParams.nBreakpoints, new BPWatch).asOutput
+    val bpwatch = Vec(coreParams.nBreakpoints, new BPWatch(coreParams.retireWidth)).asOutput
     val cease = Bool().asOutput
   }
 }


### PR DESCRIPTION

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This PR parameterizes the width of the valid field of BPWatch to accommodate systems with retireWidth>1.  

There is also a bugfix for load and store watchpoints - these were being accepted into the watchpoint pipeline two stages too early.  

