### PR TITLE
NBDCache bugfixes.

### DIFF
--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -825,7 +825,7 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
       lrsc_count := 0
     }
   }
-  when (s2_valid_masked && !s2_hit && s2_lrsc_addr_match) {
+  when (s2_valid_masked && !(s2_tag_match && s2_has_permission) && s2_lrsc_addr_match) {
     lrsc_count := 0
   }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: rtl change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix two bugs in the NBDCache.

- SC invalidates the reservation when it sees the reserved line as `Trunk`. This causes the replaying SC to fail always. Fix by not invalidating reservation when SC only needs to enter MSHR to set dirty bit.
- TileLink allows the ReleaseAck to arrive before the ReleaseData burst has completed. Existing MSHR assumes ReleaseAck arrives after the ReleaseData burst has finished. Fix by forcing MSHRs to wait for ReleaseAck to arrive AND for ReleaseData to finish.

Does anything still use the NBDCache? BOOM will no longer use this. 