### PR TITLE
Avoid when(reset) construct

### DIFF
--- a/src/main/scala/rocket/Breakpoint.scala
+++ b/src/main/scala/rocket/Breakpoint.scala
@@ -34,6 +34,16 @@ class BP(implicit p: Parameters) extends CoreBundle()(p) {
   val control = new BPControl
   val address = UInt(width = vaddrBits)
 
+  def reset(): BP = {
+    control.action := 0.U
+    control.dmode := false
+    control.chain := false
+    control.r := false
+    control.w := false
+    control.x := false
+    this
+  }
+
   def mask(dummy: Int = 0) =
     (0 until control.maskMax-1).scanLeft(control.tmatch(0))((m, i) => m && address(i)).asUInt
 

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -33,9 +33,10 @@ class PMPReg(implicit p: Parameters) extends CoreBundle()(p) {
   val cfg = new PMPConfig
   val addr = UInt(width = paddrBits - PMP.lgAlign)
 
-  def reset() {
+  def reset(): PMPReg = {
     cfg.a := 0
     cfg.l := 0
+    this
   }
 
   def readAddr = if (pmpGranularity.log2 == PMP.lgAlign) addr else {


### PR DESCRIPTION
We were primarily using this to reset subpieces of aggregate types.  Instead, reset the whole aggregate, using DontCare for subpieces that need not be reset.

This will help with supporting async reset.

This will cause a QoR regression until https://github.com/freechipsproject/firrtl/pull/1150 is merged.

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation
