### PR TITLE
Separate ITIM DeviceTree into memory and control parts

### DIFF
--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -56,7 +56,23 @@ class ICache(val icacheParams: ICacheParams, val hartId: Int)(implicit p: Parame
     name = s"Core ${hartId} ICache")))))
 
   val size = icacheParams.nSets * icacheParams.nWays * icacheParams.blockBytes
-  val device = new SimpleDevice("itim", Seq("sifive,itim0"))
+  val itim_control_offset = size - icacheParams.nSets * icacheParams.blockBytes
+
+  val device = new SimpleDevice("itim", Seq("sifive,itim0")) {
+    override def describe(resources: ResourceBindings): Description = {
+     val Description(name, mapping) = super.describe(resources)
+     val Seq(Binding(_, ResourceAddress(address, perms))) = resources("reg/mem")
+     val base_address = address.head.base
+     val mem_part = AddressSet.misaligned(base_address, itim_control_offset)
+     val control_part = AddressSet.misaligned(base_address + itim_control_offset, size - itim_control_offset)
+     val extra = Map(
+       "reg-names" -> Seq(ResourceString("mem"), ResourceString("control")),
+       "reg" -> Seq(ResourceAddress(mem_part, perms), ResourceAddress(control_part, perms)))
+     Description(name, mapping ++ extra)
+    }
+  }
+
+  def itimProperty: Option[Seq[ResourceValue]] = icacheParams.itimAddr.map(_ => device.asProperty)
 
   private val wordBytes = icacheParams.fetchBytes
   val slaveNode =

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -80,8 +80,7 @@ class RocketTile private(
   val dtimProperty = dtim_adapter.map(d => Map(
     "sifive,dtim" -> d.device.asProperty)).getOrElse(Nil)
 
-  val itimProperty = tileParams.icache.flatMap(_.itimAddr.map(i => Map(
-    "sifive,itim" -> frontend.icache.device.asProperty))).getOrElse(Nil)
+  val itimProperty = frontend.icache.itimProperty.toSeq.flatMap(p => Map("sifive,itim" -> p))
 
   val cpuDevice: SimpleDevice = new SimpleDevice("cpu", Seq("sifive,rocket0", "riscv")) {
     override def parent = Some(ResourceAnchors.cpus)


### PR DESCRIPTION
This helps introspective code know how much RAM actually lives in the ITIM.

**Type of change**: other enhancement

**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation
