### PR TITLE
GroundTest: restore lines needed for L2 Tracegen tests

### DIFF
--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -28,8 +28,8 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
   val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), beatBytes=pbus.beatBytes))
   pbus.coupleTo("TestRAM") { testram.node := TLFragmenter(pbus) := _ }
 
-  // No PLIC in ground test and no input interrupts,
-  // so no need to connect ibus output
+  // No PLIC in ground test; so just sink the interrupts to nowhere
+  IntSinkNode(IntSinkPortSimple()) :=* ibus.toPLIC
 
   override lazy val module = new GroundTestSubsystemModuleImp(this)
 }


### PR DESCRIPTION
**Type of change**: bug report
**Impact**: no functional change 
**Development Phase**: implementation

**Release Notes**
Restores some functionality erroneously removed by #2040 