### PR TITLE
adding dummy rtl module om and the om resets

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -195,13 +195,15 @@ class BusMemoryLogicalTreeNode(
   }
 }
 
-class SubSystemLogicalTreeNode(var getOMInterruptDevice: (ResourceBindings) => Seq[OMInterrupt] = (ResourceBindings) => Nil)
+class SubSystemLogicalTreeNode(rtlModule: Option[OMRTLModule], var getOMInterruptDevice: (ResourceBindings) => Seq[OMInterrupt] = (ResourceBindings) => Nil)
   extends LogicalTreeNode(() => None) {
   override def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
+
     List(
       OMCoreComplex(
         components = components,
-        documentationName = ""
+        documentationName = "",
+        rtlModule = rtlModule
       )
     )
   }

--- a/src/main/scala/diplomaticobjectmodel/model/OMCoreComplex.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCoreComplex.scala
@@ -5,5 +5,6 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 case class OMCoreComplex(
   components: Seq[OMComponent],
   documentationName: String,
+  rtlModule: Option[OMRTLModule],
   _types: Seq[String] = Seq("OMCoreComplex", "OMComponent", "OMCompoundType")
 ) extends OMComponent

--- a/src/main/scala/diplomaticobjectmodel/model/OMRTLModule.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRTLModule.scala
@@ -93,7 +93,7 @@ case class InterruptSignal(
 case class OMRTLInterface(
   clocks: Seq[OMClock],
   clockRelationships: Seq[OMClockRelationship],
-  resets: Seq[OMRTLReset],
+  resets: () => Seq[OMRTLReset],
   statuses: Seq[OMStatus]
 ) extends RTLComponent
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMRTLModule.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRTLModule.scala
@@ -2,6 +2,47 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.model
 
+// Examples of ClockRelationships
+//  {
+//   "clock0": "core_clock_0",
+//    "clock1": "clock",
+//    "relationship": "$clock0 == m * $clock1 where m is a positive integer",
+//  }
+
+//  {
+//    "clock1": "rtc_toggle",
+//    "relationship": "$clock0 >= 2 * $clock1",
+//  }
+
+trait OMStatus extends OMSignal {
+  name: String
+  description: Option[String]
+}
+
+trait OMCoreStatus extends OMStatus {
+  name: String
+  description: Option[String]
+  def hartId: Int
+}
+
+case class Halt(
+  name: String,
+  description: Option[String],
+  hartId: Int
+) extends OMCoreStatus
+
+case class WFI(
+  name: String,
+  description: Option[String],
+  hartId: Int
+) extends OMCoreStatus
+
+case class Trace(
+  name: String,
+  description: Option[String],
+  hartId: Int
+) extends OMCoreStatus
+
 trait RTLComponent extends OMCompoundType
 
 trait OMSignal extends RTLComponent {
@@ -29,22 +70,34 @@ trait Synchronous extends Synchronicity
 trait Asynchronous extends Synchronicity
 
 case class OMRTLReset(
+  name: String,
+  description: Option[String],
   activeEdge: Option[OMSignalAssertionLevel],
   clock: String, // This will always be the name of the clock signal on the to p-level module
   synchronicity: Option[Synchronicity]
-)
+) extends OMSignal
 
 case class OMResetVector(
+  name: String,
+  description: Option[String],
   width: Int
-)
+) extends OMSignal
+
+// Interrupts
+case class InterruptSignal(
+  name: String,
+  description: Option[String],
+  width: Int
+) extends OMSignal
 
 case class OMRTLInterface(
-  clocks: List[OMClock],
-  clockRelationships: List[OMClockRelationship],
-  resets: List[OMRTLReset]
+  clocks: Seq[OMClock],
+  clockRelationships: Seq[OMClockRelationship],
+  resets: Seq[OMRTLReset],
+  statuses: Seq[OMStatus]
 ) extends RTLComponent
 
-case class  OMRTLModule(
+case class OMRTLModule(
   moduleName: String,
   instanceName: Option[String],  // TODO: This does not exist for the top-level module because the top-level module is the only one that is not instantiated
   hierarchicalId: Option[String],  // Full dotted path from the root, where the root is described as a module name while all other path components are instance names

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -90,7 +90,7 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
     }
   }
 
-  val logicalTreeNode = new SubSystemLogicalTreeNode()
+  val logicalTreeNode: SubSystemLogicalTreeNode = new SubSystemLogicalTreeNode(None)
 }
 
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
adding dummy rtl module om and the om resets
* added the OM class hierarchy for the rtl module information
* added the code to extract the reset names from the cores
