### PR TITLE
devices: allow error devs that only support tl-ul

### DIFF
--- a/src/main/scala/devices/tilelink/DevNull.scala
+++ b/src/main/scala/devices/tilelink/DevNull.scala
@@ -14,8 +14,8 @@ case class DevNullParams(
   executable: Boolean = true,
   mayDenyGet: Boolean = true,
   mayDenyPut: Boolean = true,
+  hint: Boolean = true
 ) {
-  require (1 <= maxAtomic, s"Atomic transfer size must be > 1 (was $maxAtomic)")
   require (maxAtomic <= maxTransfer, s"Atomic transfer size must be <= max transfer (but $maxAtomic > $maxTransfer)")
   require (maxTransfer <= 4096, s"Max transfer size must be <= 4096 (was $maxTransfer)")
   def acquire: Boolean = region == RegionType.TRACKED
@@ -28,22 +28,24 @@ case class DevNullParams(
 abstract class DevNullDevice(params: DevNullParams, beatBytes: Int, device: SimpleDevice)
                             (implicit p: Parameters)
     extends LazyModule with HasClockDomainCrossing {
-  val xfer = TransferSizes(1, params.maxTransfer)
-  val atom = TransferSizes(1, params.maxAtomic)
+  val xfer = if (params.maxTransfer > 0) TransferSizes(1, params.maxTransfer) else TransferSizes.none
+  val atom = if (params.maxAtomic > 0) TransferSizes(1, params.maxAtomic) else TransferSizes.none
+  val acq  = if (params.acquire) xfer else TransferSizes.none
+  val hint = if (params.hint) xfer else TransferSizes.none
   val node = TLManagerNode(Seq(TLManagerPortParameters(
     Seq(TLManagerParameters(
       address            = params.address,
       resources          = device.reg,
       regionType         = params.region,
       executable         = params.executable,
-      supportsAcquireT   = if (params.acquire) xfer else TransferSizes.none,
-      supportsAcquireB   = if (params.acquire) xfer else TransferSizes.none,
+      supportsAcquireT   = acq,
+      supportsAcquireB   = acq,
       supportsGet        = xfer,
       supportsPutPartial = xfer,
       supportsPutFull    = xfer,
       supportsArithmetic = atom,
       supportsLogical    = atom,
-      supportsHint       = xfer,
+      supportsHint       = hint,
       fifoId             = Some(0), // requests are handled in order
       mayDenyGet         = params.mayDenyGet,
       mayDenyPut         = params.mayDenyPut,


### PR DESCRIPTION
`DevNull` devices (and by extension the ErrorDevice) had some baked in assumptions about supported transfer types. Mandating support for atomics and hints turned out to be disadvantageous when attempting to replicate address regions that don't have to support those transfers.