### PR TITLE
ahb: allow supportsRETRY to be overridden in helper

### DIFF
--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -266,9 +266,9 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
 
 object TLToAHB
 {
-  def apply(aFlow: Boolean = true, supportHints: Boolean = true)(implicit p: Parameters) =
+  def apply(aFlow: Boolean = true, supportHints: Boolean = true, supportsRETRY: Boolean = true)(implicit p: Parameters) =
   {
-    val tl2ahb = LazyModule(new TLToAHB(aFlow, supportHints))
+    val tl2ahb = LazyModule(new TLToAHB(aFlow, supportHints, supportsRETRY))
     tl2ahb.node
   }
 }


### PR DESCRIPTION
This knob is currently necessary to tweak in some situations, but was not exposed via the `TLToAHB` helper object's apply method