### PR TITLE
Upgrade DescribedSRAM to chisel3.

### DIFF
--- a/src/main/scala/util/DescribedSRAM.scala
+++ b/src/main/scala/util/DescribedSRAM.scala
@@ -6,8 +6,8 @@ package freechips.rocketchip.util
 import chisel3.internal.InstanceId
 import freechips.rocketchip.util.Annotated
 import freechips.rocketchip.diplomacy.DiplomaticSRAM
-import Chisel._
-import chisel3.SyncReadMem
+import chisel3.{Data, SyncReadMem, Vec}
+import chisel3.util.log2Ceil
 import freechips.rocketchip.amba.axi4.AXI4RAM
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model.OMSRAM
@@ -22,7 +22,7 @@ object DescribedSRAM {
     data: T
   ): (SyncReadMem[T], OMSRAM) = {
 
-    val mem = SeqMem(size, data)
+    val mem = SyncReadMem(size, data)
 
     mem.suggestName(name)
 


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

Being unfamiliar with the specific differences between Chisel 2 and Chisel 3, it took me a little while reading the code to realize that `SyncReadMem` and `SeqMem` are [aliases of each other](https://github.com/freechipsproject/chisel3/blob/b2a1bd7a10977d3331fee3022ec490a1aa1e0e17/src/main/scala/chisel3/compatibility.scala#L286). It doesn't seem to trigger a deprecation warning, and none of the existing chisel3 documentation appears to mention that `SyncReadMem` is the chisel3 version of `SeqMem`, despite there being independent documentation on `SyncReadMem` and `SeqMem`.

I've upgraded the `DescribedSRAM` module to chisel3 so that future readers of the code hopefully don't need to go through the same steps that I had to.