### PR TITLE
Fix OMSRAM serialization in RocketTile memories.

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -3,8 +3,9 @@
 package freechips.rocketchip.diplomaticobjectmodel.logicaltree
 
 import freechips.rocketchip.diplomacy.{LazyModule, ResourceBindings, ResourceBindingsMap, SimpleDevice}
+import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model._
-import freechips.rocketchip.rocket.{DCacheParams, Frontend, ICacheParams, ScratchpadSlavePort}
+import freechips.rocketchip.rocket.{DCacheParams, Frontend, HellaCache, ICache, ICacheParams, ScratchpadSlavePort}
 import freechips.rocketchip.tile.{RocketTileParams, TileParams, XLen}
 
 
@@ -14,34 +15,46 @@ import freechips.rocketchip.tile.{RocketTileParams, TileParams, XLen}
  * The data memory subsystem is assumed to be a DTIM if and only if deviceOpt is
  * a Some(SimpleDevice), as a DCache would not create a Device.
  */
-class DCacheLogicalTreeNode(memories: () => Seq[OMSRAM], deviceOpt: Option[SimpleDevice], params: DCacheParams) extends LogicalTreeNode(() => deviceOpt) {
+class DCacheLogicalTreeNode(dcache: HellaCache, deviceOpt: Option[SimpleDevice], params: DCacheParams) extends LogicalTreeNode(() => deviceOpt) {
   def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent]): Seq[OMComponent] = {
     deviceOpt.foreach {
       device => require(!resourceBindings.map.isEmpty, s"""ResourceBindings map for ${device.devname} is empty""")
     }
-
     Seq(
-      OMCaches.dcache(params, resourceBindings, memories)
+      OMDCache(
+        memoryRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions("DTIM", resourceBindings),
+        interrupts = Nil,
+        nSets = params.nSets,
+        nWays = params.nWays,
+        blockSizeBytes = params.blockBytes,
+        dataMemorySizeBytes = params.nSets * params.nWays * params.blockBytes,
+        dataECC = params.dataECC.map(OMECC.fromString),
+        tagECC = params.tagECC.map(OMECC.fromString),
+        nTLBEntries = params.nTLBEntries,
+        memories = dcache.getOMSRAMs(),
+      )
     )
   }
 }
 
 
-class ICacheLogicalTreeNode(memories: () => Seq[OMSRAM], deviceOpt: Option[SimpleDevice], icacheParams: ICacheParams) extends LogicalTreeNode(() => deviceOpt) {
-  def getOMICacheFromBindings(resourceBindings: ResourceBindings): OMICache = {
-    getOMComponents(resourceBindings) match {
-      case Seq() => throw new IllegalArgumentException
-      case Seq(h) => h.asInstanceOf[OMICache]
-      case _ => throw new IllegalArgumentException
-    }
-  }
-
+class ICacheLogicalTreeNode(icache: ICache, deviceOpt: Option[SimpleDevice], params: ICacheParams) extends LogicalTreeNode(() => deviceOpt) {
   override def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil): Seq[OMComponent] = {
-    Seq[OMComponent](OMCaches.icache(icacheParams, resourceBindings, memories))
-  }
-
-  def iCache(resourceBindings: ResourceBindings): OMICache = {
-    OMCaches.icache(icacheParams, resourceBindings, memories)
+    Seq(
+      OMICache(
+        memoryRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions("ITIM", resourceBindings),
+        interrupts = Nil,
+        nSets = params.nSets,
+        nWays = params.nWays,
+        blockSizeBytes = params.blockBytes,
+        dataMemorySizeBytes = params.nSets * params.nWays * params.blockBytes,
+        dataECC = params.dataECC.map(OMECC.fromString),
+        tagECC = params.tagECC.map(OMECC.fromString),
+        nTLBEntries = params.nTLBEntries,
+        maxTimSize = params.nSets * (params.nWays-1) * params.blockBytes,
+        memories = icache.module.data_arrays.map(_._2),
+      )
+    )
   }
 }
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
@@ -13,7 +13,7 @@ trait OMCache extends OMDevice {
   def dataMemorySizeBytes: Int
   def dataECC: Option[OMECC]
   def tagECC: Option[OMECC]
-  def memories: () => Seq[OMSRAM]
+  def memories: Seq[OMSRAM]
 }
 
 case class OMICache(
@@ -27,7 +27,7 @@ case class OMICache(
   tagECC: Option[OMECC],
   nTLBEntries: Int,
   maxTimSize: Int,
-  memories: () => Seq[OMSRAM],
+  memories: Seq[OMSRAM],
   _types: Seq[String] = Seq("OMICache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
 
@@ -41,7 +41,7 @@ case class OMDCache(
   dataECC: Option[OMECC],
   tagECC: Option[OMECC],
   nTLBEntries: Int,
-  memories: () => Seq[OMSRAM],
+  memories: Seq[OMSRAM],
   _types: Seq[String] = Seq("OMDCache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -2,9 +2,7 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.model
 
-import freechips.rocketchip.diplomacy.ResourceBindings
-import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
-import freechips.rocketchip.rocket.{BTBParams, DCacheParams, ICacheParams}
+import freechips.rocketchip.rocket.BTBParams
 
 case class OMRocketBranchPredictor(
   nBtbEntries: Int,
@@ -41,38 +39,4 @@ object OMBTB {
       nRasEntries = p.nRAS
     )
   }
-}
-
-object OMCaches {
-  def dcache(p: DCacheParams, resourceBindings: ResourceBindings, memories: () => Seq[OMSRAM]): OMDCache = {
-    OMDCache(
-      memoryRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions("DTIM", resourceBindings),
-      interrupts = Nil,
-      nSets = p.nSets,
-      nWays = p.nWays,
-      blockSizeBytes = p.blockBytes,
-      dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
-      dataECC = p.dataECC.map(OMECC.fromString),
-      tagECC = p.tagECC.map(OMECC.fromString),
-      nTLBEntries = p.nTLBEntries,
-      memories = memories,
-    )
-  }
-
-  def icache(p: ICacheParams, resourceBindings: ResourceBindings, memories: () => Seq[OMSRAM]): OMICache = {
-    OMICache(
-      memoryRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions("ITIM", resourceBindings),
-      interrupts = Nil,
-      nSets = p.nSets,
-      nWays = p.nWays,
-      blockSizeBytes = p.blockBytes,
-      dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
-      dataECC = p.dataECC.map(OMECC.fromString),
-      tagECC = p.tagECC.map(OMECC.fromString),
-      nTLBEntries = p.nTLBEntries,
-      maxTimSize = p.nSets * (p.nWays-1) * p.blockBytes,
-      memories = memories,
-    )
-  }
-
 }

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -355,7 +355,7 @@ trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   // don't actually use the device that is instantiated in the frontend.
   private val deviceOpt = if (tileParams.icache.get.itimAddr.isDefined) Some(frontend.icache.device) else None
 
-  val iCacheLogicalTreeNode = new ICacheLogicalTreeNode(() => frontend.icache.module.data_arrays.map(_._2), deviceOpt, tileParams.icache.get)
+  val iCacheLogicalTreeNode = new ICacheLogicalTreeNode(frontend.icache, deviceOpt, tileParams.icache.get)
 }
 
 trait HasICacheFrontendModule extends CanHavePTWModule {

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -6,7 +6,6 @@ import Chisel._
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.model.{OMCaches, OMComponent, OMDCache}
 import freechips.rocketchip.subsystem.RocketTilesKey
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -107,7 +107,7 @@ class RocketTile private(
   }
 
   val rocketLogicalTree: RocketLogicalTreeNode = new RocketLogicalTreeNode(cpuDevice, rocketParams, dtim_adapter, p(XLen))
-  val dCacheLogicalTreeNode = new DCacheLogicalTreeNode(() => dcache.getOMSRAMs(), dtim_adapter.map(_.device), rocketParams.dcache.get)
+  val dCacheLogicalTreeNode = new DCacheLogicalTreeNode(dcache, dtim_adapter.map(_.device), rocketParams.dcache.get)
   LogicalModuleTree.add(rocketLogicalTree, iCacheLogicalTreeNode)
   LogicalModuleTree.add(rocketLogicalTree, dCacheLogicalTreeNode)
 }


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
The various Rocket memories were not being correctly serialized into the Object Model JSON file, since the case class describing the `OMCache` set the type of the `memories` attribute to `() => Seq[OMSRAM]`, and it appears that the default JSON serializer serializes function types to the empty JSON object (map) type.

The main fix I made was to change the type from `() => Seq[OMSRAM]` to just `Seq[OMSRAM]`, but I also made a few other changes to how data is being passed around, partly to obviate the need to pass around thunk in the first place but also to (IMO) simplify the control flow a little bit:

- I replaced the thunk arguments of `() => Seq[OMSRAM]` with references to a LazyModule. The `getOMSRAMs()` helper functions that return the `Seq[OMSRAM]` are defined on the LazyModule to begin with, so instead of having to pass around a thunk, which defies serialization and debugging (cannot be "printed"), we can just pass around the reference to the LazyModule itself and only call the `getOMSRAMs()` method after all the Diplomacy handshakes are resolved.
- I removed the `OMCache.dcache()/icache()` static functions and just inlined them into `DCacheLogicalTreeNode` and `ICacheLogicalTreeNode`, since those were the only places where we were calling the functions, and it makes it clearer to see what is actually getting serialized into the object model without having to job to another file.

I tested this by building a few designs and confirming that the `memories` property gets serialized to an actual array of `OMSRAM` objects rather than an empty object.