### PR TITLE
BusWrapper: it is ok have a wider bus

### DIFF
--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -28,7 +28,6 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
 
   def beatBytes = params.beatBytes
   def blockBytes = params.blockBytes
-  require(blockBytes % beatBytes == 0)
 
   def inwardNode: TLInwardNode
   def outwardNode: TLOutwardNode


### PR DESCRIPTION
**Type of change**: bug report
**Impact**: no functional change
**Development Phase**: proposal
**Release Notes**
Even if the system only has very small cache blocks, we may still want a larger bus width.

@hcook I'm not 100% sure this is the right thing to do. I guess this would make all the TIMs wide enough for a 64/128-bit single-beat transfer. A front-port can then split an incoming AMBA burst into single-beat transfers of the wide system bus. I'm not sure this is a good solution, though, since it might be better to maintain the bursts all the way to the slaves. If that's the case, the right fix is to increase the "cache block size" as we really mean "burst size" with that parameter.