### PR TITLE
AHB: add a knob to control full/lite

### DIFF
--- a/src/main/scala/amba/ahb/AHBLite.scala
+++ b/src/main/scala/amba/ahb/AHBLite.scala
@@ -1,0 +1,42 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.amba.ahb
+
+import Chisel._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+class AHBLite()(implicit p: Parameters) extends LazyModule {
+  val node = AHBMasterAdapterNode(
+    masterFn = { mp => mp },
+    slaveFn  = { sp => sp.copy(lite = false) })
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      require (edgeOut.slave.lite) // or else this adapter is pointless
+
+      out.hmastlock.get := in.hlock.get
+      in.hgrant.get := Bool(true)
+      in.hresp := out.hresp // zero-extended
+
+      in.hready := out.hready
+      out.htrans := in.htrans
+      out.hsize  := in.hsize
+      out.hburst := in.hburst
+      out.hwrite := in.hwrite
+      out.hprot  := in.hprot
+      out.haddr  := in.haddr
+      out.hwdata := in.hwdata
+      out.hauser.foreach { _ := in.hauser.get }
+      in.hrdata := out.hrdata
+    }
+  }
+}
+
+object AHBLite {
+  def apply()(implicit p: Parameters) = {
+    val ahblite = LazyModule(new AHBLite)
+    ahblite.node
+  }
+}

--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -24,21 +24,19 @@ class AHBSlaveBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
   val hburst    = UInt(OUTPUT, width = params.burstBits)
   val hwrite    = Bool(OUTPUT)
   val hprot     = UInt(OUTPUT, width = params.protBits)
-  val hauser    = if ( params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
+  val hauser    = if (params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
   val haddr     = UInt(OUTPUT, width = params.addrBits)
 
   // D-phase signals from arbiter to slave
   val hwdata    = UInt(OUTPUT, width = params.dataBits)
 
   // D-phase signals from slave to arbiter
-  val hresp     = Bool(INPUT)
+  val hresp     = UInt(INPUT, width = params.hrespBits)
   val hrdata    = UInt(INPUT, width = params.dataBits)
 
   // Split signals
-/*
-  val hmaster   = UInt(OUTPUT, width = 4)
-  val hsplit    = UInt(INPUT, width = 16)
-*/
+  val hmaster   = if (params.lite) None else Some(UInt(OUTPUT, width = 4))
+  val hsplit    = if (params.lite) None else Some(UInt(INPUT, width = 16))
 
   def tieoff() {
     hrdata.dir match {
@@ -66,12 +64,18 @@ class AHBSlaveBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
 class AHBMasterBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
 {
   // Control signals from master to arbiter
-  val hlock   = Bool(OUTPUT) // AHBSlave: hmastlock
-  val hbusreq = Bool(OUTPUT) // AHBSlave: hsel
+  val hmastlock = if (params.lite) Some(Bool(OUTPUT)) else None
+  val hlock     = if (params.lite) None else Some(Bool(OUTPUT))
+  val hbusreq   = if (params.lite) None else Some(Bool(OUTPUT))
 
   // Flow control from arbiter to master
-  val hgrant  = Bool(INPUT) // AHBSlave: always true
-  val hready  = Bool(INPUT) // AHBSlave: hreadyout
+  val hgrant  = if (params.lite) None else Some(Bool(INPUT))
+  val hready  = Bool(INPUT)
+
+  // Handy methods that don't care about lite
+  def lock():   Bool = if (params.lite) hmastlock.get else hlock.get
+  def busreq(): Bool = if (params.lite) Wire(init = Bool(true)) else hbusreq.get
+  def grant():  Bool = if (params.lite) Wire(init = Bool(true)) else hgrant.get
 
   // A-phase signals from master to arbiter
   val htrans  = UInt(OUTPUT, width = params.transBits)
@@ -79,7 +83,7 @@ class AHBMasterBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
   val hburst  = UInt(OUTPUT, width = params.burstBits)
   val hwrite  = Bool(OUTPUT)
   val hprot   = UInt(OUTPUT, width = params.protBits)
-  val hauser  = if ( params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
+  val hauser  = if (params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
   val haddr   = UInt(OUTPUT, width = params.addrBits)
 
   // D-phase signals from master to arbiter
@@ -92,13 +96,13 @@ class AHBMasterBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
   def tieoff() {
     hrdata.dir match {
       case INPUT =>
-        hgrant    := Bool(false)
+        hgrant.foreach { _ := Bool(false) }
         hready    := Bool(false)
         hresp     := AHBParameters.RESP_OKAY
         hrdata    := UInt(0)
       case OUTPUT =>
-        hlock     := Bool(false)
-        hbusreq   := Bool(false)
+        lock()     := Bool(false)
+        busreq()   := Bool(false)
         htrans    := AHBParameters.TRANS_IDLE
         hsize     := UInt(0)
         hburst    := AHBParameters.BURST_SINGLE

--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -17,7 +17,8 @@ case class AHBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes:
       executable    = executable,
       supportsWrite = TransferSizes(1, min(address.alignment.toInt, beatBytes * AHBParameters.maxTransfer)),
       supportsRead  = TransferSizes(1, min(address.alignment.toInt, beatBytes * AHBParameters.maxTransfer)))),
-    beatBytes  = beatBytes)))
+    beatBytes  = beatBytes,
+    lite = true)))
 {
   require (address.contiguous)
 

--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -29,7 +29,8 @@ class AHBRAM(
       executable    = executable,
       supportsRead  = TransferSizes(1, beatBytes * AHBParameters.maxTransfer),
       supportsWrite = TransferSizes(1, beatBytes * AHBParameters.maxTransfer))),
-    beatBytes  = beatBytes)))
+    beatBytes  = beatBytes,
+    lite = true)))
 
   lazy val module = new LazyModuleImp(this) {
     val (in, _) = node.in(0)

--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -32,7 +32,8 @@ case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHB
         nodePath      = m.nodePath,
         supportsWrite = adjust(m.supportsPutFull),
         supportsRead  = adjust(m.supportsGet))},
-    beatBytes = mp.beatBytes)
+    beatBytes = mp.beatBytes,
+    lite      = true)
   })
 
 class AHBToTL()(implicit p: Parameters) extends LazyModule
@@ -53,7 +54,7 @@ class AHBToTL()(implicit p: Parameters) extends LazyModule
 
       when (out.d.valid) { d_recv  := Bool(false) }
       when (out.a.ready) { d_send  := Bool(false) }
-      when (in.hresp)    { d_pause := Bool(false) }
+      when (in.hresp(0)) { d_pause := Bool(false) }
 
       val a_count  = RegInit(UInt(0, width = 4))
       val a_first  = a_count === UInt(0)


### PR DESCRIPTION
**Type of change**: feature request
**Impact**: API modification
**Development Phase**: implementation

**Release Notes**
Make it possible to support AHB-Full/Lite based on a diplomatic parameter.
Note that AHB still requires two kinds of nodes: those before and after an Arbiter.