### PR TITLE
Fix configs with both RV32D and scratchpads

### DIFF
--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -39,6 +39,8 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
       val dmem = new HellaCacheIO
     })
 
+    require(coreDataBytes * 8 == io.dmem.resp.bits.data.getWidth, "ScratchpadSlavePort is misconfigured: coreDataBytes must match D$ data width")
+
     val (tl_in, edge) = node.in(0)
 
     val s_ready :: s_wait1 :: s_wait2 :: s_replay :: s_grant :: Nil = Enum(UInt(), 5)

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -77,7 +77,7 @@ trait HasCoreParameters extends HasTileParameters {
   val coreInstBytes = coreInstBits/8
   val coreDataBits = xLen max fLen max vMemDataBits
   val coreDataBytes = coreDataBits/8
-  val coreMaxAddrBits = paddrBits max vaddrBitsExtended
+  def coreMaxAddrBits = paddrBits max vaddrBitsExtended
 
   val nBreakpoints = coreParams.nBreakpoints
   val nPMPs = coreParams.nPMPs


### PR DESCRIPTION
A refactoring in 3133c321b7b771150168b687834fac5edd4a292a made the assumption that coreDataBits = xLen, which is not true for RV32D. Since the assumption wasn't paired with an assertion, attempting to generate such configs resulted in successful elaboration of a broken design.

**Type of change**: bug report

**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation
