### PR TITLE
pipe out compatname

### DIFF
--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -12,10 +12,10 @@ abstract class DiplomaticSRAM(
     address: AddressSet,
     beatBytes: Int,
     devName: Option[String],
-    compatName: String = "sifive,sram0")(implicit p: Parameters) extends LazyModule
+    dtsCompat: Option[Seq[String]] = None)(implicit p: Parameters) extends LazyModule
 {
   val device = devName
-    .map(new SimpleDevice(_, Seq(compatName)))
+    .map(new SimpleDevice(_, dtsCompat.getOrElse(Seq("sifive,sram0"))))
     .getOrElse(new MemoryDevice())
 
   def getOMMemRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -11,10 +11,11 @@ import freechips.rocketchip.util.DescribedSRAM
 abstract class DiplomaticSRAM(
     address: AddressSet,
     beatBytes: Int,
-    devName: Option[String])(implicit p: Parameters) extends LazyModule
+    devName: Option[String],
+    compatName: String = "sifive,sram0")(implicit p: Parameters) extends LazyModule
 {
   val device = devName
-    .map(new SimpleDevice(_, Seq("sifive,sram0")))
+    .map(new SimpleDevice(_, Seq(compatName)))
     .getOrElse(new MemoryDevice())
 
   def getOMMemRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -25,7 +25,7 @@ class TLRAM(
     ecc: ECCParams = ECCParams(),
     val devName: Option[String] = None,
     val dtsCompat: Option[Seq[String]] = None
-  )(implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName, compatName)
+  )(implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName, dtsCompat)
 {
   val eccBytes = ecc.bytes
   val code = ecc.code

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -24,7 +24,7 @@ class TLRAM(
     beatBytes: Int = 4,
     ecc: ECCParams = ECCParams(),
     val devName: Option[String] = None,
-    val compatName: String = "sifive,sram0"
+    val dtsCompat: Option[Seq[String]] = None
   )(implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName, compatName)
 {
   val eccBytes = ecc.bytes

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -24,7 +24,8 @@ class TLRAM(
     beatBytes: Int = 4,
     ecc: ECCParams = ECCParams(),
     val devName: Option[String] = None,
-  )(implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
+    val compatName: String = "sifive,sram0"
+  )(implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName, compatName)
 {
   val eccBytes = ecc.bytes
   val code = ecc.code


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This is a somewhat dirty way of allowing the compat string of an sram to be set, but to default to "sifive,sram0". Another option here would be to make all the parameters a case class, but I know this code is used a lot, so I would prefer not to break compatibility. If you prefer that method though, let me know and I can implement it.