### PR TITLE
Add option to make PLIC take up less address space

### DIFF
--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -38,7 +38,7 @@ class LevelGateway extends Module {
 object PLICConsts
 {
   def maxDevices = 1023
-  def maxHarts = 15872
+  def maxMaxHarts = 15872
   def priorityBase = 0x0
   def pendingBase = 0x1000
   def enableBase = 0x2000
@@ -52,14 +52,18 @@ object PLICConsts
   def enableBase(i: Int):Int = enableOffset(i) + enableBase
   def hartBase(i: Int):Int = hartOffset(i) + hartBase
 
-  def size = hartBase(maxHarts)
-  require(hartBase >= enableBase(maxHarts))
+  def size(maxHarts: Int): Int = {
+    require(maxHarts > 0 && maxHarts <= maxMaxHarts, s"Must be: maxHarts=$maxHarts > 0 && maxHarts <= PLICConsts.maxMaxHarts=${PLICConsts.maxMaxHarts}")
+    1 << log2Ceil(hartBase(maxHarts))
+  }
+
+  require(hartBase >= enableBase(maxMaxHarts))
 }
 
-case class PLICParams(baseAddress: BigInt = 0xC000000, maxPriorities: Int = 7, intStages: Int = 0)
+case class PLICParams(baseAddress: BigInt = 0xC000000, maxPriorities: Int = 7, intStages: Int = 0, maxHarts: Int = PLICConsts.maxMaxHarts)
 {
   require (maxPriorities >= 0)
-  def address = AddressSet(baseAddress, PLICConsts.size-1)
+  def address = AddressSet(baseAddress, PLICConsts.size(maxHarts)-1)
 }
 
 case object PLICKey extends Field[Option[PLICParams]](None)
@@ -137,7 +141,7 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     require (nHarts == harts.size, s"Must be: nHarts=$nHarts == harts.size=${harts.size}")
 
     require(nDevices <= PLICConsts.maxDevices, s"Must be: nDevices=$nDevices <= PLICConsts.maxDevices=${PLICConsts.maxDevices}")
-    require(nHarts > 0 && nHarts <= PLICConsts.maxHarts, s"Must be: nHarts=$nHarts > 0 && nHarts <= PLICConsts.maxHarts=${PLICConsts.maxHarts}")
+    require(nHarts > 0 && nHarts <= params.maxHarts, s"Must be: nHarts=$nHarts > 0 && nHarts <= PLICParams.maxHarts=${params.maxHarts}")
 
     // For now, use LevelGateways for all TL2 interrupts
     val gateways = interrupts.map { case i =>


### PR DESCRIPTION
By setting maxHarts to e.g. 512 instead of the maximum of 15872, the address
space consumption falls to 4 MiB from 64 MiB.

Compacting the PLIC address space in this manner does not affect software
compatibility, because none of the offsets change.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation
