### PR TITLE
Remove extra (Berkeley) pom scm tag, add developer, re-indent pom.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,22 +27,24 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { x => false },
   pomExtra := <url>https://github.com/freechipsproject/rocket-chip</url>
-  <licenses>
-    <license>
-      <name>Apache 2</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-    <license>
-      <name>BSD-style</name>
-        <url>http://www.opensource.org/licenses/bsd-license.php</url>
+    <licenses>
+      <license>
+        <name>Apache 2</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         <distribution>repo</distribution>
       </license>
+      <license>
+        <name>BSD-style</name>
+          <url>http://www.opensource.org/licenses/bsd-license.php</url>
+          <distribution>repo</distribution>
+      </license>
     </licenses>
-    <scm>
-      <url>https://github.com/freechipsproject/rocketchip.git</url>
-      <connection>scm:git:github.com/freechipsproject/rocketchip.git</connection>
-    </scm>,
+    <developers>
+      <developer>
+        <organization>SiFive</organization>
+        <organizationUrl>https://www.sifive.com/</organizationUrl>
+      </developer>
+    </developers>,
   publishTo := {
     val v = version.value
     val nexus = "https://oss.sonatype.org/"


### PR DESCRIPTION
The extra scm tag (some other piece of code is generating a SiFive scm tag) and the lack of a developer one cause pre-publish errors on Sonatype.

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation
