### PR TITLE
check_submodules: update regex

### DIFF
--- a/ci-tests/check_submodules
+++ b/ci-tests/check_submodules
@@ -9,3 +9,10 @@ filter='.[]|select(.commit == "\1")|select(.name == "\2")'
 git submodule status \
 | sed -r "s/[ -+U]([a-zA-Z0-9]+) ([a-zA-Z0-9\-]+) ?.*/$filter/g" \
 | xargs -d '\n' -I % sh -c "jq -e '%' wit-manifest.json"
+
+if [ $? -eq 0 ]; then
+  echo "Submodules are in sync with wit-manifest"
+else
+  echo "ERROR! Submodules are out of sync with wit-manifest!"
+  exit 1
+fi

--- a/ci-tests/check_submodules
+++ b/ci-tests/check_submodules
@@ -7,5 +7,5 @@ filter='.[]|select(.commit == "\1")|select(.name == "\2")'
 # the wit-manifest.json may have packages that are not submoduled
 # e.g. api-chisel3-sifive
 git submodule status \
-| sed -r "s/\-([a-zA-Z0-9]+)\s([a-zA-Z0-9\-]+)/$filter/g" \
+| sed -r "s/[ -+U]([a-zA-Z0-9]+) ([a-zA-Z0-9\-]+) ?.*/$filter/g" \
 | xargs -d '\n' -I % sh -c "jq -e '%' wit-manifest.json"


### PR DESCRIPTION
updates the regex in the `check_submodules` script. the hashes output by `git submodule status` may be prefixed with `-`, `+`, or `U` and there may be stuff from `git describe` appended to the end of each line.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
