### PR TITLE
Add -static option in emulator/Makefile to link libfesvr.a correctly 

### DIFF
--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -10,7 +10,7 @@ include $(base_dir)/Makefrag
 
 CXXSRCS := emulator SimDTM SimJTAG remote_bitbang
 CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include
-LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -static -lfesvr -lpthread
+LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -lpthread $(RISCV)/lib/libfesvr.a
 
 emu = emulator-$(PROJECT)-$(CONFIG)
 emu_debug = emulator-$(PROJECT)-$(CONFIG)-debug

--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -10,7 +10,7 @@ include $(base_dir)/Makefrag
 
 CXXSRCS := emulator SimDTM SimJTAG remote_bitbang
 CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include
-LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -lfesvr -lpthread
+LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -static -lfesvr -lpthread
 
 emu = emulator-$(PROJECT)-$(CONFIG)
 emu_debug = emulator-$(PROJECT)-$(CONFIG)-debug


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <#1904 #2020>

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

The emulator file size would be a bit more larger than previous since static library would be included. 

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
For those who have built the fesvr from a older version, both the libfesvr.so(of the older version) and libfesvr.a would be in the $RISCV/lib directory. The -static option tells the linker to use libfesvr.a explicitly. 