### PR TITLE
Allow a RationalCrossingSource to remain in reset longer than sink

### DIFF
--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -218,7 +218,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
     newEntry.ppn := pte.ppn
     newEntry.c := cacheable
     newEntry.u := pte.u
-    newEntry.g := pte.g
+    newEntry.g := pte.g && pte.v
     newEntry.ae := io.ptw.resp.bits.ae
     newEntry.sr := pte.sr()
     newEntry.sw := pte.sw()

--- a/src/main/scala/util/BlockDuringReset.scala
+++ b/src/main/scala/util/BlockDuringReset.scala
@@ -1,0 +1,23 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import chisel3._
+import chisel3.util.DecoupledIO
+
+/** Blocks transactions until the cycle after reset. */
+object BlockDuringReset
+{
+  def apply[T <: Data](enq: DecoupledIO[T]): DecoupledIO[T] = {
+    val out_of_reset = RegNext(true.B, false.B)
+    val res = Wire(enq.cloneType)
+    res.valid := enq.valid
+    enq.ready := res.ready
+    res.bits := enq.bits
+    when (!out_of_reset) {
+      res.valid := false.B
+      enq.ready := false.B
+    }
+    res
+  }
+}

--- a/src/main/scala/util/RationalCrossing.scala
+++ b/src/main/scala/util/RationalCrossing.scala
@@ -71,12 +71,13 @@ class RationalCrossingSource[T <: Data](gen: T, direction: RationalDirection = S
     val deq = RationalIO(gen)
   }
 
+  val enq_in = BlockDuringReset(io.enq)
   val deq = io.deq
   val enq = direction match {
-    case Symmetric  => ShiftQueue(io.enq, 1, flow=true)
-    case Flexible => ShiftQueue(io.enq, 2)
-    case FastToSlow => io.enq
-    case SlowToFast => ShiftQueue(io.enq, 2)
+    case Symmetric  => ShiftQueue(enq_in, 1, flow=true)
+    case Flexible => ShiftQueue(enq_in, 2)
+    case FastToSlow => enq_in
+    case SlowToFast => ShiftQueue(enq_in, 2)
   }
 
   val count = RegInit(UInt(0, width = 2))


### PR DESCRIPTION
...by preventing any enqueues that might spuriously happen during reset.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
