### PR TITLE
add AHB Monitors, remove Snoop bundles

### DIFF
--- a/src/main/scala/amba/ahb/Monitor.scala
+++ b/src/main/scala/amba/ahb/Monitor.scala
@@ -6,14 +6,27 @@ import chisel3._
 import chisel3.core.Reset
 import freechips.rocketchip.config.Parameters
 
-case class AHBMonitorArgs(edge: AHBEdgeParameters)
+case class AHBSlaveMonitorArgs(edge: AHBEdgeParameters)
 
-abstract class AHBMonitorBase(args: AHBMonitorArgs) extends Module
+abstract class AHBSlaveMonitorBase(args: AHBSlaveMonitorArgs) extends Module
 {
   val io = IO(new Bundle {
     val in = Input(new AHBSlaveBundle(args.edge.bundle))
   })
 
   def legalize(bundle: AHBSlaveBundle, edge: AHBEdgeParameters, reset: Reset): Unit
+  legalize(io.in, args.edge, reset)
+}
+
+
+case class AHBMasterMonitorArgs(edge: AHBEdgeParameters)
+
+abstract class AHBMasterMonitorBase(args: AHBMasterMonitorArgs) extends Module
+{
+  val io = IO(new Bundle {
+    val in = Input(new AHBMasterBundle(args.edge.bundle))
+  })
+
+  def legalize(bundle: AHBMasterBundle, edge: AHBEdgeParameters, reset: Reset): Unit
   legalize(io.in, args.edge, reset)
 }

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -284,49 +284,6 @@ object TLBundle
   def apply(params: TLBundleParameters) = new TLBundle(params)
 }
 
-final class DecoupledSnoop[+T <: Data](gen: T) extends Bundle
-{
-  val ready = Bool()
-  val valid = Bool()
-  val bits = gen.asOutput
-
-  def fire() = ready && valid
-  override def cloneType: this.type = new DecoupledSnoop(gen).asInstanceOf[this.type]
-}
-
-object DecoupledSnoop
-{
-  def apply[T <: Data](source: DecoupledIO[T], sink: DecoupledIO[T]) = {
-    val out = Wire(new DecoupledSnoop(sink.bits))
-    out.ready := sink.ready
-    out.valid := source.valid
-    out.bits  := source.bits
-    out
-  }
-}
-
-class TLBundleSnoop(params: TLBundleParameters) extends TLBundleBase(params)
-{
-  val a = new DecoupledSnoop(new TLBundleA(params))
-  val b = new DecoupledSnoop(new TLBundleB(params))
-  val c = new DecoupledSnoop(new TLBundleC(params))
-  val d = new DecoupledSnoop(new TLBundleD(params))
-  val e = new DecoupledSnoop(new TLBundleE(params))
-}
-
-object TLBundleSnoop
-{
-  def apply(source: TLBundle, sink: TLBundle) = {
-    val out = Wire(new TLBundleSnoop(sink.params))
-    out.a := DecoupledSnoop(source.a, sink.a)
-    out.b := DecoupledSnoop(sink.b, source.b)
-    out.c := DecoupledSnoop(source.c, sink.c)
-    out.d := DecoupledSnoop(sink.d, source.d)
-    out.e := DecoupledSnoop(source.e, sink.e)
-    out
-  }
-}
-
 class TLAsyncBundleBase(params: TLAsyncBundleParameters) extends GenericParameterizedBundle(params)
 
 class TLAsyncBundle(params: TLAsyncBundleParameters) extends TLAsyncBundleBase(params)


### PR DESCRIPTION
Sorry, was supposed to do this in https://github.com/chipsalliance/rocket-chip/pull/2124 but never got around to it before it got merged.
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- add `AHBSlaveMonitor` and `AHBMasterMonitor`
- remove `TLBundleSnoop` and `DecoupledSnoop`