### PR TITLE
Continue to improve flexibility of subsystem bus attachment

### DIFF
--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.HasLogicalTreeNode
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
-import freechips.rocketchip.diplomaticobjectmodel.model.{OMComponent, OMInterrupt}
+import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.util._
 
 
@@ -57,13 +57,15 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
   val mbus = LazyModule(new MemoryBus(p(MemoryBusKey)))
   val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
 
-  protected def attach(where: BaseSubsystemBusAttachment) = where match {
+  type PartialAttachment = PartialFunction[BaseSubsystemBusAttachment, TLBusWrapper]
+  protected def baseAttachment: PartialAttachment = {
     case SBUS => sbus
     case PBUS => pbus
     case FBUS => fbus
     case MBUS => mbus
     case CBUS => cbus
   }
+  protected def attach(where: BaseSubsystemBusAttachment) = baseAttachment(where)
 
   // Collect information for use in DTS
   lazy val topManagers = sbus.unifyManagers

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -37,6 +37,9 @@ abstract class BareSubsystemModuleImp[+L <: BareSubsystem](_outer: L) extends La
 }
 
 
+/** This trait contains the cases matched in baseAttachmentFunc below.
+  * Both can be extended to offer novel attachment locations in subclasses of BaseSubsystem.
+  */
 trait BaseSubsystemBusAttachment
 case object SBUS extends BaseSubsystemBusAttachment
 case object PBUS extends BaseSubsystemBusAttachment
@@ -57,15 +60,15 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
   val mbus = LazyModule(new MemoryBus(p(MemoryBusKey)))
   val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
 
-  type PartialAttachment = PartialFunction[BaseSubsystemBusAttachment, TLBusWrapper]
-  protected def baseAttachment: PartialAttachment = {
+  type BusAttachmentFunction = PartialFunction[BaseSubsystemBusAttachment, TLBusWrapper]
+  protected def baseBusAttachmentFunc: BusAttachmentFunction = {
     case SBUS => sbus
     case PBUS => pbus
     case FBUS => fbus
     case MBUS => mbus
     case CBUS => cbus
   }
-  protected def attach(where: BaseSubsystemBusAttachment) = baseAttachment(where)
+  protected def attach(where: BaseSubsystemBusAttachment): TLBusWrapper = baseBusAttachmentFunc(where)
 
   // Collect information for use in DTS
   lazy val topManagers = sbus.unifyManagers


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation

- Allow some common TileLink-based peripherals (CLINT and PLIC) to have more flexible attachment points to the subsytem bus hierarchy
- Defines `type BusAttachmentFunction`
- Allow subclasses of `BaseSubsystem` to override `def attach` while providing new matches of type `BusAttachmentFunction`  
- user facing API backwards compatible