### PR TITLE
Update OMPorts.scala

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -56,9 +56,9 @@ case class AHB_Lite(
   val _types: Seq[String] = Seq("AHB_Lite", "AMBA",  "OMProtocol")
 ) extends AMBA
 
-case class AHB_Full(
+case class AHB(
   specification: Option[OMSpecification],
-  val _types: Seq[String] = Seq("AHB_Full", "AMBA",  "OMProtocol")
+  val _types: Seq[String] = Seq("AHB", "AMBA",  "OMProtocol")
 ) extends AMBA
 
 case class APB(
@@ -163,7 +163,7 @@ object OMPortMaker {
       case (AXI4Protocol, AXI4SubProtocol) => AXI4(specification = specVersion(protocol, version))
       case (AXI4Protocol, AXI4LiteSubProtocol) => AXI4_Lite(specification = specVersion(protocol, version))
       case (AHBProtocol, AHBLiteSubProtocol) => AHB_Lite(specification = specVersion(protocol, version))
-      case (AHBProtocol, AHBFullSubProtocol) => AHB_Full(specification = specVersion(protocol, version))
+      case (AHBProtocol, AHBFullSubProtocol) => AHB(specification = specVersion(protocol, version))
       case (APBProtocol, APBSubProtocol) => APB(specification = specVersion(protocol, version))
       case (TLProtocol, TL_UHSubProtocol) => TL_UH(specification = specVersion(protocol, version))
       case (TLProtocol, TL_ULSubProtocol) => TL_UL(specification = specVersion(protocol, version))

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -49,8 +49,6 @@ case class AXI4_Lite(
   val _types: Seq[String] = Seq("AXI4_Lite", "AMBA",  "OMProtocol")
 ) extends AMBA
 
-trait AHB extends AMBA
-
 case class AHB_Lite(
   specification: Option[OMSpecification],
   val _types: Seq[String] = Seq("AHB_Lite", "AMBA",  "OMProtocol")


### PR DESCRIPTION
analagous with AXI4 vs AXI4_Lite, the pair should be AHB and AHB_Lite

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Full AHB is described in Logical Tree Nodes as "AHB", analogous to how AXI4 is AXI4_Full vs Lite.