### PR TITLE
Speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,9 @@ branches:
 
 jobs:
   include:
-    - stage: wake and wit checks
+    - stage: check wit
       script:
         - ci-tests/check_submodules
-        - ci-tests/wake_scala_compilation
     - stage: prepare cache-riscv-tools
       script:
         - travis_wait 120 make tools -C regression SUITE=none
@@ -110,3 +109,7 @@ jobs:
     - <<: *test
       script:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=Miscellaneous JVM_MEMORY=3G
+    - <<: *test
+      name: check wake compilation
+      script:
+        - ci-tests/wake_scala_compilation


### PR DESCRIPTION
Move Wake compilation check into Test stage

Previously all tests were serialized behind the wake compilation check (~12 min), but we might as well parallelize that with the normal tests. I left the wit manifest vs. submodules check as a separate stage because it's easy to forget and the check is super fast.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
