### PR TITLE
tilelink: add TLFilter.mSubtract

### DIFF
--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -85,7 +85,7 @@ object TLFilter
     intersectionHelper(m, filtered, alignment)
   }
 
-  // make everything except the intersecyed address sets visible
+  // make everything except the intersected address sets visible
   def mExceptIntersect(except: AddressSet): ManagerFilter = { m =>
     val filtered = m.address.flatMap(_.subtract(except))
     val alignment: BigInt = if (filtered.isEmpty) 0 else filtered.map(_.alignment).max

--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -82,18 +82,18 @@ object TLFilter
   def mSelectIntersect(select: AddressSet): ManagerFilter = { m =>
     val filtered = m.address.map(_.intersect(select)).flatten
     val alignment = select.alignment /* alignment 0 means 'select' selected everything */
-    intersectionHelper(m, filtered, alignment)
+    transferSizeHelper(m, filtered, alignment)
   }
 
   // make everything except the intersected address sets visible
-  def mExceptIntersect(except: AddressSet): ManagerFilter = { m =>
+  def mSubtract(except: AddressSet): ManagerFilter = { m =>
     val filtered = m.address.flatMap(_.subtract(except))
-    val alignment: BigInt = if (filtered.isEmpty) 0 else filtered.map(_.alignment).max
-    intersectionHelper(m, filtered, alignment)
+    val alignment: BigInt = if (filtered.isEmpty) 0 else filtered.map(_.alignment).min
+    transferSizeHelper(m, filtered, alignment)
   }
 
   // adjust supported transfer sizes based on filtered intersection
-  private def intersectionHelper(m: TLManagerParameters, filtered: Seq[AddressSet], alignment: BigInt): Option[TLManagerParameters] = {
+  private def transferSizeHelper(m: TLManagerParameters, filtered: Seq[AddressSet], alignment: BigInt): Option[TLManagerParameters] = {
     val maxTransfer = 1 << 30
     val capTransfer = if (alignment == 0 || alignment > maxTransfer) maxTransfer else alignment.toInt
     val cap = TransferSizes(1, capTransfer)


### PR DESCRIPTION
Adds a new built-in `ManagerFilter` to the `TLFilter` helper object called `mSubtract`. Factors out some common code between it and `mSelectIntersect`.