### PR TITLE
Core signal monitor

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -851,12 +851,14 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val icache_blocked = !(io.imem.resp.valid || RegNext(io.imem.resp.valid))
   csr.io.counters foreach { c => c.inc := RegNext(perfEvents.evaluate(c.eventSel)) }
 
-  val coreMonitorBundle = Wire(new CoreMonitorBundle(xLen))
-  coreMonitorBundle.clock := clock
-  coreMonitorBundle.reset := reset
-  coreMonitorBundle.cease := csr.io.status.cease
-  coreMonitorBundle.reg_mscratch := 0.U //FIXME
-  coreMonitorBundle.hartid := io.hartid
+  val coreMonitorBundle =
+    CoreMonitorBundleTest(
+      xLen,
+      csr.io.status.cease,
+      csr.reg_mscratch,
+      io.hartid)
+
+  val coreMonitorBundles = List(coreMonitorBundle)
 
   val commitTraceMonitorBundle = Wire(new CommitTraceMonitorBundle(xLen))
   commitTraceMonitorBundle.clock := clock

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -851,14 +851,14 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val icache_blocked = !(io.imem.resp.valid || RegNext(io.imem.resp.valid))
   csr.io.counters foreach { c => c.inc := RegNext(perfEvents.evaluate(c.eventSel)) }
 
-  val coreMonitorBundle =
-    CoreMonitorBundleTest(
+  val coreSignalMonitor =
+    CoreSignalMonitor(
+      clock,
+      reset,
       xLen,
       csr.io.status.cease,
       csr.reg_mscratch,
       io.hartid)
-
-  val coreMonitorBundles = List(coreMonitorBundle)
 
   val commitTraceMonitorBundle = Wire(new CommitTraceMonitorBundle(xLen))
   commitTraceMonitorBundle.clock := clock

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.tile.{BaseTile, LookupByHartId, LookupByHartIdImpl, 
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-trait HasTiles extends HasCoreMonitorBundles with HasCommitTraceMonitorBundles { this: BaseSubsystem =>
+trait HasTiles extends HasCoreSignalMonitors with HasCommitTraceMonitorBundles { this: BaseSubsystem =>
   implicit val p: Parameters
   val tiles: Seq[BaseTile]
   protected def tileParams: Seq[TileParams] = tiles.map(_.tileParams)

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -54,8 +54,8 @@ trait HasRocketTiles extends HasTiles
       LogicalModuleTree.add(logicalTreeNode, r.rocketLogicalTree)
   }
 
-  def coreMonitorBundles = (rocketTiles map { t => //FIXME
-    t.module.core.rocketImpl.coreMonitorBundle
+  def coreSignalMonitors = (rocketTiles map { t =>
+    t.module.core.rocketImpl.coreSignalMonitor
   }).toList
 
   def commitTraceMonitorBundles = (rocketTiles map { t =>

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -8,12 +8,12 @@ import Chisel._
 // this class is used to expose some internal core signals
 // to verification monitors
 case class CoreSignalMonitor(
-  val clock: Clock,
-  val reset: Reset,
-  val xLen: Int,
-  val cease: Bool,
-  val reg_mscratch: UInt,
-  val hartid: UInt)
+  clock: Clock,
+  reset: Reset,
+  xLen: Int,
+  cease: Bool,
+  reg_mscratch: UInt,
+  hartid: UInt)
   extends HasCoreSignalMonitorParameters
 
 trait HasCoreSignalMonitorParameters {

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -7,6 +7,12 @@ import chisel3._
 
 // this bundle is used to expose some internal core signals
 // to verification monitors which sample instruction commits
+case class CoreMonitorBundleTest(
+  val xLen: Int,
+  val cease: Bool,
+  val reg_mscratch: UInt,
+  val hartid: UInt)
+
 class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
   val cease = Bool()
   val reg_mscratch = UInt(width = xLen.W)
@@ -15,5 +21,5 @@ class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
 
 // mark a module that has cores with CoreMonitorBundles
 trait HasCoreMonitorBundles {
-    def coreMonitorBundles: List[CoreMonitorBundle]
+    def coreMonitorBundles: List[CoreMonitorBundleTest]
 }

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -15,12 +15,6 @@ case class CoreSignalMonitor(
   val reg_mscratch: UInt,
   val hartid: UInt)
 
-class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
-  val cease = Bool()
-  val reg_mscratch = UInt(width = xLen.W)
-  val hartid = UInt(width = xLen.W)
-}
-
 // mark a module that has cores with a CoreSignalMonitor
 trait HasCoreSignalMonitors {
     def coreSignalMonitors: List[CoreSignalMonitor]

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -3,11 +3,13 @@
 
 package freechips.rocketchip.util
 
-import chisel3._
+import Chisel._
 
-// this bundle is used to expose some internal core signals
-// to verification monitors which sample instruction commits
-case class CoreMonitorBundleTest(
+// this class is used to expose some internal core signals
+// to verification monitors
+case class CoreSignalMonitor(
+  val clock: Clock,
+  val reset: Reset,
   val xLen: Int,
   val cease: Bool,
   val reg_mscratch: UInt,
@@ -19,7 +21,7 @@ class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
   val hartid = UInt(width = xLen.W)
 }
 
-// mark a module that has cores with CoreMonitorBundles
-trait HasCoreMonitorBundles {
-    def coreMonitorBundles: List[CoreMonitorBundleTest]
+// mark a module that has cores with a CoreSignalMonitor
+trait HasCoreSignalMonitors {
+    def coreSignalMonitors: List[CoreSignalMonitor]
 }

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -14,8 +14,18 @@ case class CoreSignalMonitor(
   val cease: Bool,
   val reg_mscratch: UInt,
   val hartid: UInt)
+  extends HasCoreSignalMonitorParameters
+
+trait HasCoreSignalMonitorParameters {
+  def clock: Clock
+  def reset: Reset
+  def xLen: Int
+  def cease: Bool
+  def reg_mscratch: UInt
+  def hartid: UInt
+}
 
 // mark a module that has cores with a CoreSignalMonitor
 trait HasCoreSignalMonitors {
-    def coreSignalMonitors: List[CoreSignalMonitor]
+  def coreSignalMonitors: List[CoreSignalMonitor]
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition

<!-- choose one -->
**Development Phase**: implementation

Added a new case class `CoreSignalMonitor` to directly access signals in the core which are not available as IOs.