### PR TITLE
Add missing define for SCIEPipelined

### DIFF
--- a/src/main/scala/scie/SCIE.scala
+++ b/src/main/scala/scie/SCIE.scala
@@ -146,6 +146,10 @@ class SCIEPipelined(xLen: Int) extends BlackBox(Map("XLEN" -> xLen)) with HasBla
       |  reg funct3_0;
       |  reg [XLEN-1:0] result;
       |
+      |`ifndef RANDOM
+      |`define RANDOM $$random
+      |`endif
+      |
       |  always @(posedge clock)
       |  begin
       |    /* Gating using the valid signal is optional, but saves power. */


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: Minor fix

The SCIEPipelined module was using a define without defining it. This leads to non deterministic failures when compiling with this verilog file. Fix is to define it before using.

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
