### PR TITLE
Expose part_number and version of IDCODE

### DIFF
--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -13,7 +13,7 @@ case class JtagDTMConfig (
   idcodeVersion    : Int,      // chosen by manuf.
   idcodePartNum    : Int,      // Chosen by manuf.
   idcodeManufId    : Int,      // Assigned by JEDEC
-  // Note: the actual manufId is passed in through a wire.
+  // Note: the actual fields are passed in through wires.
   // Do not forget to wire up io.jtag_mfr_id through your top-level to set the
   // mfr_id for this core.
   // If you wish to use this field in the config, you can obtain it along
@@ -66,6 +66,8 @@ class SystemJTAGIO extends Bundle {
   val jtag = new JTAGIO(hasTRSTn = false).flip
   val reset = Bool(INPUT)
   val mfr_id = UInt(INPUT, 11)
+  val part_number = UInt(INPUT, 16)
+  val version = UInt(INPUT, 4)
 }
 
 class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
@@ -76,6 +78,8 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
     val jtag = Flipped(new JTAGIO(hasTRSTn = false)) // TODO: re-use SystemJTAGIO here?
     val jtag_reset = Bool(INPUT)
     val jtag_mfr_id = UInt(INPUT, 11)
+    val jtag_part_number = UInt(INPUT, 16)
+    val jtag_version = UInt(INPUT, 4)
     val fsmReset = Bool(OUTPUT)
   }
 
@@ -242,8 +246,8 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   // Actual JTAG TAP
   val idcode = Wire(init = new JTAGIdcodeBundle().fromBits(0.U))
   idcode.always1    := 1.U
-  idcode.version    := c.idcodeVersion.U
-  idcode.partNumber := c.idcodePartNum.U
+  idcode.version    := io.jtag_version
+  idcode.partNumber := io.jtag_part_number
   idcode.mfrId      := io.jtag_mfr_id
 
   val tapIO = JtagTapGenerator(irLength = 5,

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -126,6 +126,8 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
     dtm.clock          := sj.jtag.TCK
     dtm.io.jtag_reset  := sj.reset
     dtm.io.jtag_mfr_id := sj.mfr_id
+    dtm.io.jtag_part_number := sj.part_number
+    dtm.io.jtag_version := sj.version
     dtm.reset          := dtm.io.fsmReset
 
     outer.debug.module.io.dmi.get.dmi <> dtm.io.dmi
@@ -215,6 +217,8 @@ object Debug {
       val jtag = Module(new SimJTAG(tickDelay=3)).connect(sj.jtag, c, r, ~r, out)
       sj.reset := r
       sj.mfr_id := p(JtagDTMKey).idcodeManufId.U(11.W)
+      sj.part_number := p(JtagDTMKey).idcodePartNum.U(16.W)
+      sj.version := p(JtagDTMKey).idcodeVersion.U(4.W)
     }
     debug.apb.foreach { apb =>
       require(false, "No support for connectDebug for an APB debug connection.")
@@ -232,6 +236,8 @@ object Debug {
       sj.jtag.TRSTn.foreach { r => r := Bool(true) }
       sj.reset := Bool(true)
       sj.mfr_id := 0.U
+      sj.part_number := 0.U
+      sj.version := 0.U
     }
 
     debug.clockeddmi.foreach { d =>


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
When the JTAG TAP is included by a customer in a larger system, they may want to identify it using the JTAG IDCODE scan register.  This PR adds the part_number and version fields of IDCODE to the mfr_id port exposed at the top level so that all three can be set by the customer.
