### PR TITLE
AddressAdjuster Improvements

### DIFF
--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -115,7 +115,7 @@ object TransferSizes {
 case class AddressSet(base: BigInt, mask: BigInt) extends Ordered[AddressSet]
 {
   // Forbid misaligned base address (and empty sets)
-  require ((base & mask) == 0, s"Mis-aligned AddressSets are forbidden, got: ($base, $mask)")
+  require ((base & mask) == 0, s"Mis-aligned AddressSets are forbidden, got: ${this.toString}")
   require (base >= 0, s"AddressSet negative base is ambiguous: $base") // TL2 address widths are not fixed => negative is ambiguous
   // We do allow negative mask (=> ignore all high bits)
 

--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -7,260 +7,315 @@ import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 
+case class TLSplitterNode(
+  clientFn:  TLClientPortParameters  => TLClientPortParameters  = { s => s },
+  managerFn: Seq[TLManagerPortParameters] => Seq[TLManagerPortParameters] = { s => s })(
+  implicit valName: ValName) extends TLCustomNode {
+
+  def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
+    require (iStars == 0, s"$context does not support :*=")
+    if (oStars > 0) {
+      require (2*iKnown >= oKnown, s"$context has $oKnown outputs and $iKnown inputs; cannot assign ${2*iKnown-oKnown} edges to resolve :=*")
+      (0, iKnown - oKnown)
+    } else {
+      require (oKnown == 2*iKnown, s"$context has $oKnown outputs and $iKnown inputs; but 2*$iKnown must be $oKnown")
+      (0, 0)
+    }
+  }
+
+  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] = { p.map(clientFn) ++ p.map(clientFn) }
+
+  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] = { managerFn(p) } // dFn will halve the size of TLManagerPortParameters
+}
+
 // mask=0 -> passthrough
-// forceLocal -> used to ensure special devices (like debug) remain reacheable at chip_id=0
+// adjustableRegion -> only devices in this regions get adjusted
+// forceLocal -> used to ensure special devices (like debug) remain reacheable at chip_id=0 even if in adjustableRegion
 class AddressAdjuster(mask: BigInt, adjustableRegion: AddressSet = AddressSet.everything, forceLocal: Seq[AddressSet] = Nil)(implicit p: Parameters) extends LazyModule {
   // Which bits are in the mask?
   val bits = AddressSet.enumerateBits(mask)
   // Which ids must we route within that mask?
   val ids  = AddressSet.enumerateMask(mask)
+  // Find the intersection of the mask with some region
+  private def masked(region: Seq[AddressSet], offset: BigInt = 0): Seq[AddressSet] = {
+    region.flatMap { _.intersect(AddressSet(0 + offset, ~mask)) }
+  }
+
   // forceLocal better only go one place (the low index)
   forceLocal.foreach { as => require((as.max & mask) == 0) }
 
-  val node = TLNexusNode(
-    clientFn = { cp => cp(0) },
+  // Address Adjustment requires many things about the downstream devices, captured here as helper functions:
+
+  // Report whether a region of addresses fully contains a particular manager
+  def deviceContainedBy(region: Seq[AddressSet], m: TLManagerParameters): Boolean = {
+    val any_in  = region.exists { f => m.address.exists { a => f.overlaps(a) } }
+    val any_out = region.exists { f => m.address.exists { a => !f.contains(a) } }
+    // Ensure device is either completely inside or outside this region
+    require (!any_in || !any_out,
+      s"Address adjuster cannot have partially contained devices, but for ${m.name}: $region vs ${m.address}")
+    any_in
+  }
+
+  // Confirm that bits of an address are repeated according to the mask
+  def requireMaskRepetition(managers: Seq[TLManagerParameters]): Unit = managers.map { m =>
+    val sorted = m.address.sorted
+    bits.foreach { b =>
+      val flipped = m.address.map(a => AddressSet((a.base ^ b) & ~a.mask, a.mask)).sorted
+      require (sorted == flipped, s"AddressSets for ${m.name} (${sorted}) do not repeat with bit ${b} (${flipped})")
+    }
+  }
+
+  // Confirm that everything supported by the remote PMA (which will be the final PMA) can be taken to the error device
+  def requireErrorSupport(errorDev: TLManagerParameters, managers: Seq[TLManagerParameters]): Unit = managers.map { r =>
+    require (errorDev.supportsAcquireT  .contains(r.supportsAcquireT  ), s"Error device cannot cover ${r.name}'s AcquireT")
+    require (errorDev.supportsAcquireB  .contains(r.supportsAcquireB  ), s"Error device cannot cover ${r.name}'s AcquireB")
+    require (errorDev.supportsArithmetic.contains(r.supportsArithmetic), s"Error device cannot cover ${r.name}'s Arithmetic")
+    require (errorDev.supportsLogical   .contains(r.supportsLogical   ), s"Error device cannot cover ${r.name}'s Logical")
+    require (errorDev.supportsGet       .contains(r.supportsGet       ), s"Error device cannot cover ${r.name}'s Get")
+    require (errorDev.supportsPutFull   .contains(r.supportsPutFull   ), s"Error device cannot cover ${r.name}'s PutFull")
+    require (errorDev.supportsPutPartial.contains(r.supportsPutPartial), s"Error device cannot cover ${r.name}'s PutPartial")
+    require (errorDev.supportsHint      .contains(r.supportsHint      ), s"Error device cannot cover ${r.name}'s Hint")
+  }
+
+  // Confirm that a subset of managers have homogeneous FIFO ids
+  // TODO: a bit not-DRY w.r.t. TLManagerPortParameters.requireFifo()
+  def requireFifoHomogeneity(managers: Seq[TLManagerParameters]): Unit = managers.map { m =>
+    require(m.fifoId.isDefined && m.fifoId == managers.head.fifoId,
+      s"${m.name} had fifoId ${m.fifoId}, " +
+      s"which was not homogeneous (${managers.map(s => (s.name, s.fifoId))}) ")
+  }
+
+  // Confirm that a particular manager r can successfully handle all operations targetting another manager l
+  // TODO: is this general enough to be a method of TLManagerParameters?
+  def requireContainerSupport(l: TLManagerParameters, r: TLManagerParameters): Unit = {
+    require (l.regionType >= r.regionType,  s"Device ${l.name} cannot be ${l.regionType} when ${r.name} is ${r.regionType}")
+    require (!l.executable || r.executable, s"Device ${l.name} cannot be executable if ${r.name} is not")
+    require (!l.mayDenyPut || r.mayDenyPut, s"Device ${l.name} cannot deny Put if ${r.name} does not")
+    require (!l.mayDenyGet || r.mayDenyGet, s"Device ${l.name} cannot deny Get if ${r.name} does not")
+    require (l.alwaysGrantsT || !r.alwaysGrantsT, s"Device ${l.name} must always Grant toT if ${r.name} does")
+    // Confirm no capabilities are lost
+    require (!l.supportsAcquireT   || r.supportsAcquireT,   s"Device ${l.name} (${l.address}) loses AcquireT suppport because ${r.name} does not support it")
+    require (!l.supportsAcquireB   || r.supportsAcquireB,   s"Device ${l.name} (${l.address}) loses AcquireB support because ${r.name} does not support it")
+    require (!l.supportsArithmetic || r.supportsArithmetic, s"Device ${l.name} (${l.address}) loses Arithmetic support because ${r.name} does not support it")
+    require (!l.supportsLogical    || r.supportsLogical,    s"Device ${l.name} (${l.address}) loses Logical support because ${r.name} does not support it")
+    require (!l.supportsGet        || r.supportsGet,        s"Device ${l.name} (${l.address}) loses Get support because ${r.name} does not support it")
+    require (!l.supportsPutFull    || r.supportsPutFull,    s"Device ${l.name} (${l.address}) loses PutFull support because ${r.name} does not support it")
+    require (!l.supportsPutPartial || r.supportsPutPartial, s"Device ${l.name} (${l.address}) loses PutPartial support because ${r.name} does not support it")
+    require (!l.supportsHint       || r.supportsHint,       s"Device ${l.name} (${l.address}) loses Hint support because ${r.name} does not support it")
+  }
+
+  // Utility debug printer
+  def printManagers(kind: String, managers: Seq[TLManagerParameters]): Unit = {
+    println(s"$kind:")
+    println(managers.map(m => s"\t${m.name} ${m.address.head} ${m.fifoId}").mkString("\n"))
+  }
+
+  // Now we create a custom node that joins the local and remote manager parameters, changing the PMAs of devices in the adjustable region
+  val node = TLSplitterNode(
     managerFn = { mp =>
-      require (mp.size == 2)
-      val remote = mp(0)
-      val local  = mp(1)
 
-      def masked(address: Seq[AddressSet], offset: BigInt = 0): Seq[AddressSet] =
-        address.flatMap { _.intersect(AddressSet(0 + offset, ~mask)) }
+      require (mp.size % 2 == 0, s"AddressAdjuster requires an even number of manager ports because it splits them in half. (Got ${mp.size})")
+      val (remotes, locals) = mp.splitAt(mp.size / 2)
 
-      def deviceContainedBy(region: Seq[AddressSet], m: TLManagerParameters): Boolean = {
-        val any_in  = region.exists { f => m.address.exists { a => f.overlaps(a) } }
-        val any_out = region.exists { f => m.address.exists { a => !f.contains(a) } }
-        // Ensure device is either completely inside or outside this region
-        require (!any_in || !any_out,
-          s"Address adjuster cannot have partially contained devices, but for ${m.name}: $region vs ${m.address}")
-        any_in
-      }
+      remotes.zip(locals).map { case (remote, local) =>
+        // Subdivide the managers into four cases: (adjustable vs fixed) x (local vs remote)
+        val adjustableLocalManagers  = local.managers.filter(m =>  deviceContainedBy(List(adjustableRegion), m))
+        val fixedLocalManagers       = local.managers.filter(m => !deviceContainedBy(List(adjustableRegion), m))
 
-      val adjustableLocalManagers  = local.managers.filter(m =>  deviceContainedBy(List(adjustableRegion), m))
-      val onlyLocalManagers        = local.managers.filter(m => !deviceContainedBy(List(adjustableRegion), m))
-
-      val adjustableRemoteManagers = remote.managers.flatMap { m =>
-        val intersection = m.address.flatMap(_.intersect(adjustableRegion))
-        if (intersection.isEmpty) None else Some(m.copy(address = intersection))
-      }
-
-      val onlyRemoteManagers = remote.managers.flatMap { m =>
-        val subtraction = m.address.flatMap(_.subtract (adjustableRegion))
-        if (subtraction.isEmpty) None else Some(m.copy(address = subtraction))
-      }
-
-      if (false) {
-        def printM(m: TLManagerParameters) = s"${m.name} ${m.address.head} ${m.fifoId}"
-        println(
-          s"Adjustable Local: ${adjustableLocalManagers.map(printM)}\n" +
-          s"Adjustable Remote:${adjustableRemoteManagers.map(printM)}\n" +
-          s"Only Local:       ${onlyLocalManagers.map(printM)}\n" +
-          s"Only Remote:      ${onlyRemoteManagers.map(printM)}\n")
-      }
-
-      // Confirm that the PMAs of devices are replicated according to the mask
-      def checkMask(m: TLManagerParameters) = {
-        val sorted = m.address.sorted
-        bits.foreach { b =>
-          val flipped = m.address.map(a => AddressSet((a.base ^ b) & ~a.mask, a.mask)).sorted
-          require (sorted == flipped, s"AddressSets for ${m.name} (${sorted}) do not repeat with bit ${b} (${flipped})")
+        val adjustableRemoteManagers = remote.managers.flatMap { m =>
+          val intersection = m.address.flatMap(_.intersect(adjustableRegion))
+          if (intersection.isEmpty) None else Some(m.copy(address = intersection))
         }
-      }
-      adjustableLocalManagers .foreach { z => checkMask(z) }
-      adjustableRemoteManagers.foreach { z => checkMask(z) }
 
-      // Find the downstream error device
-      val errorDevs = local.managers.filter(_.nodePath.last.lazyModule.className == "TLError")
-      require (!errorDevs.isEmpty, s"There is no TLError reachable from ${name}. One must be instantiated.")
-      val errorDev = errorDevs.head
-
-      // Confirm that everything supported by the remote PMA (which will be the final PMA) can be taken to the error device
-      adjustableRemoteManagers.foreach { r =>
-        require (errorDev.supportsAcquireT  .contains(r.supportsAcquireT  ), s"Error device cannot cover ${r.name}'s AcquireT")
-        require (errorDev.supportsAcquireB  .contains(r.supportsAcquireB  ), s"Error device cannot cover ${r.name}'s AcquireB")
-        require (errorDev.supportsArithmetic.contains(r.supportsArithmetic), s"Error device cannot cover ${r.name}'s Arithmetic")
-        require (errorDev.supportsLogical   .contains(r.supportsLogical   ), s"Error device cannot cover ${r.name}'s Logical")
-        require (errorDev.supportsGet       .contains(r.supportsGet       ), s"Error device cannot cover ${r.name}'s Get")
-        require (errorDev.supportsPutFull   .contains(r.supportsPutFull   ), s"Error device cannot cover ${r.name}'s PutFull")
-        require (errorDev.supportsPutPartial.contains(r.supportsPutPartial), s"Error device cannot cover ${r.name}'s PutPartial")
-        require (errorDev.supportsHint      .contains(r.supportsHint      ), s"Error device cannot cover ${r.name}'s Hint")
-      }
-
-      // Enforce FIFO-ness of the adjustable managers only
-      // TODO: a bit not-DRY w.r.t. TLManagerPortParameters.requireFifo()
-      def requireFifo(managers: Seq[TLManagerParameters]) {
-        managers.map { m =>
-          require(m.fifoId.isDefined && m.fifoId == managers.head.fifoId,
-            s"${m.name} had fifoId ${m.fifoId}, " +
-            s"which was not homogeneous (${managers.map(s => (s.name, s.fifoId))}) ")
+        val fixedRemoteManagers = remote.managers.flatMap { m =>
+          val subtraction = m.address.flatMap(_.subtract (adjustableRegion))
+          if (subtraction.isEmpty) None else Some(m.copy(address = subtraction))
         }
+
+        if (false) {
+          printManagers("Adjustable Local", adjustableLocalManagers)
+          printManagers("Adjustable Remote",adjustableRemoteManagers)
+          printManagers("Fixed Local", fixedLocalManagers)
+          printManagers("Fixed Remote",fixedRemoteManagers)
+        }
+
+        // For address adjustment to be possible, we have to calculate some specific things about the downstream addess map:
+
+        // Find the downstream error device
+        val errorDevs = local.managers.filter(_.nodePath.last.lazyModule.className == "TLError")
+        require (!errorDevs.isEmpty, s"There is no TLError reachable from ${name}. One must be instantiated.")
+        val errorDev = errorDevs.head
+
+        // Find all the holes in local routing
+        val holes = {
+          val ra = masked(adjustableRemoteManagers.flatMap(_.address))
+          val la = masked(adjustableLocalManagers .flatMap(_.address))
+          la.foldLeft(ra) { case (holes, la) => holes.flatMap(_.subtract(la)) }
+        }
+
+        // Confirm that the PMAs of all adjustable devices are replicated according to the mask
+        requireMaskRepetition(adjustableLocalManagers ++ adjustableRemoteManagers)
+
+        // Confirm that the error device can supply all the same capabilities as the remote path
+        requireErrorSupport(errorDev, adjustableRemoteManagers)
+
+        // Confirm that each subset of adjustable managers have homogeneous FIFO ids
+        requireFifoHomogeneity(adjustableLocalManagers)
+        requireFifoHomogeneity(adjustableRemoteManagers)
+
+        // Actually rewrite the PMAs for the adjustable local devices
+        val newLocals = adjustableLocalManagers.map { l =>
+          // Ensure that every local device has a matching remote device
+          val container = adjustableRemoteManagers.find { r => l.address.forall { la => r.address.exists(_.contains(la)) } }
+          require (!container.isEmpty, s"There is no remote manager which contains the addresses of ${l.name} (${l.address})")
+          val r = container.get
+          requireContainerSupport(l, r)
+
+          // The address can be dynamically adjusted to anywhere in the adjustable region, but we take the 0 setting as default for DTS output
+          // Any address space holes in the local adjustable region will be plugged with the error device.
+          // All other PMAs are replaced with the capabilities of the remote path, since that's all we can know statically.
+          // Capabilities supported by the remote but not the local will result in dynamic re-reouting to the error device.
+          l.copy(
+            address            = AddressSet.unify(masked(l.address) ++ (if (l == errorDev) holes else Nil)),
+            regionType         = r.regionType,
+            executable         = r.executable,
+            supportsAcquireT   = r.supportsAcquireT,
+            supportsAcquireB   = r.supportsAcquireB,
+            supportsArithmetic = r.supportsArithmetic,
+            supportsLogical    = r.supportsLogical,
+            supportsGet        = r.supportsGet,
+            supportsPutFull    = r.supportsPutFull,
+            supportsPutPartial = r.supportsPutPartial,
+            supportsHint       = r.supportsHint,
+            mayDenyGet         = r.mayDenyGet,
+            mayDenyPut         = r.mayDenyPut,
+            alwaysGrantsT      = r.alwaysGrantsT,
+            fifoId             = Some(if (deviceContainedBy(forceLocal, l)) ids.size else 0))
+        }
+
+        // Actually rewrite the PMAs for the adjustable remote region too, to account for the differing FIFO domains under the mask
+        val newRemotes = ids.tail.zipWithIndex.flatMap { case (id, i) => adjustableRemoteManagers.map { r =>
+          r.copy(
+            address = AddressSet.unify(masked(r.address, offset = id)),
+            fifoId = Some(i+1))
+        } }
+
+        // Relable the FIFO domains for certain manager subsets
+        val fifoIdFactory = TLXbar.relabeler()
+        def relabelFifo(managers: Seq[TLManagerParameters]): Seq[TLManagerParameters] = {
+          val fifoIdMapper = fifoIdFactory()
+          managers.map(m => m.copy(fifoId = m.fifoId.map(fifoIdMapper(_))))
+        }
+
+        val newManagerList =
+          relabelFifo(newLocals ++ newRemotes) ++
+          relabelFifo(fixedLocalManagers) ++
+          relabelFifo(fixedRemoteManagers)
+
+        local.copy(
+          managers   = newManagerList,
+          endSinkId  = local.endSinkId + remote.endSinkId,
+          minLatency = local.minLatency min remote.minLatency)
       }
-
-      requireFifo(adjustableLocalManagers)
-      requireFifo(adjustableRemoteManagers)
-
-      // Find all the holes in local routing
-      val holes = {
-        val ra = masked(adjustableRemoteManagers.flatMap(_.address))
-        val la = masked(adjustableLocalManagers .flatMap(_.address))
-        la.foldLeft(ra) { case (holes, la) => holes.flatMap(_.subtract(la)) }
-      }
-
-      // Ensure that every local device has a matching remote device
-      val newLocals = adjustableLocalManagers.map { l =>
-        val container = adjustableRemoteManagers.find { r => l.address.forall { la => r.address.exists(_.contains(la)) } }
-        require (!container.isEmpty, s"There is no remote manager which contains the addresses of ${l.name} (${l.address})")
-        val r = container.get
-        require (l.regionType >= r.regionType,  s"Device ${l.name} cannot be ${l.regionType} when ${r.name} is ${r.regionType}")
-        require (!l.executable || r.executable, s"Device ${l.name} cannot be executable if ${r.name} is not")
-        require (!l.mayDenyPut || r.mayDenyPut, s"Device ${l.name} cannot deny Put if ${r.name} does not")
-        require (!l.mayDenyGet || r.mayDenyGet, s"Device ${l.name} cannot deny Get if ${r.name} does not")
-        require (l.alwaysGrantsT || !r.alwaysGrantsT, s"Device ${l.name} must always Grant toT if ${r.name} does")
-        // Confirm no capabilities are lost
-        require (!l.supportsAcquireT   || r.supportsAcquireT,   s"Device ${l.name} (${l.address}) loses AcquireT suppport because ${r.name} does not support it")
-        require (!l.supportsAcquireB   || r.supportsAcquireB,   s"Device ${l.name} (${l.address}) loses AcquireB support because ${r.name} does not support it")
-        require (!l.supportsArithmetic || r.supportsArithmetic, s"Device ${l.name} (${l.address}) loses Arithmetic support because ${r.name} does not support it")
-        require (!l.supportsLogical    || r.supportsLogical,    s"Device ${l.name} (${l.address}) loses Logical support because ${r.name} does not support it")
-        require (!l.supportsGet        || r.supportsGet,        s"Device ${l.name} (${l.address}) loses Get support because ${r.name} does not support it")
-        require (!l.supportsPutFull    || r.supportsPutFull,    s"Device ${l.name} (${l.address}) loses PutFull support because ${r.name} does not support it")
-        require (!l.supportsPutPartial || r.supportsPutPartial, s"Device ${l.name} (${l.address}) loses PutPartial support because ${r.name} does not support it")
-        require (!l.supportsHint       || r.supportsHint,       s"Device ${l.name} (${l.address}) loses Hint support because ${r.name} does not support it")
-
-        // take the 0 setting as default for DTS output
-        l.copy(
-          address            = AddressSet.unify(masked(l.address) ++ (if (l == errorDev) holes else Nil)),
-          regionType         = r.regionType,
-          executable         = r.executable,
-          supportsAcquireT   = r.supportsAcquireT,
-          supportsAcquireB   = r.supportsAcquireB,
-          supportsArithmetic = r.supportsArithmetic,
-          supportsLogical    = r.supportsLogical,
-          supportsGet        = r.supportsGet,
-          supportsPutFull    = r.supportsPutFull,
-          supportsPutPartial = r.supportsPutPartial,
-          supportsHint       = r.supportsHint,
-          mayDenyGet         = r.mayDenyGet,
-          mayDenyPut         = r.mayDenyPut,
-          alwaysGrantsT      = r.alwaysGrantsT,
-          fifoId             = Some(if (deviceContainedBy(forceLocal, l)) ids.size else 0))
-      }
-
-      val newRemotes = ids.tail.zipWithIndex.flatMap { case (id, i) => adjustableRemoteManagers.map { r =>
-        r.copy(
-          address = AddressSet.unify(masked(r.address, offset = id)),
-          fifoId = Some(i+1))
-      } }
-
-      val fifoIdFactory = TLXbar.relabeler()
-      def relabelFifo(managers: Seq[TLManagerParameters]): Seq[TLManagerParameters] = {
-        val fifoIdMapper = fifoIdFactory()
-        managers.map(m => m.copy(fifoId = m.fifoId.map(fifoIdMapper(_))))
-      }
-
-      val newManagerList =
-        relabelFifo(newLocals ++ newRemotes) ++
-        relabelFifo(onlyLocalManagers) ++
-        relabelFifo(onlyRemoteManagers)
-
-      local.copy(
-        managers   = newManagerList,
-        endSinkId  = local.endSinkId + remote.endSinkId,
-        minLatency = local.minLatency min remote.minLatency)
     })
 
   val chip_id = BundleBridgeSink[UInt]()
 
   lazy val module = new LazyModuleImp(this) {
-    require (node.edges.in.size == 1)
-    require (node.edges.out.size == 2)
+    val edgesInSize = node.edges.in.size
+    val edgesOutSize = node.edges.out.size
+    require (edgesOutSize % 2 == 0,
+      s"AddressAdjuster requires an even number of  out edges, but got $edgesOutSize")
+    require (edgesOutSize / 2  == edgesInSize,
+      s"AddressAdjuster requires two out edges for every one in edge, but: out($edgesOutSize}) / 2 != in($edgesInSize)")
 
-    val (parent, parentEdge) = node.in(0)
-    val (remote, remoteEdge) = node.out(0)
-    val (local,  localEdge)  = node.out(1)
+    val (remotes, locals) = node.out.splitAt(edgesOutSize / 2)
+    node.in.zip(remotes).zip(locals).foreach { case (((parent, parentEdge), (remote, remoteEdge)), (local,  localEdge)) => {
 
-    require (localEdge.manager.beatBytes == remoteEdge.manager.beatBytes,
-      s"Port width mismatch ${localEdge.manager.beatBytes} (${localEdge.manager.managers.map(_.name)}) != ${remoteEdge.manager.beatBytes} (${remoteEdge.manager.managers.map(_.name)})")
+      require (localEdge.manager.beatBytes == remoteEdge.manager.beatBytes,
+        s"Port width mismatch ${localEdge.manager.beatBytes} (${localEdge.manager.managers.map(_.name)}) != ${remoteEdge.manager.beatBytes} (${remoteEdge.manager.managers.map(_.name)})")
 
-    // Which address within the mask routes to local devices?
-    val local_address = (bits zip chip_id.bundle.asBools).foldLeft(0.U) {
-      case (acc, (bit, sel)) => acc | Mux(sel, bit.U, 0.U)
-    }
+      // Which address within the mask routes to local devices?
+      val local_address = (bits zip chip_id.bundle.asBools).foldLeft(0.U) {
+        case (acc, (bit, sel)) => acc | Mux(sel, bit.U, 0.U)
+      }
 
-    def containsAddress(region: Seq[AddressSet], addr: UInt): Bool =
-      region.foldLeft(false.B)(_ || _.contains(addr))
+      def containsAddress(region: Seq[AddressSet], addr: UInt): Bool =
+        region.foldLeft(false.B)(_ || _.contains(addr))
 
-    def isAdjustable(addr: UInt) = containsAddress(List(adjustableRegion), addr)
+      def isAdjustable(addr: UInt) = containsAddress(List(adjustableRegion), addr)
 
-    def isLocal(addr: UInt): Bool =
-      ( isAdjustable(addr) && (local_address === (addr & mask.U) || containsAddress(forceLocal, addr))) ||
-      (!isAdjustable(addr) && containsAddress(localEdge.manager.managers.flatMap(_.address), addr))
+      def isLocal(addr: UInt): Bool =
+        ( isAdjustable(addr) && (local_address === (addr & mask.U) || containsAddress(forceLocal, addr))) ||
+        (!isAdjustable(addr) && containsAddress(localEdge.manager.managers.flatMap(_.address), addr))
 
-    // Route A by address, but reroute unsupported operations
-    val a_local = isLocal(parent.a.bits.address)
-    parent.a.ready := Mux(a_local, local.a.ready, remote.a.ready)
-    local .a.valid := parent.a.valid &&  a_local
-    remote.a.valid := parent.a.valid && !a_local
-    local .a.bits  := parent.a.bits
-    remote.a.bits  := parent.a.bits
+      // Route A by address, but reroute unsupported operations
+      val a_local = isLocal(parent.a.bits.address)
+      parent.a.ready := Mux(a_local, local.a.ready, remote.a.ready)
+      local .a.valid := parent.a.valid &&  a_local
+      remote.a.valid := parent.a.valid && !a_local
+      local .a.bits  := parent.a.bits
+      remote.a.bits  := parent.a.bits
 
-    val a_routable  = AddressSet.unify(localEdge.manager.managers.flatMap(_.address))
-    val a_contained = a_routable.map(_.contains(parent.a.bits.address)).reduce(_ || _)
+      val a_routable  = AddressSet.unify(localEdge.manager.managers.flatMap(_.address))
+      val a_contained = a_routable.map(_.contains(parent.a.bits.address)).reduce(_ || _)
 
-    val acquire_ok =
-      Mux(parent.a.bits.param === TLPermissions.toT,
-        localEdge.manager.supportsAcquireTFast(parent.a.bits.address, parent.a.bits.size),
-        localEdge.manager.supportsAcquireBFast(parent.a.bits.address, parent.a.bits.size))
+      val acquire_ok =
+        Mux(parent.a.bits.param === TLPermissions.toT,
+          localEdge.manager.supportsAcquireTFast(parent.a.bits.address, parent.a.bits.size),
+          localEdge.manager.supportsAcquireBFast(parent.a.bits.address, parent.a.bits.size))
 
-    val a_support = VecInit(
-      localEdge.manager.supportsPutFullFast   (parent.a.bits.address, parent.a.bits.size),
-      localEdge.manager.supportsPutPartialFast(parent.a.bits.address, parent.a.bits.size),
-      localEdge.manager.supportsArithmeticFast(parent.a.bits.address, parent.a.bits.size),
-      localEdge.manager.supportsLogicalFast   (parent.a.bits.address, parent.a.bits.size),
-      localEdge.manager.supportsGetFast       (parent.a.bits.address, parent.a.bits.size),
-      localEdge.manager.supportsHintFast      (parent.a.bits.address, parent.a.bits.size),
-      acquire_ok, acquire_ok)(parent.a.bits.opcode)
+      val a_support = VecInit(
+        localEdge.manager.supportsPutFullFast   (parent.a.bits.address, parent.a.bits.size),
+        localEdge.manager.supportsPutPartialFast(parent.a.bits.address, parent.a.bits.size),
+        localEdge.manager.supportsArithmeticFast(parent.a.bits.address, parent.a.bits.size),
+        localEdge.manager.supportsLogicalFast   (parent.a.bits.address, parent.a.bits.size),
+        localEdge.manager.supportsGetFast       (parent.a.bits.address, parent.a.bits.size),
+        localEdge.manager.supportsHintFast      (parent.a.bits.address, parent.a.bits.size),
+        acquire_ok, acquire_ok)(parent.a.bits.opcode)
 
-    val errorSet = localEdge.manager.managers.filter(_.nodePath.last.lazyModule.className == "TLError").head.address.head
-    val a_error = !a_contained || !a_support
-    local.a.bits.address := Cat(
-      Mux(!a_error, parent.a.bits.address, errorSet.base.U) >> log2Ceil(errorSet.alignment),
-      parent.a.bits.address(log2Ceil(errorSet.alignment)-1, 0))
+      val errorSet = localEdge.manager.managers.filter(_.nodePath.last.lazyModule.className == "TLError").head.address.head
+      val a_error = !a_contained || !a_support
+      local.a.bits.address := Cat(
+        Mux(!a_error, parent.a.bits.address, errorSet.base.U) >> log2Ceil(errorSet.alignment),
+        parent.a.bits.address(log2Ceil(errorSet.alignment)-1, 0))
 
-    // Rewrite sink in D
-    val sink_threshold = localEdge.manager.endSinkId.U // more likely to be 0 than remote.endSinkId
-    val local_d  = Wire(chiselTypeOf(parent.d)) // type-cast, because 'sink' width differs
-    local.d.ready := local_d.ready
-    local_d.valid := local.d.valid
-    local_d.bits  := local.d.bits
-    val remote_d = Wire(chiselTypeOf(parent.d))
-    remote.d.ready := remote_d.ready
-    remote_d.valid := remote.d.valid
-    remote_d.bits := remote.d.bits
-    remote_d.bits.sink := remote.d.bits.sink +& sink_threshold
-    TLArbiter.robin(parentEdge, parent.d, local_d, remote_d)
+      // Rewrite sink in D
+      val sink_threshold = localEdge.manager.endSinkId.U // more likely to be 0 than remote.endSinkId
+      val local_d  = Wire(chiselTypeOf(parent.d)) // type-cast, because 'sink' width differs
+      local.d.ready := local_d.ready
+      local_d.valid := local.d.valid
+      local_d.bits  := local.d.bits
+      val remote_d = Wire(chiselTypeOf(parent.d))
+      remote.d.ready := remote_d.ready
+      remote_d.valid := remote.d.valid
+      remote_d.bits := remote.d.bits
+      remote_d.bits.sink := remote.d.bits.sink +& sink_threshold
+      TLArbiter.robin(parentEdge, parent.d, local_d, remote_d)
 
-    if (parentEdge.manager.anySupportAcquireB && parentEdge.client.anySupportProbe) {
-      // Merge probe channels
-      assert (!local .b.valid || ((local .b.bits.address & mask.U) === local_address))
-      assert (!remote.b.valid || ((remote.b.bits.address & mask.U) =/= local_address))
-      TLArbiter.robin(parentEdge, parent.b, local.b, remote.b)
+      if (parentEdge.manager.anySupportAcquireB && parentEdge.client.anySupportProbe) {
+        // Merge probe channels
+        assert (!local .b.valid || ((local .b.bits.address & mask.U) === local_address))
+        assert (!remote.b.valid || ((remote.b.bits.address & mask.U) =/= local_address))
+        TLArbiter.robin(parentEdge, parent.b, local.b, remote.b)
 
-      // Route C by address
-      val c_local = isLocal(parent.c.bits.address)
-      parent.c.ready := Mux(c_local, local.c.ready, remote.c.ready)
-      local .c.valid := parent.c.valid &&  c_local
-      remote.c.valid := parent.c.valid && !c_local
-      local .c.bits  := parent.c.bits
-      remote.c.bits  := parent.c.bits
+        // Route C by address
+        val c_local = isLocal(parent.c.bits.address)
+        parent.c.ready := Mux(c_local, local.c.ready, remote.c.ready)
+        local .c.valid := parent.c.valid &&  c_local
+        remote.c.valid := parent.c.valid && !c_local
+        local .c.bits  := parent.c.bits
+        remote.c.bits  := parent.c.bits
 
-      // Route E by sink
-      val e_local = parent.e.bits.sink < sink_threshold
-      parent.e.ready := Mux(e_local, local.e.ready, remote.e.ready)
-      local .e.valid := parent.e.valid &&  e_local
-      remote.e.valid := parent.e.valid && !e_local
-      local .e.bits  := parent.e.bits
-      remote.e.bits  := parent.e.bits
-      remote.e.bits.sink := parent.e.bits.sink - sink_threshold
-    }
+        // Route E by sink
+        val e_local = parent.e.bits.sink < sink_threshold
+        parent.e.ready := Mux(e_local, local.e.ready, remote.e.ready)
+        local .e.valid := parent.e.valid &&  e_local
+        remote.e.valid := parent.e.valid && !e_local
+        local .e.bits  := parent.e.bits
+        remote.e.bits  := parent.e.bits
+        remote.e.bits.sink := parent.e.bits.sink - sink_threshold
+      }
+    } }
   }
 }

--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -27,8 +27,9 @@ class AddressAdjuster(mask: BigInt, adjustableRegion: AddressSet = AddressSet.ev
 
   // Report whether a region of addresses fully contains a particular manager
   def isDeviceContainedBy(region: Seq[AddressSet], m: TLManagerParameters): Boolean = {
-    val any_in  = region.exists { f => m.address.exists { a => f.overlaps(a) } }
-    val any_out = region.exists { f => m.address.exists { a => !f.contains(a) } }
+    val addr = masked(m.address)
+    val any_in  = region.exists { f => addr.exists { a => f.overlaps(a) } }
+    val any_out = region.exists { f => addr.exists { a => !f.contains(a) } }
     // Ensure device is either completely inside or outside this region
     require (!any_in || !any_out,
       s"Address adjuster cannot have partially contained devices, but for ${m.name}: $region vs ${m.address}")

--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -7,27 +7,6 @@ import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 
-case class TLSplitterNode(
-  clientFn:  TLClientPortParameters  => TLClientPortParameters  = { s => s },
-  managerFn: Seq[TLManagerPortParameters] => Seq[TLManagerPortParameters] = { s => s })(
-  implicit valName: ValName) extends TLCustomNode {
-
-  def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
-    require (iStars == 0, s"$context does not support :*=")
-    if (oStars > 0) {
-      require (2*iKnown >= oKnown, s"$context has $oKnown outputs and $iKnown inputs; cannot assign ${2*iKnown-oKnown} edges to resolve :=*")
-      (0, iKnown - oKnown)
-    } else {
-      require (oKnown == 2*iKnown, s"$context has $oKnown outputs and $iKnown inputs; but 2*$iKnown must be $oKnown")
-      (0, 0)
-    }
-  }
-
-  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] = { p.map(clientFn) ++ p.map(clientFn) }
-
-  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] = { managerFn(p) } // dFn will halve the size of TLManagerPortParameters
-}
-
 // mask=0 -> passthrough
 // adjustableRegion -> only devices in this regions get adjusted
 // forceLocal -> used to ensure special devices (like debug) remain reacheable at chip_id=0 even if in adjustableRegion

--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -16,8 +16,8 @@ case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCus
     val ports = ids.size
     val oStar = if (oStars == 0) 0 else (ports - oKnown) / oStars
     val iStar = if (iStars == 0) 0 else (ports - iKnown) / iStars
-    require (ports == iKnown + iStar*iStars, s"${name} must have ${ports} inputs, but has ${iKnown} + ${iStar}*${iStars}$lazyModule.line}")
-    require (ports == oKnown + oStar*oStars, s"${name} must have ${ports} outputs, but has ${iKnown} + ${iStar}*${iStars}$lazyModule.line}")
+    require (ports == iKnown + iStar*iStars, s"${name} must have ${ports} inputs, but has ${iKnown} + ${iStar}*${iStars} (at ${lazyModule.line})")
+    require (ports == oKnown + oStar*oStars, s"${name} must have ${ports} outputs, but has ${iKnown} + ${iStar}*${iStars} (at ${lazyModule.line})")
     (iStar, oStar)
   }
 

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -59,6 +59,29 @@ case class TLNexusNode(
 abstract class TLCustomNode(implicit valName: ValName)
   extends CustomNode(TLImp)
 
+case class TLSplitterNode(
+  clientFn:  TLClientPortParameters  => TLClientPortParameters  = { s => s },
+  managerFn: Seq[TLManagerPortParameters] => Seq[TLManagerPortParameters] = { s => s })(
+  implicit valName: ValName) extends TLCustomNode {
+
+  def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
+    require (iStars == 0, s"$context does not support :*=")
+    if (oStars > 0) {
+      require (oStars == 2, s"$context can only resolve an input :=* with 2 :=* outputs, but found $oStars")
+      require (oKnown == 0, s"$context can only resolve an input :=* with no := outputs, but found $oKnown")
+      (0, iKnown)
+    } else {
+      require (oKnown == 2*iKnown, s"$context has $oKnown outputs and $iKnown inputs; but 2*$iKnown must be $oKnown")
+      (0, 0)
+    }
+  }
+
+  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] = { p.map(clientFn) ++ p.map(clientFn) }
+
+  // managerFn should halve the size of p by pairwise merging the managers from two downstream paths
+  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] = { managerFn(p) }
+}
+
 // Asynchronous crossings
 
 object TLAsyncImp extends SimpleNodeImp[TLAsyncClientPortParameters, TLAsyncManagerPortParameters, TLAsyncEdgeParameters, TLAsyncBundle]

--- a/src/main/scala/tilelink/RegionReplication.scala
+++ b/src/main/scala/tilelink/RegionReplication.scala
@@ -12,21 +12,28 @@ trait HasRegionReplicatorParams {
   val replicatorMask: BigInt
 }
 
-// Replicate all devices below this adapter to multiple addreses.
+// Replicate all devices below this adapter that are inside replicationRegion to multiple addreses based on mask.
 // If a device was at 0x4000-0x4fff and mask=0x10000, it will now be at 0x04000-0x04fff and 0x14000-0x14fff.
-class RegionReplicator(mask: BigInt = 0)(implicit p: Parameters) extends LazyModule {
+class RegionReplicator(mask: BigInt = 0, region: Option[AddressSet] = Some(AddressSet.everything))(implicit p: Parameters) extends LazyModule {
   def ids = AddressSet.enumerateMask(mask)
 
   val node = TLAdapterNode(
     clientFn  = { cp => cp },
-    managerFn = { mp => mp.copy(managers = mp.managers.map { m => m.copy(
-      address = m.address.flatMap { a => ids.map { id => 
-        AddressSet(a.base | id, a.mask) } })})})
+    managerFn = { mp => mp.copy(managers = mp.managers.map { m =>
+      m.copy(address = m.address.flatMap { a =>
+        if (region.map(_.contains(a)).getOrElse(false)) { ids.map { id => AddressSet(a.base | id, a.mask) } }
+        else { Seq(a) }
+      })
+    })}
+  )
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out <> in
-      out.a.bits.address := ~(~in.a.bits.address | mask.U)
+
+      val addr = in.a.bits.address
+      val contained = region.foldLeft(false.B)(_ || _.contains(addr))
+      out.a.bits.address := Mux(contained, ~(~addr | mask.U), addr)
 
       // We can't support probes; we don't have the required information
       edgeOut.manager.managers.foreach { m =>

--- a/src/main/scala/tilelink/RegionReplication.scala
+++ b/src/main/scala/tilelink/RegionReplication.scala
@@ -44,8 +44,8 @@ class RegionReplicator(mask: BigInt = 0, region: Option[AddressSet] = Some(Addre
 }
 
 object RegionReplicator {
-  def apply(mask: BigInt = 0)(implicit p: Parameters): TLNode = {
-    val replicator = LazyModule(new RegionReplicator(mask))
+  def apply(mask: BigInt = 0, region: Option[AddressSet] = Some(AddressSet.everything))(implicit p: Parameters): TLNode = {
+    val replicator = LazyModule(new RegionReplicator(mask, region))
     replicator.node
   }
 }


### PR DESCRIPTION
This PR makes the AddressAdjuster adapter more flexible in several ways:
 - It now allows the user to specify only a particular address range to be adjusted via the `adjustableRegion` optional parameter. Devices outside of this range can be attached on either the local or the remote side of the downstream ports, and traffic will be routed to them as usual. Only local devices within the `adjustableRegion` have their PMAs edited by the adapter and traffic dynamically toggled between them and the remote side device.
- It now supports flexible cardinality over its edges by defining a new CustomNode type. Specifically, it can now pass through `:=*` flexibility, allowing masters to specify the cardinality.

Also added a missing requirement and limited the scope of some existing requirements to target only the adjustable region.