### PR TITLE
change the blockBytes of l2 broadcast hub to sbus's blockBytes

### DIFF
--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -26,7 +26,7 @@ case class BankedL2Params(
   coherenceManager: BaseSubsystem => (TLInwardNode, TLOutwardNode, Option[IntOutwardNode]) = { subsystem =>
     implicit val p = subsystem.p
     val BroadcastParams(nTrackers, bufferless) = p(BroadcastKey)
-    val bh = LazyModule(new TLBroadcast(subsystem.mbus.blockBytes, nTrackers, bufferless))
+    val bh = LazyModule(new TLBroadcast(subsystem.sbus.blockBytes, nTrackers, bufferless))
     val ww = LazyModule(new TLWidthWidget(subsystem.sbus.beatBytes))
     val ss = TLSourceShrinker(nTrackers)
     ww.node :*= bh.node


### PR DESCRIPTION
Signed-off-by: shuyun <shuyunjia@outlook.com>

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement
The blockBytes of the L2 broadcast hub should be the same as the L1 blockBytes, which is the sbus.blockBytes. Although for now, the `sbus.blockBytes === mbus.blockBytes === L1 CacheBlockBytes`, it is better to declare it right, for possible future L3 implementation.

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
