### PR TITLE
Filter RegressionTestSuite based on coreParams

### DIFF
--- a/src/main/scala/system/Generator.scala
+++ b/src/main/scala/system/Generator.scala
@@ -11,34 +11,36 @@ import scala.collection.mutable.LinkedHashSet
 /** A Generator for platforms containing Rocket Subsystemes */
 object Generator extends GeneratorApp {
 
-  val rv64RegrTestNames = LinkedHashSet(
-        "rv64ud-v-fcvt",
-        "rv64ud-p-fdiv",
-        "rv64ud-v-fadd",
-        "rv64uf-v-fadd",
-        "rv64um-v-mul",
-        "rv64mi-p-breakpoint",
-        "rv64uc-v-rvc",
-        "rv64ud-v-structural",
-        "rv64si-p-wfi",
-        "rv64um-v-divw",
-        "rv64ua-v-lrsc",
-        "rv64ui-v-fence_i",
-        "rv64ud-v-fcvt_w",
-        "rv64uf-v-fmin",
-        "rv64ui-v-sb",
-        "rv64ua-v-amomax_d",
-        "rv64ud-v-move",
-        "rv64ud-v-fclass",
-        "rv64ua-v-amoand_d",
-        "rv64ua-v-amoxor_d",
-        "rv64si-p-sbreak",
-        "rv64ud-v-fmadd",
-        "rv64uf-v-ldst",
-        "rv64um-v-mulh",
-        "rv64si-p-dirty")
+  override def addTestSuites {
+    import DefaultTestSuites._
+    val xlen = params(XLen)
 
-  val rv32RegrTestNames = LinkedHashSet(
+    val regressionTests = LinkedHashSet(
+      "rv64ud-v-fcvt",
+      "rv64ud-p-fdiv",
+      "rv64ud-v-fadd",
+      "rv64uf-v-fadd",
+      "rv64um-v-mul",
+      "rv64mi-p-breakpoint",
+      "rv64uc-v-rvc",
+      "rv64ud-v-structural",
+      "rv64si-p-wfi",
+      "rv64um-v-divw",
+      "rv64ua-v-lrsc",
+      "rv64ui-v-fence_i",
+      "rv64ud-v-fcvt_w",
+      "rv64uf-v-fmin",
+      "rv64ui-v-sb",
+      "rv64ua-v-amomax_d",
+      "rv64ud-v-move",
+      "rv64ud-v-fclass",
+      "rv64ua-v-amoand_d",
+      "rv64ua-v-amoxor_d",
+      "rv64si-p-sbreak",
+      "rv64ud-v-fmadd",
+      "rv64uf-v-ldst",
+      "rv64um-v-mulh",
+      "rv64si-p-dirty",
       "rv32mi-p-ma_addr",
       "rv32mi-p-csr",
       "rv32ui-p-sh",
@@ -47,10 +49,6 @@ object Generator extends GeneratorApp {
       "rv32mi-p-sbreak",
       "rv32ui-p-sll")
 
-
-  override def addTestSuites {
-    import DefaultTestSuites._
-    val xlen = params(XLen)
     // TODO: for now only generate tests for the first core in the first subsystem
     params(RocketTilesKey).headOption.map { tileParams =>
       val coreParams = tileParams.core
@@ -82,7 +80,26 @@ object Generator extends GeneratorApp {
       TestGeneration.addSuites(rvi.map(_("p")))
       TestGeneration.addSuites((if (vm) List("v") else List()).flatMap(env => rvu.map(_(env))))
       TestGeneration.addSuite(benchmarks)
-      TestGeneration.addSuite(new RegressionTestSuite(if (xlen == 64) rv64RegrTestNames else rv32RegrTestNames))
+
+      /* Filter the regression tests based on what the Rocket Chip configuration supports */
+      val extensions = {
+        val fd = coreParams.fpu.map {
+          case cfg if cfg.fLen >= 64 => "fd"
+          case _                     => "f"
+        }
+        val m = coreParams.mulDiv.map{ case _ => "m" }
+        fd ++ m ++ Seq( if (coreParams.useRVE)        Some("e") else Some("i"),
+                        if (coreParams.useAtomics)    Some("a") else None,
+                        if (coreParams.useCompressed) Some("c") else None )
+          .flatten
+          .mkString("")
+      }
+      val re = s"""^rv$xlen[usm][$extensions].+""".r
+      regressionTests.retain{
+        case re() => true
+        case _    => false
+      }
+      TestGeneration.addSuite(new RegressionTestSuite(regressionTests))
     }
   }
 


### PR DESCRIPTION
This fixes a bug where the `regression-tests` target in `freechips.rocketchip.system.$CONFIG.d` would include tests which the core couldn't support and which were not being added via `TestGeneration.addSuites`. E.g., if you build a `WithoutFPU` configuration and try to `make run-regression-tests-fast` make will error out being unable to find the `output/rv64ud-v-fcvt` test. This fixes this by filtering the possible regression tests based on what the core actually supports.

Note: this solution includes a lot of overlap with both [`isaDTS`](https://github.com/chipsalliance/rocket-chip/blob/77b4e6b84c91aa0617c7e54c7c57c8783bcd30b3/src/main/scala/tile/BaseTile.scala#L74) and [`isaString`](https://github.com/chipsalliance/rocket-chip/blob/77b4e6b84c91aa0617c7e54c7c57c8783bcd30b3/src/main/scala/rocket/CSR.scala#L427)

<!-- choose one -->
**Type of change**: bug report | other enhancement

<!-- choose one -->
**Impact**: API modification

This removes public APIs from `GeneratorApp`.

<!-- choose one -->
**Development Phase**: implementation
