### PR TITLE
interrupts: correct ranges for IntSourcePortSimple

### DIFF
--- a/src/main/scala/interrupts/Parameters.scala
+++ b/src/main/scala/interrupts/Parameters.scala
@@ -48,7 +48,8 @@ object IntSourcePortSimple
 {
   def apply(num: Int = 1, ports: Int = 1, sources: Int = 1, resources: Seq[Resource] = Nil) =
     if (num == 0) Nil else
-    Seq.fill(ports)(IntSourcePortParameters(Seq.fill(sources)(IntSourceParameters(range = IntRange(0, num), resources = resources))))
+    Seq.fill(ports)(IntSourcePortParameters(
+      Seq.tabulate(sources)(idx => IntSourceParameters(range = IntRange(idx*num, idx*num+num), resources = resources))))
 }
 
 case class IntSinkPortParameters(sinks: Seq[IntSinkParameters])


### PR DESCRIPTION
Previously `IntSourcePortSimple(num = 1, ports = 1, sources = 2)` would trip over the requirement about overlapping ranges on line 43. This makes the ranges unique for all simple sources within a simple port.

I think this is a more correct fix for the issue reported in #1738.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change 
<!-- choose one -->
**Development Phase**:  implementation
