### PR TITLE
AMBA: HasAHBControlRegMap and HasAPBControlRegMap 

### DIFF
--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -105,3 +105,17 @@ class AHBRegisterRouter[B <: AHBRegBundleBase, M <: LazyModuleImp]
 
   lazy val module = moduleBuilder(bundleBuilder(AHBRegBundleArg()), this)
 }
+
+/** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
+trait HasAHBControlRegMap { this: RegisterRouter[_] =>
+  // Externally, this node should be used to connect the register control port to a bus
+  val controlNode = AHBRegisterNode(
+    address = address.head,
+    concurrency = concurrency,
+    beatBytes = beatBytes,
+    undefZero = undefZero,
+    executable = executable)
+
+  // Internally, this function should be used to populate the control port with registers
+  protected def regmap(mapping: RegField.Map*) { controlNode.regmap(mapping:_*) }
+}

--- a/src/main/scala/amba/apb/RegisterRouter.scala
+++ b/src/main/scala/amba/apb/RegisterRouter.scala
@@ -88,3 +88,17 @@ class APBRegisterRouter[B <: APBRegBundleBase, M <: LazyModuleImp]
 
   lazy val module = moduleBuilder(bundleBuilder(APBRegBundleArg()), this)
 }
+
+/** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
+trait HasAPBControlRegMap { this: RegisterRouter[_] =>
+  // Externally, this node should be used to connect the register control port to a bus
+  val controlNode = APBRegisterNode(
+    address = address.head,
+    concurrency = concurrency,
+    beatBytes = beatBytes,
+    undefZero = undefZero,
+    executable = executable)
+
+  // Internally, this function should be used to populate the control port with registers
+  protected def regmap(mapping: RegField.Map*) { controlNode.regmap(mapping:_*) }
+}


### PR DESCRIPTION
Adds the missing mix-ins for making RegisterRouted devices that speak other AMBA protocols.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation
