### PR TITLE
Respond NtoN for all Nothing states

### DIFF
--- a/src/main/scala/tilelink/Metadata.scala
+++ b/src/main/scala/tilelink/Metadata.scala
@@ -126,7 +126,7 @@ class ClientMetadata extends Bundle {
       Cat(toB, Dirty)   -> (Bool(true),  TtoB, Branch),
       Cat(toB, Trunk)   -> (Bool(false), TtoB, Branch),  // Policy: Don't notify on clean downgrade
       Cat(toB, Branch)  -> (Bool(false), BtoB, Branch),
-      Cat(toB, Nothing) -> (Bool(false), BtoN, Nothing),
+      Cat(toB, Nothing) -> (Bool(false), NtoN, Nothing),
       Cat(toN, Dirty)   -> (Bool(true),  TtoN, Nothing),
       Cat(toN, Trunk)   -> (Bool(false), TtoN, Nothing), // Policy: Don't notify on clean downgrade
       Cat(toN, Branch)  -> (Bool(false), BtoN, Nothing), // Policy: Don't notify on clean downgrade


### PR DESCRIPTION
This aligns how `shrinkWrapper` handles responses for `toB` when in a `Nothing` state to be the same as responses to `toT` and `toN` when in the same state.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation
