### PR TITLE
Build AsyncResetSynchronizerShiftReg from new SynchronizerPrimitive

### DIFF
--- a/src/main/scala/util/AsyncResetReg.scala
+++ b/src/main/scala/util/AsyncResetReg.scala
@@ -4,6 +4,7 @@ package freechips.rocketchip.util
 
 import Chisel._
 import chisel3.util.HasBlackBoxResource
+import chisel3.experimental.RawModule
 import chisel3.core.IntParam
 
 /** This black-boxes an Async Reset
@@ -44,7 +45,25 @@ class AsyncResetReg(resetValue: Int = 0)
     val rst = Bool(INPUT)
   }
 
-  setResource("/vsrc/AsyncResetReg.v")
+  addResource("/vsrc/AsyncResetReg.v")
+}
+
+class SynchronizerPrimitiveReg(resetValue: Int = 0) extends RawModule {
+  val io = IO(new Bundle {
+    val d = Bool(INPUT)
+    val q = Bool(OUTPUT)
+    val en = Bool(INPUT)
+
+    val clk = Clock(INPUT)
+    val rst = Bool(INPUT)
+  })
+
+  val reg = Module(new AsyncResetReg(resetValue))
+  reg.io.d   := io.d
+  reg.io.en  := io.en
+  reg.io.clk := io.clk
+  reg.io.rst := io.rst
+  io.q := reg.io.q
 }
 
 class SimpleRegIO(val w: Int) extends Bundle{

--- a/src/main/scala/util/ShiftReg.scala
+++ b/src/main/scala/util/ShiftReg.scala
@@ -26,13 +26,16 @@ object ShiftRegInit {
   *  rather than buffering.
   *  
   *  The different types vary in their reset behavior:
-  *  AsyncResetShiftReg -- This is identical to the AsyncResetSynchronizerShiftReg, 
-  *      it is just named differently to distinguish its use case.
-  *      This is an async ShiftRegister meant for timing,
-  *      not for synchronization.
-  *  AsyncResetSynchronizerShiftReg -- asynchronously reset to specific value.
-  *  SyncResetSynchronizerShiftReg  -- reset to specific value.
-  *  SynchronizerShiftReg           -- no reset, pipeline only.
+  *  AsyncResetShiftReg             -- Asynchronously reset register array
+  *                                    A W(width) x D(depth) sized array is constructed from D instantiations of a
+  *                                    W-wide register vector. Functionally identical to AsyncResetSyncrhonizerShiftReg,
+  *                                    but only used for timing applications
+  *  SynchronizerShiftReg           -- Synchronously reset register array, a WxD-sized instantation is constructed
+  *                                    similarly to AsyncResetShiftReg. No reset, pipeline only
+  *  AsyncResetSynchronizerShiftReg -- Asynchronously reset register array, constructed from W instantiations of D deep
+  *                                    1-bit-wide shift registers. Functionally identical to AsyncResetShiftReg but only used for
+  *                                    reset sychronization
+  *  SyncResetSynchronizerShiftReg  -- Synchronously reset register array, constructed similarly to AsyncResetSynchronizerShiftReg
   */
 
 abstract class AbstractPipelineReg(w: Int = 1) extends Module {
@@ -166,7 +169,7 @@ class SyncResetSynchronizerShiftReg(w: Int = 1, sync: Int = 3, init: Int = 0) ex
 
   override def desiredName = s"SyncResetSynchronizerShiftReg_w${w}_d${sync}_i${init}"
 
-  val shiftRegs = List.tabluate(w) { i => ShiftRegInit(io.d(w), n = sync, init = init(w), name = Some(s"sync_${i}")) }
+  val shiftRegs = List.tabulate(w) { i => ShiftRegInit[UInt](io.d(w), n = sync, init = init.U, name = Some(s"sync_${i}")) }
   io.q := Cat(shiftRegs.reverse)
 
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
`AsyncSynchronizerShiftReg` synchronizes W-bit wide signals with D stages of synchronizers and, previously, was constructed from D instantiations of a W-bit wide register. This PR changes that construction to instantiate W shift registers, each D stages deep, which is more friendly to industry CDC checking and tool flows

This PR also creates the module out of a new `SynchronizerPrimitive`, distinct from but functionally identical to `AsyncResetReg`, which makes it easier to substitute specific synchronizer cells during implementation
