### PR TITLE
SBA: Fix invalid sbaccess value error case, remove spurious assert

### DIFF
--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -180,7 +180,7 @@ object SystemBusAccessModule
                         (SBCSFieldsReg.sbaccess === 1.U) && (SBCSFieldsReg.sbaccess16  =/= 1.U) ||
                         (SBCSFieldsReg.sbaccess === 2.U) && (SBCSFieldsReg.sbaccess32  =/= 1.U) ||
                         (SBCSFieldsReg.sbaccess === 3.U) && (SBCSFieldsReg.sbaccess64  =/= 1.U) ||
-                        (SBCSFieldsReg.sbaccess === 4.U) && (SBCSFieldsReg.sbaccess128 =/= 1.U)
+                        (SBCSFieldsReg.sbaccess === 4.U) && (SBCSFieldsReg.sbaccess128 =/= 1.U) || (SBCSFieldsReg.sbaccess > 4.U)
 
     val compareAddr = Wire(UInt(32.W)) // Need use written or latched address to detect error case depending on how transaction is initiated
     compareAddr := Mux(SBADDRESSWrEn(0),SBADDRESSWrData(0),SBADDRESSFieldsReg(0))
@@ -355,7 +355,6 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
     tl.c.valid := false.B
     tl.e.valid := false.B
 
-    assert (!tl.d.valid || tl.d.ready, "Debug module not ready to accept TL response") // assert tl.d.valid |-> tl.d.ready
     assert (sbState === Idle.id.U ||
             sbState === SBReadRequest.id.U ||
             sbState === SBWriteRequest.id.U || 

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -253,6 +253,8 @@ object SystemBusAccessModule
     cover(SBCSFieldsReg.sbautoincrement && SBCSFieldsReg.sbbusy,  "SBCS Cover", "Access with autoincrement set")
     cover(!SBCSFieldsReg.sbautoincrement && SBCSFieldsReg.sbbusy, "SBCS Cover", "Access without autoincrement set")
 
+    cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess > 4.U, "SBCS Cover", "Invalid sbaccess value")
+
     (sbcsfields, sbaddrfields, sbdatafields)
   }
 }


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This PR fixes the error handling case where programming the Debug Module's sbaccess register to a value > 4.U would not result in the correct error handling and setting of the sberror register. Also removes a spurious assertion related to the queue size on the SBA unit's TileLink response interface
