### PR TITLE
Change TDO and TDO.driven to async reset

### DIFF
--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -73,8 +73,6 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
 
   val tdo = Wire(Bool())  // 4.4.1c TDI should appear here uninverted after shifting
   val tdo_driven = Wire(Bool())
-  io.jtag.TDO.data := NegEdgeReg(clock, tdo, name = Some("tdoReg"))  // 4.5.1a TDO changes on falling edge of TCK, 6.1.2.1d driver active on first TCK falling edge in ShiftIR and ShiftDR states
-  io.jtag.TDO.driven := NegEdgeReg(clock, tdo_driven, name = Some("tdoeReg"))
 
   //
   // JTAG state machine
@@ -92,6 +90,9 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
     stateMachine.io.tms := io.jtag.TMS
     currState := stateMachine.io.currState
     io.output.state := stateMachine.io.currState
+     // 4.5.1a TDO changes on falling edge of TCK, 6.1.2.1d driver active on first TCK falling edge in ShiftIR and ShiftDR states
+    io.jtag.TDO.data := NegEdgeAsyncResetReg(clock, tdo, name = Some("tdoReg"))
+    io.jtag.TDO.driven := NegEdgeAsyncResetReg(clock, tdo_driven, name = Some("tdoeReg"))
   }
 
   //
@@ -111,12 +112,10 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
   val updateInstruction = Wire(Bool())
 
   val nextActiveInstruction = Wire(UInt(irLength.W))
-  val activeInstruction = NegEdgeReg(clock, nextActiveInstruction, updateInstruction, name = Some("irReg"))   // 7.2.1d active instruction output latches on TCK falling edge
+  val activeInstruction = NegEdgeReg(clock, nextActiveInstruction, initialInstruction.U, updateInstruction, name = Some("irReg"))
+   // 7.2.1d active instruction output latches on TCK falling edge
 
-  when (reset.asBool) {
-    nextActiveInstruction := initialInstruction.U(irLength.W)
-    updateInstruction := true.B
-  } .elsewhen (currState === JtagState.UpdateIR.U) {
+  when (currState === JtagState.UpdateIR.U) {
     nextActiveInstruction := irChain.io.update.bits
     updateInstruction := true.B
   } .otherwise {

--- a/src/main/scala/jtag/Utils.scala
+++ b/src/main/scala/jtag/Utils.scala
@@ -5,6 +5,7 @@ package freechips.rocketchip.jtag
 import Chisel._
 import chisel3.core.{Input, Output}
 import chisel3.experimental.withClock
+import freechips.rocketchip.util.AsyncResetReg
 
 /** Bundle representing a tristate pin.
   */
@@ -17,11 +18,27 @@ class Tristate extends Bundle {
   */
 object NegEdgeReg {
   def apply[T <: Data](clock: Clock, next: T, enable: Bool=true.B, name: Option[String] = None): T = {
-    // TODO pass in initial value as well
     withClock((!clock.asUInt).asClock) {
       val reg = RegEnable(next = next, enable = enable)
       name.foreach{reg.suggestName(_)}
       reg
+    }
+  }
+  def apply[T <: Data](clock: Clock, next: T, init: T, enable: Bool, name: Option[String]): T = {
+    withClock((!clock.asUInt).asClock) {
+      val reg = RegEnable(next = next, init = init, enable = enable)
+      name.foreach{reg.suggestName(_)}
+      reg
+    }
+  }
+}
+
+object NegEdgeAsyncResetReg {
+  def apply[T <: Data](clock: Clock, next: T, init: BigInt=0, enable: Bool=true.B, name: Option[String] = None): T = {
+    withClock((!clock.asUInt).asClock) {
+      val reg = AsyncResetReg(updateData = next.asUInt, resetData = init, enable = enable)
+      name.foreach{reg.suggestName(_)}
+      reg.asTypeOf(next)
     }
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/chipsalliance/rocket-chip/issues/2165

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Changed TDO and TDO.driven drivers to asynchronous reset based on jtag_reset input.