### PR TITLE
Disallow null values in LogicalTree.

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
@@ -25,6 +25,8 @@ object LogicalModuleTree {
   private val tree: mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]] = mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]]()
 
   def add(parent: LogicalTreeNode, child: => LogicalTreeNode): Unit = {
+    require(parent != null, "Cannot add null parent to the LogicalModuleTree")
+    require(child != null, "Cannot add null child to the LogicalModuleTree")
     val treeOpt = tree.get(parent)
     val treeNode = treeOpt.map{
       children => child +: children


### PR DESCRIPTION
**Related issue**:

**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
[One weakness in Scala's type system](https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html) can allow `null`s to sneak in if you access an uninitialized field. This PR adds some guards to the `LogicalModuleTree` to detect and abort if a `null` is passed in.