### PR TITLE
Diplomatic IO Creation from Nodes

### DIFF
--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -22,24 +22,14 @@ case class BundleBridgeSink[T <: Data]()(implicit valName: ValName) extends Sink
 {
   def bundle: T = in(0)._1
 
-  def makeIO()(implicit valName: ValName): T = {
-    val io = IO(bundle.cloneType)
-    io.suggestName(valName.name)
-    io <> bundle
-    io
-  }
+  def makeIO()(implicit valName: ValName): T = makeIOs()(valName).head
 }
 
 case class BundleBridgeSource[T <: Data](gen: () => T)(implicit valName: ValName) extends SourceNode(new BundleBridgeImp[T])(Seq(BundleBridgeParams(gen)))
 {
   def bundle: T = out(0)._1
 
-  def makeIO()(implicit valName: ValName): T = {
-    val io = IO(Flipped(bundle.cloneType))
-    io.suggestName(valName.name)
-    bundle <> io
-    io
-  }
+  def makeIO()(implicit valName: ValName): T = makeIOs()(valName).head
 
   private var doneSink = false
   def makeSink()(implicit p: Parameters) = {

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -308,6 +308,10 @@ class TLEdge(
 
     (flight, next_flight)
   }
+
+  def prettySourceMapping(context: String): String = {
+    s"TL-Source mapping for $context:\n${(new TLSourceIdMap(client)).pretty}\n"
+  }
 }
 
 class TLEdgeOut(

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -20,6 +20,14 @@ abstract class TLMonitorBase(args: TLMonitorArgs) extends Module
   legalize(io.in, args.edge, reset)
 }
 
+object TLMonitor {
+  def apply(enable: Boolean, node: TLNode)(implicit p: Parameters): TLNode = {
+    if (enable) {
+      EnableMonitors { implicit p => node := TLEphemeralNode()(ValName("monitor")) }
+    } else { node }
+  }
+}
+
 class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
 {
   def extra = {

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -487,3 +487,25 @@ case class TLBufferParams(
   def copyOut(x: BufferParams) = this.copy(a = x, c = x, e = x)
   def copyInOut(x: BufferParams) = this.copyIn(x).copyOut(x)
 }
+
+/** Pretty printing of TL source id maps */
+class TLSourceIdMap(tl: TLClientPortParameters) {
+  private val tlDigits = String.valueOf(tl.endSourceId-1).length()
+  private val fmt = s"\t[%${tlDigits}d, %${tlDigits}d) %s%s%s"
+  private val sorted = tl.clients.sortWith(TLToAXI4.sortByType)
+
+  val mapping: Seq[TLSourceIdMapEntry] = sorted.map { case c =>
+    TLSourceIdMapEntry(c.sourceId, c.name, c.supportsProbe, c.requestFifo)
+  }
+
+  def pretty: String = mapping.map(_.pretty(fmt)).mkString(",\n")
+}
+
+case class TLSourceIdMapEntry(tlId: IdRange, name: String, isCache: Boolean, requestFifo: Boolean) {
+  def pretty(fmt: String): String = fmt.format(
+    tlId.start,
+    tlId.end,
+    s""""$name"""",
+    if (isCache) " [CACHE]" else "",
+    if (requestFifo) " [FIFO]" else "")
+}


### PR DESCRIPTION
This encapsulates the popular pattern of making IOs out of the bundles associated with SourceNodes or SinkNodes via cloning them into `HeterogeneousBags`. It is a generalization of the behavior of `makeIO()` on BundleBridge sources and sinks, and as such I named it `makeIOs()` and reimplemented the bridge methods using it. Should be totally backward compatible.

I also threw in some TL-specific utilities for printing out port metadata or monitoring port behavior.

Follow-on PR will convert the ports to use this capability.

**Related Issues**: Someone asked for this but I'm having trouble finding the issue. 

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**:API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Diplomacy: Source and Sink Nodes have `makeIOs` method