### PR TITLE
fuzzer: update parameter description

### DIFF
--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -74,7 +74,7 @@ object LFSRNoiseMaker {
 /** TLFuzzer drives test traffic over TL2 links. It generates a sequence of randomized
   * requests, and issues legal ones into the DUT. TODO: Currently the fuzzer only generates
   * memory operations, not permissions transfers.
-  * @param nOperations is the total number of operations that the fuzzer must complete for the test to pass
+  * @param nOperations is the total number of operations that the fuzzer must complete for the test to pass (0 => run forever)
   * @param inFlight is the number of operations that can be in-flight to the DUT concurrently
   * @param noiseMaker is a function that supplies a random UInt of a given width every time inc is true
   */


### PR DESCRIPTION
Specifying `nOperations = 0` means that the fuzzer should run forever.

This means some other entity must be responsible for terminating the simulation.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**:
Closes #2117
