### PR TITLE
Modernize Port Creation

### DIFF
--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -34,8 +34,7 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
   override lazy val module = new GroundTestSubsystemModuleImp(this)
 }
 
-class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)
-    with CanHaveMasterAXI4MemPortModuleImp {
+class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer) {
   val success = IO(Bool(OUTPUT))
 
   outer.tiles.zipWithIndex.map { case(t, i) => t.module.constants.hartid := UInt(i) }

--- a/src/main/scala/groundtest/TestHarness.scala
+++ b/src/main/scala/groundtest/TestHarness.scala
@@ -3,13 +3,14 @@
 package freechips.rocketchip.groundtest
 
 import Chisel._
-
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.LazyModule
+import freechips.rocketchip.system.SimAXIMem
 
 class TestHarness(implicit p: Parameters) extends Module {
   val io = new Bundle { val success = Bool(OUTPUT) }
-  val dut = Module(LazyModule(new GroundTestSubsystem).module)
+  val ldut = LazyModule(new GroundTestSubsystem)
+  val dut = Module(ldut.module)
   io.success := dut.success
-  dut.connectSimAXIMem()
+  SimAXIMem.connectMem(ldut)
 }

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -69,7 +69,6 @@ trait CanHaveMasterAXI4MMIOPort { this: BaseSubsystem =>
   private val mmioPortParamsOpt = p(ExtBus)
   private val portName = "mmio_port_axi4"
   private val device = new SimpleBus(portName.kebab, Nil)
-  private val idBits = mmioPortParamsOpt.map(_.idBits).getOrElse(1)
 
   val mmioAXI4Node = AXI4SlaveNode(
     mmioPortParamsOpt.map(params =>

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -23,8 +23,5 @@ class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
 class ExampleRocketSystemModuleImp[+L <: ExampleRocketSystem](_outer: L) extends RocketSubsystemModuleImp(_outer)
     with HasRTCModuleImp
     with HasExtInterruptsModuleImp
-    with CanHaveMasterAXI4MemPortModuleImp
-    with CanHaveMasterAXI4MMIOPortModuleImp
-    with CanHaveSlaveAXI4PortModuleImp
     with HasPeripheryBootROMModuleImp
     with DontTouch

--- a/src/main/scala/system/SimAXIMem.scala
+++ b/src/main/scala/system/SimAXIMem.scala
@@ -1,0 +1,35 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.system // TODO this should really be in a testharness package
+
+import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.subsystem.{CanHaveMasterAXI4MMIOPort, CanHaveMasterAXI4MemPort, ExtMem}
+
+/** Memory with AXI port for use in elaboratable test harnesses. */
+class SimAXIMem(edge: AXI4EdgeParameters, size: BigInt)(implicit p: Parameters) extends SimpleLazyModule {
+  val node = AXI4MasterNode(List(edge.master))
+  val srams = AddressSet.misaligned(0, size).map{ aSet => LazyModule(new AXI4RAM(aSet, beatBytes = edge.bundle.dataBits/8))}
+  val xbar = AXI4Xbar()
+  srams.foreach{ s => s.node := AXI4Buffer() := AXI4Fragmenter() := xbar }
+  xbar := node
+  val io_axi4 = InModuleBody { node.makeIOs() }
+}
+
+object SimAXIMem {
+  def connectMMIO(dut: CanHaveMasterAXI4MMIOPort)(implicit p: Parameters): Unit = {
+    dut.mmio_axi4.zip(dut.mmioAXI4Node.in).foreach { case (io, (_, edge)) =>
+      // test harness size capped to 4KB (ignoring p(ExtMem).get.master.size)
+      val mmio_mem = LazyModule(new SimAXIMem(edge, size = 4096))
+      mmio_mem.io_axi4.head <> io
+    }
+  }
+
+  def connectMem(dut: CanHaveMasterAXI4MemPort)(implicit p: Parameters): Unit = {
+    dut.mem_axi4.zip(dut.memAXI4Node.in).foreach { case (io, (_, edge)) =>
+      val mem = LazyModule(new SimAXIMem(edge, size = p(ExtMem).get.master.size))
+      mem.io_axi4.head <> io
+    }
+  }
+}

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -13,15 +13,16 @@ class TestHarness()(implicit p: Parameters) extends Module {
     val success = Bool(OUTPUT)
   }
 
-  val dut = Module(LazyModule(new ExampleRocketSystem).module)
+  val ldut = LazyModule(new ExampleRocketSystem)
+  val dut = Module(ldut.module)
 
   // Allow the debug ndreset to reset the dut, but not until the initial reset has completed
   dut.reset := reset | dut.debug.map { debug => AsyncResetReg(debug.ndreset) }.getOrElse(false.B)
 
   dut.dontTouchPorts()
   dut.tieOffInterrupts()
-  dut.connectSimAXIMem()
-  dut.connectSimAXIMMIO()
-  dut.l2_frontend_bus_axi4.foreach(_.tieoff)
+  SimAXIMem.connectMem(ldut)
+  SimAXIMem.connectMMIO(ldut)
+  ldut.l2_frontend_bus_axi4.foreach(_.tieoff)
   Debug.connectDebug(dut.debug, dut.psd, clock, reset, io.success)
 }


### PR DESCRIPTION
This builds on #2176 by using the new `makeIOs` methods to create ports in the subsystem. This 
 new methods allows the two traits used previously to be collapsed into one, which then results in some API tweaks  to how collateral is attached in the testharness.

The following traits are removed:
- `CanHaveMasterAXI4MemPortModuleImp`
- `CanHaveMasterAXI4MMIOPortModuleImp`
- `CanHaveSlaveAXI4PortModuleImp`
- `CanHaveMasterTLMMIOPortModuleImp`
- `CanHaveSlaveTLPortModuleImp`

The following APIs are changed:
- `class SimAXIMem` is moved to the `system` package
- `object SimAXIMem` has methods `connectMMIO` and `connectMem` which are used in the test harnesses by passing them the dut instead of calling them as methods of the dut.

The following soon-to-be-deprecated APIs are avoided:
- `TLBusWrapper.coupleTo` and `TLBusWrapper.coupleFrom` are used instead of the specific child class coupling methods `MemoryBus.toDRAMController` `SystemBus.toFixedWidthPort` `FrontBus.fromPort`

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:   implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
