### PR TITLE
config: WithDefaultMMIOPort should use SystemBusKey not MemoryBusKey

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -356,7 +356,7 @@ class WithDefaultMMIOPort extends Config((site, here, up) => {
   case ExtBus => Some(MasterPortParams(
                       base = x"6000_0000",
                       size = x"2000_0000",
-                      beatBytes = site(MemoryBusKey).beatBytes,
+                      beatBytes = site(SystemBusKey).beatBytes,
                       idBits = 4))
 })
 


### PR DESCRIPTION
Per #2185 the example configuration of WithDefaultMMIOPort is not very sensible. The example MMIO port is attached to the SystemBus, not the MemoryBus, and should be configured accordingly.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**:  implementation
