### PR TITLE
BaseSubsystem: Move attachment function into trait

### DIFF
--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -47,8 +47,28 @@ case object FBUS extends BaseSubsystemBusAttachment
 case object MBUS extends BaseSubsystemBusAttachment
 case object CBUS extends BaseSubsystemBusAttachment
 
+trait HasBusAttachmentFunction {
+  val sbus: SystemBus
+  val pbus: PeripheryBus
+  val fbus: FrontBus
+  val mbus: MemoryBus
+  val cbus: PeripheryBus
+
+  type BusAttachmentFunction = PartialFunction[BaseSubsystemBusAttachment, TLBusWrapper]
+  def baseBusAttachmentFunc: BusAttachmentFunction = {
+    case SBUS => sbus
+    case PBUS => pbus
+    case FBUS => fbus
+    case MBUS => mbus
+    case CBUS => cbus
+  }
+  def attach(where: BaseSubsystemBusAttachment): TLBusWrapper = baseBusAttachmentFunc(where)
+}
+
 /** Base Subsystem class with no peripheral devices or ports added */
-abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with HasLogicalTreeNode {
+abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem
+  with HasBusAttachmentFunction with HasLogicalTreeNode {
+
   override val module: BaseSubsystemModuleImp[BaseSubsystem]
 
   // These are wrappers around the standard buses available in all subsytems, where
@@ -59,16 +79,6 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
   val fbus = LazyModule(new FrontBus(p(FrontBusKey)))
   val mbus = LazyModule(new MemoryBus(p(MemoryBusKey)))
   val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
-
-  type BusAttachmentFunction = PartialFunction[BaseSubsystemBusAttachment, TLBusWrapper]
-  protected def baseBusAttachmentFunc: BusAttachmentFunction = {
-    case SBUS => sbus
-    case PBUS => pbus
-    case FBUS => fbus
-    case MBUS => mbus
-    case CBUS => cbus
-  }
-  protected def attach(where: BaseSubsystemBusAttachment): TLBusWrapper = baseBusAttachmentFunc(where)
 
   // Collect information for use in DTS
   lazy val topManagers = sbus.unifyManagers


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Moving `baseBusAttachmentFunction` member of `BaseSubsystem` into separate trait so it can be mixed-into and leveraged by other layers of design hierarchy if needed
