### PR TITLE
diplomacy: SourceNode.makeIOs uses ValName.name

### DIFF
--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -546,7 +546,7 @@ class SourceNode[D, U, EO, EI, B <: Data](imp: NodeImp[D, U, EO, EI, B])(po: Seq
   def makeIOs()(implicit valName: ValName): HeterogeneousBag[B] = {
     val bundles = this.out.map(_._1)
     val ios = IO(Flipped(new HeterogeneousBag(bundles.map(_.cloneType))))
-    ios.suggestName(valName.toString)
+    ios.suggestName(valName.name)
     bundles.zip(ios).foreach { case (bundle, io) => bundle <> io }
     ios
   }


### PR DESCRIPTION
Turns out `ValName.toString` prefixed the name with the string "ValName". `ValName.name` is what I wanted and even what I used in the SinkNode already.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Closes #2200

<!-- choose one -->
**Type of change**: bug fix
<!-- choose one -->
**Impact**: bug fix

<!-- choose one -->
**Development Phase**: implementation
