### PR TITLE
Convert DM and JTAG to chisel3

### DIFF
--- a/src/main/scala/devices/debug/APB.scala
+++ b/src/main/scala/devices/debug/APB.scala
@@ -1,7 +1,7 @@
 // See LICENSE.SiFive for license details.
 
 package freechips.rocketchip.devices.debug
-import Chisel._
+import chisel3._
 import chisel3.experimental._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/debug/Custom.scala
+++ b/src/main/scala/devices/debug/Custom.scala
@@ -2,8 +2,8 @@
 
 package freechips.rocketchip.devices.debug
 
-import Chisel._
-import chisel3.core.{Input, Output}
+import chisel3._
+import chisel3.util._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp, NexusNode, RenderedEdge,
   SimpleNodeImp, SinkNode, SourceNode, ValName}

--- a/src/main/scala/devices/debug/DMI.scala
+++ b/src/main/scala/devices/debug/DMI.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.devices.debug
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
@@ -59,7 +60,7 @@ class DMIResp( ) extends Bundle {
   */
 class DMIIO(implicit val p: Parameters) extends ParameterizedBundle()(p) {
   val req = new  DecoupledIO(new DMIReq(p(DebugModuleKey).get.nDMIAddrSize))
-  val resp = new DecoupledIO(new DMIResp).flip()
+  val resp = Flipped(new DecoupledIO(new DMIResp))
 }
 
 /** This includes the clock and reset as these are passed through the
@@ -69,8 +70,8 @@ class DMIIO(implicit val p: Parameters) extends ParameterizedBundle()(p) {
 
 class ClockedDMIIO(implicit val p: Parameters) extends ParameterizedBundle()(p){
   val dmi      = new DMIIO()(p)
-  val dmiClock = Clock(OUTPUT)
-  val dmiReset = Bool(OUTPUT)
+  val dmiClock = Output(Clock())
+  val dmiReset = Output(Bool())
 }
 
 /** Convert DMI to TL. Avoids using special DMI synchronizers and register accesses
@@ -87,13 +88,13 @@ class DMIToTL(implicit p: Parameters) extends LazyModule {
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val dmi = new DMIIO()(p).flip()
+      val dmi = Flipped(new DMIIO()(p))
     })
 
     val (tl, edge) = node.out(0)
 
-    val src  = Wire(init = 0.U)
-    val addr = Wire(init = (io.dmi.req.bits.addr << 2))
+    val src  = WireInit(0.U)
+    val addr = WireInit(io.dmi.req.bits.addr << 2)
     val size = (log2Ceil(DMIConsts.dmiDataSize / 8)).U
 
     val (_,  gbits) = edge.Get(src, addr, size)

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -3,8 +3,8 @@
 package freechips.rocketchip.devices.debug
 
 
-import Chisel._
-import chisel3.experimental._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
@@ -203,9 +203,9 @@ class DebugInternalBundle (val nComponents: Int)(implicit val p: Parameters) ext
  */
 
 class DebugCtrlBundle (nComponents: Int)(implicit val p: Parameters) extends ParameterizedBundle()(p) {
-  val debugUnavail    = Vec(nComponents, Bool()).asInput
-  val ndreset         = Bool(OUTPUT)
-  val dmactive        = Bool(OUTPUT)
+  val debugUnavail    = Input(Vec(nComponents, Bool()))
+  val ndreset         = Output(Bool())
+  val dmactive        = Output(Bool())
 }
 
 // *****************************************
@@ -240,10 +240,10 @@ class DebugCtrlBundle (nComponents: Int)(implicit val p: Parameters) extends Par
 // Local reg mapper function : Notify when written, but give the value as well.  
 object WNotifyWire {
   def apply(n: Int, value: UInt, set: Bool, name: String, desc: String) : RegField = {
-    RegField(n, UInt(0), RegWriteFn((valid, data) => {
+    RegField(n, 0.U, RegWriteFn((valid, data) => {
       set := valid
       value := data
-      Bool(true)
+      true.B
     }), Some(RegFieldDesc(name = name, desc = desc,
       access = RegFieldAccessType.W)))
   }
@@ -253,11 +253,11 @@ object WNotifyWire {
 object RWNotify {
     def apply (n: Int, rVal: UInt, wVal: UInt, rNotify: Bool, wNotify: Bool, desc: Option[RegFieldDesc] = None): RegField = {
       RegField(n,
-        RegReadFn ((ready)       => {rNotify := ready ; (Bool(true), rVal)}),
+        RegReadFn ((ready)       => {rNotify := ready ; (true.B, rVal)}),
         RegWriteFn((valid, data) => {
           wNotify := valid
           when (valid) {wVal := data}
-          Bool(true)
+          true.B
         }
         ), desc)
     }
@@ -308,7 +308,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     val io = IO(new Bundle {
       val ctrl = (new DebugCtrlBundle(nComponents))
       val innerCtrl = new DecoupledIO(new DebugInternalBundle(nComponents))
-      val hgDebugInt = Vec(nComponents, Bool()).asInput
+      val hgDebugInt = Input(Vec(nComponents, Bool()))
       val hartResetReq = cfg.hasHartResets.option(Output(Vec(nComponents, Bool())))
       val dmAuthenticated = cfg.hasAuthentication.option(Input(Bool()))
     })
@@ -321,27 +321,27 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     //               harts while the rest of the system is in reset. It doesn't really allow any other
     //               register accesses, which will keep returning 'busy' to the debugger interface.
 
-    val DMCONTROLReset = Wire(init = (new DMCONTROLFields().fromBits(0.U)))
-    val DMCONTROLNxt = Wire(init = new DMCONTROLFields().fromBits(0.U))
+    val DMCONTROLReset = WireInit(0.U.asTypeOf(new DMCONTROLFields()))
+    val DMCONTROLNxt = WireInit(0.U.asTypeOf(new DMCONTROLFields()))
 
-    val DMCONTROLReg = Wire(init = new DMCONTROLFields().fromBits(AsyncResetReg(updateData = DMCONTROLNxt.asUInt,
+    val DMCONTROLReg = WireInit(AsyncResetReg(updateData = DMCONTROLNxt.asUInt,
       resetData = BigInt(0),
       enable = true.B,
       name = "DMCONTROL"
-    )))
+    ).asTypeOf(new DMCONTROLFields()))
 
     val hartsel_mask = if (nComponents > 1) ((1 << p(MaxHartIdBits)) - 1).U else 0.U
-    val DMCONTROLWrData = Wire(init = new DMCONTROLFields().fromBits(0.U))
-    val dmactiveWrEn        = Wire(init = false.B)
-    val ndmresetWrEn        = Wire(init = false.B)
-    val clrresethaltreqWrEn = Wire(init = false.B)
-    val setresethaltreqWrEn = Wire(init = false.B)
-    val hartselloWrEn       = Wire(init = false.B)
-    val haselWrEn           = Wire(init = false.B)
-    val ackhaveresetWrEn    = Wire(init = false.B)
-    val hartresetWrEn       = Wire(init = false.B)
-    val resumereqWrEn       = Wire(init = false.B)
-    val haltreqWrEn         = Wire(init = false.B)
+    val DMCONTROLWrData = WireInit(0.U.asTypeOf(new DMCONTROLFields()))
+    val dmactiveWrEn        = WireInit(false.B)
+    val ndmresetWrEn        = WireInit(false.B)
+    val clrresethaltreqWrEn = WireInit(false.B)
+    val setresethaltreqWrEn = WireInit(false.B)
+    val hartselloWrEn       = WireInit(false.B)
+    val haselWrEn           = WireInit(false.B)
+    val ackhaveresetWrEn    = WireInit(false.B)
+    val hartresetWrEn       = WireInit(false.B)
+    val resumereqWrEn       = WireInit(false.B)
+    val haltreqWrEn         = WireInit(false.B)
 
     val dmactive = DMCONTROLReg.dmactive
 
@@ -366,32 +366,32 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     //  HAMASK is 1 bit per component
     //  HAWINDOWSEL selects a 32-bit slice of HAMASK to be visible for read/write in HAWINDOW
     //--------------------------------------------------------------
-    val hamask = Wire(init = Vec.fill(nComponents){false.B})
+    val hamask = WireInit(VecInit(Seq.fill(nComponents) {false.B} ))
     def haWindowSize = 32
 
       // The following need to be declared even if supportHartArray is false due to reference
       // at compile time by dmiNode.regmap
-    val HAWINDOWSELWrData = Wire(init = (new HAWINDOWSELFields()).fromBits(0.U))
-    val HAWINDOWSELWrEn   = Wire(init = false.B)
+    val HAWINDOWSELWrData = WireInit(0.U.asTypeOf(new HAWINDOWSELFields()))
+    val HAWINDOWSELWrEn   = WireInit(false.B)
 
-    val HAWINDOWRdData = Wire(init = (new HAWINDOWFields()).fromBits(0.U))
-    val HAWINDOWWrData = Wire(init = (new HAWINDOWFields()).fromBits(0.U))
-    val HAWINDOWWrEn   = Wire(init = false.B)
+    val HAWINDOWRdData = WireInit(0.U.asTypeOf(new HAWINDOWFields()))
+    val HAWINDOWWrData = WireInit(0.U.asTypeOf(new HAWINDOWFields()))
+    val HAWINDOWWrEn   = WireInit(false.B)
 
     def hartSelected(hart: Int): Bool = {
       ((io.innerCtrl.bits.hartsel === hart.U) ||
         (if (supportHartArray) io.innerCtrl.bits.hasel && io.innerCtrl.bits.hamask(hart) else false.B))
     }
 
-    val HAWINDOWSELNxt = Wire(init = (new HAWINDOWSELFields().fromBits(0.U)))
-    val HAWINDOWSELReg = Wire(init = new HAWINDOWSELFields().fromBits(AsyncResetReg(updateData = HAWINDOWSELNxt.asUInt,
+    val HAWINDOWSELNxt = WireInit(0.U.asTypeOf(new HAWINDOWSELFields()))
+    val HAWINDOWSELReg = WireInit(AsyncResetReg(updateData = HAWINDOWSELNxt.asUInt,
       resetData = 0,
       enable = true.B,
       name = "HAWINDOWSELReg"
-    )))
+    ).asTypeOf(new HAWINDOWSELFields()))
 
     if (supportHartArray) {
-      val HAWINDOWSELReset = Wire(init = (new HAWINDOWSELFields().fromBits(0.U)))
+      val HAWINDOWSELReset = WireInit(0.U.asTypeOf(new HAWINDOWSELFields()))
 
       HAWINDOWSELNxt := HAWINDOWSELReg
       when (~dmactive || ~dmAuthenticated) {
@@ -412,9 +412,9 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
       for (ii <- 0 until numHAMASKSlices) {
         val sliceMask = if (nComponents > ((ii*haWindowSize) + haWindowSize-1)) (BigInt(1) << haWindowSize) - 1  // All harts in this slice exist
                         else (BigInt(1)<<(nComponents - (ii*haWindowSize))) - 1         // Partial last slice
-        val HAMASKRst = Wire(init = (new HAWINDOWFields().fromBits(0.U)))
-        val HAMASKNxt = Wire(init = (new HAWINDOWFields().fromBits(0.U)))
-        val HAMASKReg = Wire(init = Vec(AsyncResetReg(updateData = HAMASKNxt.asUInt,
+        val HAMASKRst = WireInit(0.U.asTypeOf(new HAWINDOWFields()))
+        val HAMASKNxt = WireInit(0.U.asTypeOf(new HAWINDOWFields()))
+        val HAMASKReg = WireInit(VecInit(AsyncResetReg(updateData = HAMASKNxt.asUInt,
           resetData = 0,
           enable = true.B,
           name = s"HAMASKReg${ii}")))
@@ -457,7 +457,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     //--------------------------------------------------------------
     val hrmask    = Wire(Vec(nComponents, Bool()))
     val hrmaskNxt = Wire(Vec(nComponents, Bool()))
-    val hrmaskReg = Wire(init = Vec(AsyncResetReg(updateData = hrmaskNxt.asUInt,
+    val hrmaskReg = WireInit(VecInit(AsyncResetReg(updateData = hrmaskNxt.asUInt,
       resetData = 0,
       enable = true.B,
       name = "hrmaskReg").asBools))
@@ -531,8 +531,8 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     // Interrupt Registers
     //--------------------------------------------------------------
 
-    val debugIntNxt = Wire(init = Vec.fill(nComponents){false.B})
-    val debugIntRegs = Wire(init = Vec(AsyncResetReg(updateData = debugIntNxt.asUInt,
+    val debugIntNxt = WireInit(VecInit(Seq.fill(nComponents) {false.B} ))
+    val debugIntRegs = WireInit(VecInit(AsyncResetReg(updateData = debugIntNxt.asUInt,
       resetData = 0,
       enable = true.B,
       name = "debugInterrupts").asBools))
@@ -579,7 +579,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
 
     if (cfg.hasHartResets) {
       val hartResetNxt = Wire(Vec(nComponents, Bool()))
-      val hartResetReg = Wire(init = Vec(AsyncResetReg(updateData = hartResetNxt.asUInt,
+      val hartResetReg = WireInit(VecInit(AsyncResetReg(updateData = hartResetNxt.asUInt,
         resetData = 0,
         enable = true.B,
         name = "hartResetReg").asBools))
@@ -627,11 +627,11 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
     val nComponents = dmOuter.intnode.edges.out.size
 
     val io = IO(new Bundle {
-      val dmi   = (!p(ExportDebug).apb).option(new DMIIO()(p).flip())
+      val dmi   = (!p(ExportDebug).apb).option(Flipped(new DMIIO()(p)))
       // Optional APB Interface is fully diplomatic so is not listed here.
       val ctrl = new DebugCtrlBundle(nComponents)
       val innerCtrl = new AsyncBundle(new DebugInternalBundle(nComponents), AsyncQueueParams.singleton())
-      val hgDebugInt = Vec(nComponents, Bool()).asInput
+      val hgDebugInt = Input(Vec(nComponents, Bool()))
       val hartResetReq = p(DebugModuleKey).get.hasHartResets.option(Output(Vec(nComponents, Bool())))
       val dmAuthenticated = p(DebugModuleKey).get.hasAuthentication.option(Input(Bool()))
     })
@@ -639,7 +639,7 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
     dmi2tlOpt.foreach { _.module.io.dmi <> io.dmi.get }
 
     io.ctrl <> dmOuter.module.io.ctrl
-    io.innerCtrl := ToAsyncBundle(dmOuter.module.io.innerCtrl, AsyncQueueParams.singleton())
+    io.innerCtrl <> ToAsyncBundle(dmOuter.module.io.innerCtrl, AsyncQueueParams.singleton())
     dmOuter.module.io.hgDebugInt := io.hgDebugInt
     io.hartResetReq.foreach { x => dmOuter.module.io.hartResetReq.foreach {y => x := y}}
     io.dmAuthenticated.foreach { x => dmOuter.module.io.dmAuthenticated.foreach { y => y := x}}
@@ -688,15 +688,15 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       else 0  // no halt groups possible if single hart with no external triggers
 
     val hartSelFuncs = if (getNComponents() > 1) p(DebugModuleHartSelKey) else DebugModuleHartSelFuncs(
-      hartIdToHartSel = (x) => UInt(0),
+      hartIdToHartSel = (x) => 0.U,
       hartSelToHartId = (x) => x
     )
 
     val io = IO(new Bundle {
-      val dmactive = Bool(INPUT)
-      val innerCtrl = (new DecoupledIO(new DebugInternalBundle(nComponents))).flip
-      val debugUnavail = Vec(nComponents, Bool()).asInput
-      val hgDebugInt = Vec(nComponents, Bool()).asOutput
+      val dmactive = Input(Bool())
+      val innerCtrl = Flipped(new DecoupledIO(new DebugInternalBundle(nComponents)))
+      val debugUnavail = Input(Vec(nComponents, Bool()))
+      val hgDebugInt = Output(Vec(nComponents, Bool()))
       val extTrigger = (nExtTriggers > 0).option(new DebugExtTriggerIO())
       val hartReset  = cfg.hasHartResets.option(Input(Vec(nComponents, Bool())))
       val auth = cfg.hasAuthentication.option(new DebugAuthenticationIO())
@@ -738,13 +738,13 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     val hartExceptionWrEn    = Wire(Bool())
     val hartExceptionId      = Wire(UInt(sbIdWidth.W))
 
-    val dmiProgramBufferRdEn = Wire(init = Vec.fill(cfg.nProgramBufferWords * 4){false.B})
-    val dmiProgramBufferAccessLegal = Wire(init = false.B)
-    val dmiProgramBufferWrEnMaybe = Wire(init = Vec.fill(cfg.nProgramBufferWords * 4){false.B})
+    val dmiProgramBufferRdEn = WireInit(VecInit(Seq.fill(cfg.nProgramBufferWords * 4) {false.B} ))
+    val dmiProgramBufferAccessLegal = WireInit(false.B)
+    val dmiProgramBufferWrEnMaybe = WireInit(VecInit(Seq.fill(cfg.nProgramBufferWords * 4) {false.B} ))
 
-    val dmiAbstractDataRdEn = Wire(init = Vec.fill(cfg.nAbstractDataWords * 4){false.B})
-    val dmiAbstractDataAccessLegal = Wire (init = false.B)
-    val dmiAbstractDataWrEnMaybe = Wire(init = Vec.fill(cfg.nAbstractDataWords * 4){false.B})
+    val dmiAbstractDataRdEn = WireInit(VecInit(Seq.fill(cfg.nAbstractDataWords * 4) {false.B} ))
+    val dmiAbstractDataAccessLegal = WireInit(false.B)
+    val dmiAbstractDataWrEnMaybe = WireInit(VecInit(Seq.fill(cfg.nAbstractDataWords * 4) {false.B} ))
 
     //--------------------------------------------------------------
     // Registers coming from 'CONTROL' in Outer
@@ -754,7 +754,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     val selectedHartReg = Reg(UInt(p(MaxHartIdBits).W))
       // hamaskFull is a vector of all selected harts including hartsel, whether or not supportHartArray is true
-    val hamaskFull = Wire(init = Vec.fill(nComponents){false.B})
+    val hamaskFull = WireInit(VecInit(Seq.fill(nComponents) {false.B} ))
 
     if (nComponents > 1) {
       when (~io.dmactive) {
@@ -765,8 +765,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     }
 
     if (supportHartArray) withReset (~io.dmactive || ~dmAuthenticated) {
-      val hamaskZero = Wire(init = Vec.fill(nComponents){false.B})
-      val hamaskReg = RegInit(Vec.fill(nComponents){false.B})
+      val hamaskZero = WireInit(VecInit(Seq.fill(nComponents) {false.B} ))
+      val hamaskReg = RegInit(VecInit(Seq.fill(nComponents) {false.B} ))
       when (io.innerCtrl.fire()){
         hamaskReg := Mux(io.innerCtrl.bits.hasel, io.innerCtrl.bits.hamask, hamaskZero)
       }
@@ -781,7 +781,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
      // Construct a Vec from io.innerCtrl fields indicating whether each hart is being selected in this write
      // A hart may be selected by hartsel field or by hart array
-    val hamaskWrSel = Wire(init = Vec.fill(nComponents){false.B})
+    val hamaskWrSel = WireInit(VecInit(Seq.fill(nComponents) {false.B} ))
     for (component <- 0 until nComponents ) {
       hamaskWrSel(component) := ((io.innerCtrl.bits.hartsel === component.U) ||
         (if (supportHartArray) io.innerCtrl.bits.hasel && io.innerCtrl.bits.hamask(component) else false.B))
@@ -794,7 +794,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     //  Debug interrupt is generated when a reset occurs whose corresponding hrmask bit is set
     //  Debug interrupt is maintained until the hart enters halted state
     //-------------------------------------
-    val hrReset    = Wire(Vec.fill(nComponents) { false.B })
+    val hrReset    = WireInit(VecInit(Seq.fill(nComponents) { false.B } ))
     val hrDebugInt = Reg(Vec(nComponents, Bool()))
     val hrmaskReg  = Reg(Vec(nComponents, Bool()))
     val hartResets = Wire(Vec(nComponents, Bool()))
@@ -822,7 +822,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     //----DMSTATUS
 
-    val DMSTATUSRdData = Wire(init = (new DMSTATUSFields()).fromBits(0.U))
+    val DMSTATUSRdData = WireInit(0.U.asTypeOf(new DMSTATUSFields()))
     DMSTATUSRdData.authenticated := dmAuthenticated
     DMSTATUSRdData.version       := 2.U    // Version 0.13
     io.auth.map(a => DMSTATUSRdData.authbusy := a.dmAuthBusy)
@@ -868,19 +868,19 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     //----DMCS2 (Halt Groups)
 
-    val DMCS2RdData    = Wire(init = (new DMCS2Fields()).fromBits(0.U))
-    val DMCS2WrData    = Wire(init = (new DMCS2Fields()).fromBits(0.U))
-    val hgselectWrEn   = Wire(init = false.B)
-    val hgwriteWrEn    = Wire(init = false.B)
-    val haltgroupWrEn  = Wire(init = false.B)
-    val exttriggerWrEn = Wire(init = false.B)
-    val hgDebugInt     = Wire(Vec.fill(nComponents){false.B})
+    val DMCS2RdData    = WireInit(0.U.asTypeOf(new DMCS2Fields()))
+    val DMCS2WrData    = WireInit(0.U.asTypeOf(new DMCS2Fields()))
+    val hgselectWrEn   = WireInit(false.B)
+    val hgwriteWrEn    = WireInit(false.B)
+    val haltgroupWrEn  = WireInit(false.B)
+    val exttriggerWrEn = WireInit(false.B)
+    val hgDebugInt     = WireInit(VecInit(Seq.fill(nComponents) {false.B} ))
 
     if (nHaltGroups > 0) withReset(~io.dmactive) {
       val hgBits = log2Up(nHaltGroups)
        // hgParticipate: Each entry indicates which hg that entity belongs to (1 to nHartGroups). 0 means no hg assigned.
-      val hgParticipateHart = RegInit(Vec(Seq.fill(nComponents)(0.U(hgBits.W))))
-      val hgParticipateTrig = if (nExtTriggers > 0) RegInit(Vec(Seq.fill(nExtTriggers)(0.U(hgBits.W)))) else Nil
+      val hgParticipateHart = RegInit(VecInit(Seq.fill(nComponents)(0.U(hgBits.W))))
+      val hgParticipateTrig = if (nExtTriggers > 0) RegInit(VecInit(Seq.fill(nExtTriggers)(0.U(hgBits.W)))) else Nil
 
       for (component <- 0 until nComponents) {
         when (~io.dmactive || ~dmAuthenticated) {
@@ -949,10 +949,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       //                     and all trig out in this hg have been acknowledged
 
       val hgFired = Reg(Vec(nHaltGroups+1, Bool()))
-      val hgHartFiring     = Wire(init = Vec.fill(nHaltGroups+1){false.B})     // which hg's are firing due to hart halting
-      val hgTrigFiring     = Wire(init = Vec.fill(nHaltGroups+1){false.B})     // which hg's are firing due to trig in
-      val hgHartsAllHalted = Wire(init = Vec.fill(nHaltGroups+1){false.B})     // in which hg's have all harts halted
-      val hgTrigsAllAcked  = Wire(init = Vec.fill(nHaltGroups+1){ true.B})     // in which hg's have all trigouts been acked
+      val hgHartFiring     = WireInit(VecInit(Seq.fill(nHaltGroups+1) {false.B} ))     // which hg's are firing due to hart halting
+      val hgTrigFiring     = WireInit(VecInit(Seq.fill(nHaltGroups+1) {false.B} ))     // which hg's are firing due to trig in
+      val hgHartsAllHalted = WireInit(VecInit(Seq.fill(nHaltGroups+1) {false.B} ))     // in which hg's have all harts halted
+      val hgTrigsAllAcked  = WireInit(VecInit(Seq.fill(nHaltGroups+1) { true.B} ))     // in which hg's have all trigouts been acked
 
       io.extTrigger.foreach {extTrigger =>
         val extTriggerInReq = Wire(Vec(nExtTriggers, Bool()))
@@ -988,7 +988,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
       // For each hg that has fired, assert trigger out for all external triggers in that hg
       io.extTrigger.foreach {extTrigger =>
-        val extTriggerOutReq = RegInit(Vec.fill(cfg.nExtTriggers){false.B})
+        val extTriggerOutReq = RegInit(VecInit(Seq.fill(cfg.nExtTriggers) {false.B} ))
         for (trig <- 0 until nExtTriggers) {
           extTriggerOutReq(trig) := hgFired(hgParticipateTrig(trig))
         }
@@ -1000,7 +1000,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     //----HARTINFO
 
-    val HARTINFORdData = Wire (init = (new HARTINFOFields()).fromBits(0.U))
+    val HARTINFORdData = WireInit(0.U.asTypeOf(new HARTINFOFields()))
     when (dmAuthenticated) {
       HARTINFORdData.dataaccess  := true.B
       HARTINFORdData.datasize    := cfg.nAbstractDataWords.U
@@ -1010,7 +1010,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     //----HALTSUM*
     val numHaltedStatus = ((nComponents - 1) / 32) + 1
-    val haltedStatus   = Wire(Vec(numHaltedStatus, Bits(width = 32)))
+    val haltedStatus   = Wire(Vec(numHaltedStatus, Bits(32.W)))
 
     for (ii <- 0 until numHaltedStatus) {
       when (dmAuthenticated) {
@@ -1021,33 +1021,33 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     }
 
     val haltedSummary = Cat(haltedStatus.map(_.orR).reverse)
-    val HALTSUM1RdData = (new HALTSUM1Fields()).fromBits(haltedSummary)
+    val HALTSUM1RdData = haltedSummary.asTypeOf(new HALTSUM1Fields())
 
     val selectedHaltedStatus = Mux((selectedHartReg >> 5) > numHaltedStatus.U, 0.U, haltedStatus(selectedHartReg >> 5))
-    val HALTSUM0RdData = (new HALTSUM0Fields()).fromBits(selectedHaltedStatus)
+    val HALTSUM0RdData = selectedHaltedStatus.asTypeOf(new HALTSUM0Fields())
 
     // Since we only support 1024 harts, we don't implement HALTSUM2 or HALTSUM3
 
     //----ABSTRACTCS
 
-    val ABSTRACTCSReset = Wire(init = (new ABSTRACTCSFields()).fromBits(0.U))
+    val ABSTRACTCSReset = WireInit(0.U.asTypeOf(new ABSTRACTCSFields()))
     ABSTRACTCSReset.datacount   := cfg.nAbstractDataWords.U
     ABSTRACTCSReset.progbufsize := cfg.nProgramBufferWords.U
 
     val ABSTRACTCSReg       = Reg(new ABSTRACTCSFields())
-    val ABSTRACTCSWrData    = Wire(init = (new ABSTRACTCSFields()).fromBits(0.U))
-    val ABSTRACTCSRdData    = Wire(init = ABSTRACTCSReg)
+    val ABSTRACTCSWrData    = WireInit(0.U.asTypeOf(new ABSTRACTCSFields()))
+    val ABSTRACTCSRdData    = WireInit(ABSTRACTCSReg)
 
-    val ABSTRACTCSRdEn = Wire(init = false.B)
-    val ABSTRACTCSWrEnMaybe = Wire(init = false.B)
+    val ABSTRACTCSRdEn = WireInit(false.B)
+    val ABSTRACTCSWrEnMaybe = WireInit(false.B)
 
-    val ABSTRACTCSWrEnLegal = Wire(init = false.B)
+    val ABSTRACTCSWrEnLegal = WireInit(false.B)
     val ABSTRACTCSWrEn      = ABSTRACTCSWrEnMaybe && ABSTRACTCSWrEnLegal
 
-    val errorBusy        = Wire(init = false.B)
-    val errorException   = Wire(init = false.B)
-    val errorUnsupported = Wire(init = false.B)
-    val errorHaltResume  = Wire(init = false.B)
+    val errorBusy        = WireInit(false.B)
+    val errorException   = WireInit(false.B)
+    val errorUnsupported = WireInit(false.B)
+    val errorHaltResume  = WireInit(false.B)
 
     when (~io.dmactive || ~dmAuthenticated) {
       ABSTRACTCSReg := ABSTRACTCSReset
@@ -1068,7 +1068,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     }
 
     // For busy, see below state machine.
-    val abstractCommandBusy = Wire(init = true.B)
+    val abstractCommandBusy = WireInit(true.B)
     ABSTRACTCSRdData.busy := abstractCommandBusy
     when (~dmAuthenticated) {   // read value must be 0 when not authenticated
       ABSTRACTCSRdData.datacount := 0.U
@@ -1077,16 +1077,16 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     //---- ABSTRACTAUTO
 
-    val ABSTRACTAUTOReset     = Wire(init = (new ABSTRACTAUTOFields()).fromBits(0.U))
+    val ABSTRACTAUTOReset     = WireInit(0.U.asTypeOf(new ABSTRACTAUTOFields()))
     val ABSTRACTAUTOReg       = Reg(new ABSTRACTAUTOFields())
-    val ABSTRACTAUTOWrData    = Wire(init = (new ABSTRACTAUTOFields()).fromBits(0.U))
-    val ABSTRACTAUTORdData    = Wire(init = ABSTRACTAUTOReg)
+    val ABSTRACTAUTOWrData    = WireInit(0.U.asTypeOf(new ABSTRACTAUTOFields()))
+    val ABSTRACTAUTORdData    = WireInit(ABSTRACTAUTOReg)
 
-    val ABSTRACTAUTORdEn = Wire(init = false.B)
-    val autoexecdataWrEnMaybe = Wire(init = false.B)
-    val autoexecprogbufWrEnMaybe = Wire(init = false.B)
+    val ABSTRACTAUTORdEn = WireInit(false.B)
+    val autoexecdataWrEnMaybe = WireInit(false.B)
+    val autoexecprogbufWrEnMaybe = WireInit(false.B)
 
-    val ABSTRACTAUTOWrEnLegal = Wire(init = false.B)
+    val ABSTRACTAUTOWrEnLegal = WireInit(false.B)
 
     when (~io.dmactive || ~dmAuthenticated) {
       ABSTRACTAUTOReg := ABSTRACTAUTOReset
@@ -1099,18 +1099,18 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       }
     }
 
-    val dmiAbstractDataAccessVec  = Wire(init = Vec.fill(cfg.nAbstractDataWords * 4){false.B})
+    val dmiAbstractDataAccessVec  = WireInit(VecInit(Seq.fill(cfg.nAbstractDataWords * 4) {false.B} ))
     dmiAbstractDataAccessVec := (dmiAbstractDataWrEnMaybe zip dmiAbstractDataRdEn).map{ case (r,w) => r | w}
 
-    val dmiProgramBufferAccessVec  = Wire(init = Vec.fill(cfg.nProgramBufferWords * 4){false.B})
+    val dmiProgramBufferAccessVec  = WireInit(VecInit(Seq.fill(cfg.nProgramBufferWords * 4) {false.B} ))
     dmiProgramBufferAccessVec := (dmiProgramBufferWrEnMaybe zip dmiProgramBufferRdEn).map{ case (r,w) => r | w}
 
     val dmiAbstractDataAccess  = dmiAbstractDataAccessVec.reduce(_ || _ )
     val dmiProgramBufferAccess = dmiProgramBufferAccessVec.reduce(_ || _)
 
     // This will take the shorter of the lists, which is what we want.
-    val autoexecData  = Wire(init = Vec.fill(cfg.nAbstractDataWords){false.B})
-    val autoexecProg  = Wire(init = Vec.fill(cfg.nProgramBufferWords){false.B})
+    val autoexecData  = WireInit(VecInit(Seq.fill(cfg.nAbstractDataWords) {false.B} ))
+    val autoexecProg  = WireInit(VecInit(Seq.fill(cfg.nProgramBufferWords) {false.B} ))
       (autoexecData zip ABSTRACTAUTOReg.autoexecdata.asBools).zipWithIndex.foreach {case (t, i) => t._1 := dmiAbstractDataAccessVec(i * 4) && t._2 }
       (autoexecProg zip ABSTRACTAUTOReg.autoexecprogbuf.asBools).zipWithIndex.foreach {case (t, i) => t._1 := dmiProgramBufferAccessVec(i * 4) && t._2}
 
@@ -1118,14 +1118,14 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     //---- COMMAND
 
-    val COMMANDReset = Wire(init = (new COMMANDFields()).fromBits(0.U))
+    val COMMANDReset = WireInit(0.U.asTypeOf(new COMMANDFields()))
     val COMMANDReg = Reg(new COMMANDFields())
 
-    val COMMANDWrDataVal    = Wire(init = 0.U(32.W))
-    val COMMANDWrData       = Wire(init = (new COMMANDFields()).fromBits(COMMANDWrDataVal))
-    val COMMANDWrEnMaybe    = Wire(init = false.B)
-    val COMMANDWrEnLegal    = Wire(init = false.B)
-    val COMMANDRdEn  = Wire(init = false.B)
+    val COMMANDWrDataVal    = WireInit(0.U(32.W))
+    val COMMANDWrData       = WireInit(COMMANDWrDataVal.asTypeOf(new COMMANDFields()))
+    val COMMANDWrEnMaybe    = WireInit(false.B)
+    val COMMANDWrEnLegal    = WireInit(false.B)
+    val COMMANDRdEn  = WireInit(false.B)
 
     val COMMANDWrEn = COMMANDWrEnMaybe && COMMANDWrEnLegal
     val COMMANDRdData = COMMANDReg
@@ -1143,11 +1143,11 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     // These are byte addressible, s.t. the Processor can use
     // byte-addressible instructions to store to them.
     val abstractDataMem       = Reg(Vec(cfg.nAbstractDataWords*4, UInt(8.W)))
-    val abstractDataNxt       = Wire(init = abstractDataMem)
+    val abstractDataNxt       = WireInit(abstractDataMem)
 
     // --- Program Buffer
     val programBufferMem    = Reg(Vec(cfg.nProgramBufferWords*4, UInt(8.W)))
-    val programBufferNxt    = Wire(init = programBufferMem)
+    val programBufferNxt    = WireInit(programBufferMem)
 
     //--------------------------------------------------------------
     // These bits are implementation-specific bits set
@@ -1189,8 +1189,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     }
 
     //---- AUTHDATA
-    val authRdEnMaybe = Wire(Bool())
-    val authWrEnMaybe = Wire(Bool())
+    val authRdEnMaybe = WireInit(false.B)
+    val authWrEnMaybe = WireInit(false.B)
     io.auth.map { a =>
       a.dmactive    := io.dmactive
       a.dmAuthRead  := authRdEnMaybe & ~a.dmAuthBusy
@@ -1336,9 +1336,9 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     //--------------------------------------------------------------
 
     val goReg        = Reg(Bool())
-    val goAbstract   = Wire(init = false.B)
-    val goCustom     = Wire(init = false.B)
-    val jalAbstract  = Wire(init = (new GeneratedUJ()).fromBits(Instructions.JAL.value.U))
+    val goAbstract   = WireInit(false.B)
+    val goCustom     = WireInit(false.B)
+    val jalAbstract  = WireInit(Instructions.JAL.value.U.asTypeOf(new GeneratedUJ()))
     jalAbstract.setImm(ABSTRACT(cfg) - WHERETO)
 
     when (~io.dmactive){
@@ -1358,13 +1358,13 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       val go = Bool()
     }
 
-    val flags = Wire(init = Vec.fill(1 << selectedHartReg.getWidth){new flagBundle().fromBits(0.U)})
+    val flags = WireInit(VecInit(Seq.fill(1 << selectedHartReg.getWidth) {0.U.asTypeOf(new flagBundle())} ))
     assert ((hartSelFuncs.hartSelToHartId(selectedHartReg) < flags.size.U),
       s"HartSel to HartId Mapping is illegal for this Debug Implementation, because HartID must be < ${flags.size} for it to work.")
     flags(hartSelFuncs.hartSelToHartId(selectedHartReg)).go := goReg
 
     for (component <- 0 until nComponents) {
-      val componentSel = Wire(init = component.U)
+      val componentSel = WireInit(component.U)
       flags(hartSelFuncs.hartSelToHartId(componentSel)).resume := resumeReqRegs(component)
     }
 
@@ -1372,8 +1372,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     // Abstract Command Decoding & Generation
     //----------------------------
 
-    val accessRegisterCommandWr  = Wire(init = (new ACCESS_REGISTERFields()).fromBits(COMMANDWrData.asUInt()))
-    val accessRegisterCommandReg = Wire(init = (new ACCESS_REGISTERFields()).fromBits(COMMANDReg.asUInt()))
+    val accessRegisterCommandWr  = WireInit(COMMANDWrData.asUInt().asTypeOf(new ACCESS_REGISTERFields()))
+    val accessRegisterCommandReg = WireInit(COMMANDReg.asUInt().asTypeOf(new ACCESS_REGISTERFields()))
 
     // TODO: Quick Access
 
@@ -1406,8 +1406,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         // TODO: Check bounds of imm.
 
         require(imm % 2 == 0, "Immediate must be even for UJ encoding.")
-        val immWire = Wire(init = imm.S(21.W))
-        val immBits = Wire(init = Vec(immWire.asBools))
+        val immWire = WireInit(imm.S(21.W))
+        val immBits = WireInit(VecInit(immWire.asBools))
 
         imm0 := immBits.slice(1,  1  + 10).asUInt()
         imm1 := immBits.slice(11, 11 + 11).asUInt()
@@ -1421,20 +1421,20 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     val abstractGeneratedS = Wire(new GeneratedS())
     val nop = Wire(new GeneratedI())
 
-    abstractGeneratedI.opcode := ((new GeneratedI()).fromBits(Instructions.LW.value.U)).opcode
+    abstractGeneratedI.opcode := (Instructions.LW.value.U.asTypeOf(new GeneratedI())).opcode
     abstractGeneratedI.rd     := (accessRegisterCommandReg.regno & 0x1F.U)
     abstractGeneratedI.funct3 := accessRegisterCommandReg.size
     abstractGeneratedI.rs1    := 0.U
     abstractGeneratedI.imm    := DATA.U
 
-    abstractGeneratedS.opcode := ((new GeneratedS()).fromBits(Instructions.SW.value.U)).opcode
+    abstractGeneratedS.opcode := (Instructions.SW.value.U.asTypeOf(new GeneratedS())).opcode
     abstractGeneratedS.immlo  := (DATA & 0x1F).U
     abstractGeneratedS.funct3 := accessRegisterCommandReg.size
     abstractGeneratedS.rs1    := 0.U
     abstractGeneratedS.rs2    := (accessRegisterCommandReg.regno & 0x1F.U)
     abstractGeneratedS.immhi  := (DATA >> 5).U
 
-    nop := ((new GeneratedI()).fromBits(Instructions.ADDI.value.U))
+    nop := Instructions.ADDI.value.U.asTypeOf(new GeneratedI())
     nop.rd   := 0.U
     nop.rs1  := 0.U
     nop.imm  := 0.U
@@ -1517,10 +1517,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     import CtrlState._
 
     // This is not an initialization!
-    val ctrlStateReg = Reg(CtrlState(Waiting))
+    val ctrlStateReg = RegInit(CtrlState(Waiting))
 
     val hartHalted   = haltedBitRegs(selectedHartReg)
-    val ctrlStateNxt = Wire(init = ctrlStateReg)
+    val ctrlStateNxt = WireInit(ctrlStateReg)
 
     //------------------------
     // DMI Register Control and Status
@@ -1546,8 +1546,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
     val commandWrIsUnsupported = COMMANDWrEn && !commandWrIsAccessRegister;
 
-    val commandRegIsUnsupported = Wire(init = true.B)
-    val commandRegBadHaltResume = Wire(init = false.B)
+    val commandRegIsUnsupported = WireInit(true.B)
+    val commandRegBadHaltResume = WireInit(false.B)
 
     // We only support abstract commands for GPRs and any custom registers, if specified.
     val accessRegIsGPR = (accessRegisterCommandReg.regno >= 0x1000.U && accessRegisterCommandReg.regno <= 0x101F.U)
@@ -1657,22 +1657,22 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int, beatByt
 
     val io = IO(new Bundle {
       // These are all asynchronous and come from Outer
-      val dmactive = Bool(INPUT)
-      val innerCtrl = new AsyncBundle(new DebugInternalBundle(getNComponents()), AsyncQueueParams.singleton()).flip
+      val dmactive = Input(Bool())
+      val innerCtrl = Flipped(new AsyncBundle(new DebugInternalBundle(getNComponents()), AsyncQueueParams.singleton()))
       // This comes from tlClk domain.
-      val debugUnavail    = Vec(getNComponents(), Bool()).asInput
-      val hgDebugInt      = Vec(getNComponents(), Bool()).asOutput
+      val debugUnavail    = Input(Vec(getNComponents(), Bool()))
+      val hgDebugInt      = Output(Vec(getNComponents(), Bool()))
       val extTrigger = (p(DebugModuleKey).get.nExtTriggers > 0).option(new DebugExtTriggerIO())
       val hartReset  = p(DebugModuleKey).get.hasHartResets.option(Input(Vec(getNComponents(), Bool())))
       val auth = p(DebugModuleKey).get.hasAuthentication.option(new DebugAuthenticationIO())
-      val psd = new PSDTestMode().asInput
+      val psd = Input(new PSDTestMode())
     })
 
     val dmactive_synced = ~ResetCatchAndSync(clock, ~io.dmactive, "dmactiveSync", io.psd)
     // Need to clock DM during reset because of synchronous reset.  The unit
     // should also be reset when dmactive_synced is low, so keep the clock
     // alive for one cycle after dmactive_synced falls to action this behavior.
-    val clock_en = RegNext(dmactive_synced || reset)
+    val clock_en = RegNext(dmactive_synced || reset.asBool)
     val gated_clock =
       if (!p(DebugModuleKey).get.clockGate) clock
       else ClockGate(clock, clock_en, "debug_clock_gate")
@@ -1683,7 +1683,7 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int, beatByt
       dmInner.module.clock := gated_clock
       dmInner.module.io.dmactive := dmactive_synced
       withReset (~dmactive_synced) {
-        dmInner.module.io.innerCtrl := FromAsyncBundle(io.innerCtrl)
+        dmInner.module.io.innerCtrl <> FromAsyncBundle(io.innerCtrl)
       }
       dmInner.module.io.debugUnavail := io.debugUnavail
       io.hgDebugInt := dmInner.module.io.hgDebugInt
@@ -1730,14 +1730,14 @@ class TLDebugModule(beatBytes: Int)(implicit p: Parameters) extends LazyModule {
 
     val io = IO(new Bundle {
       val ctrl = new DebugCtrlBundle(nComponents)
-      val dmi = (!p(ExportDebug).apb).option(new ClockedDMIIO().flip)
-      val apb_clock = p(ExportDebug).apb.option(Clock(INPUT))
-      val apb_reset = p(ExportDebug).apb.option(Bool(INPUT))
+      val dmi = (!p(ExportDebug).apb).option(Flipped(new ClockedDMIIO()))
+      val apb_clock = p(ExportDebug).apb.option(Input(Clock()))
+      val apb_reset = p(ExportDebug).apb.option(Input(Bool()))
       val extTrigger = (p(DebugModuleKey).get.nExtTriggers > 0).option(new DebugExtTriggerIO())
       val hartReset    = p(DebugModuleKey).get.hasHartResets.option(Input(Vec(nComponents, Bool())))
       val hartResetReq = p(DebugModuleKey).get.hasHartResets.option(Output(Vec(nComponents, Bool())))
       val auth = p(DebugModuleKey).get.hasAuthentication.option(new DebugAuthenticationIO())
-      val psd = new PSDTestMode().asInput
+      val psd = Input(new PSDTestMode())
     })
 
     dmOuter.module.io.dmi.foreach { dmOuterDMI =>
@@ -1751,7 +1751,7 @@ class TLDebugModule(beatBytes: Int)(implicit p: Parameters) extends LazyModule {
       dmOuter.module.clock := c
     }
 
-    dmInner.module.io.innerCtrl    := dmOuter.module.io.innerCtrl
+    dmInner.module.io.innerCtrl    <> dmOuter.module.io.innerCtrl
     dmInner.module.io.dmactive     := dmOuter.module.io.ctrl.dmactive
     dmInner.module.io.debugUnavail := io.ctrl.debugUnavail
     dmOuter.module.io.hgDebugInt   := dmInner.module.io.hgDebugInt

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1517,7 +1517,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     import CtrlState._
 
     // This is not an initialization!
-    val ctrlStateReg = RegInit(CtrlState(Waiting))
+    val ctrlStateReg = Reg(chiselTypeOf(CtrlState(Waiting)))
 
     val hartHalted   = haltedBitRegs(selectedHartReg)
     val ctrlStateNxt = WireInit(ctrlStateReg)

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -190,7 +190,10 @@ class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam
   })
 
   def connect(dutio: JTAGIO, tbclock: Clock, tbreset: Bool, init_done: Bool, tbsuccess: Bool) = {
-    dutio <> io.jtag
+    dutio.TCK := io.jtag.TCK
+    dutio.TMS := io.jtag.TMS
+    dutio.TDI := io.jtag.TDI
+    io.jtag.TDO := dutio.TCK
 
     io.clock := tbclock
     io.reset := tbreset

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -193,7 +193,7 @@ class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam
     dutio.TCK := io.jtag.TCK
     dutio.TMS := io.jtag.TMS
     dutio.TDI := io.jtag.TDI
-    io.jtag.TDO := dutio.TCK
+    io.jtag.TDO := dutio.TDO
 
     io.clock := tbclock
     io.reset := tbreset

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -186,7 +186,7 @@ class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam
     val jtag = new JTAGIO(hasTRSTn = true)
     val enable = Input(Bool())
     val init_done = Input(Bool())
-    val exit = Output(UInt())
+    val exit = Output(UInt(32.W))
   })
 
   def connect(dutio: JTAGIO, tbclock: Clock, tbreset: Bool, init_done: Bool, tbsuccess: Bool) = {

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -101,7 +101,7 @@ object SystemBusAccessModule
     val hasSBAddr3 = (sb2tl.module.edge.bundle.addressBits >= 97)
     val hasAddr    = Seq(true, hasSBAddr1, hasSBAddr2, hasSBAddr3)
 
-    val SBADDRESSFieldsReg = RegInit(VecInit(Seq.fill(4) {0.U(32.W)} ))
+    val SBADDRESSFieldsReg = Reg(Vec(4, UInt(32.W)))
     SBADDRESSFieldsReg.zipWithIndex.foreach { case(a,i) => a.suggestName("SBADDRESS"+i+"FieldsReg")}
     val SBADDRESSWrData    = WireInit(VecInit(Seq.fill(4) {0.U(32.W)} ))
     val SBADDRESSRdEn      = WireInit(VecInit(Seq.fill(4) {false.B} ))
@@ -123,6 +123,7 @@ object SystemBusAccessModule
         RegFieldGroup("dmi_sbaddr"+i, Some("SBA Address Register"), Seq(RWNotify(32, a, SBADDRESSWrData(i), SBADDRESSRdEn(i), SBADDRESSWrEn(i),
           Some(RegFieldDesc("dmi_sbaddr"+i, "SBA address register", reset=Some(0), volatile=true)))))
       } else {
+        a := DontCare
         Seq.empty[RegField]
       }
     }
@@ -139,7 +140,7 @@ object SystemBusAccessModule
     val hasSBData2And3 = (cfg.maxSupportedSBAccess == 128)
     val hasData        = Seq(true, hasSBData1, hasSBData2And3, hasSBData2And3)
 
-    val SBDATAFieldsReg = RegInit(VecInit(Seq.fill(4) {VecInit(Seq.fill(4) {0.U(8.W)} )} ))
+    val SBDATAFieldsReg = Reg(Vec(4, Vec(4, UInt(8.W))))
     SBDATAFieldsReg.zipWithIndex.foreach { case(d,i) => d.zipWithIndex.foreach { case(d,j) => d.suggestName("SBDATA"+i+"BYTE"+j) }}
     val SBDATARdData    = WireInit(VecInit(Seq.fill(4) {0.U(32.W)} ))
     SBDATARdData.zipWithIndex.foreach { case(d,i) => d.suggestName("SBDATARdData"+i) }
@@ -166,6 +167,7 @@ object SystemBusAccessModule
         RegFieldGroup("dmi_sbdata"+i, Some("SBA Data Register"), Seq(RWNotify(32, SBDATARdData(i), SBDATAWrData(i), SBDATARdEn(i), SBDATAWrEn(i),
           Some(RegFieldDesc("dmi_sbdata"+i, "SBA data register", reset=Some(0), volatile=true)))))
       } else {
+        for (j <- 0 to 3) { d(j) := DontCare }
         Seq.empty[RegField]
       }
     }

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.devices.debug.systembusaccess
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
@@ -38,14 +39,14 @@ object SystemBusAccessModule
 
     val cfg = p(DebugModuleKey).get
 
-    val anyAddressWrEn = Wire(init = false.B).suggestName("anyAddressWrEn")
-    val anyDataRdEn    = Wire(init = false.B).suggestName("anyDataRdEn")
-    val anyDataWrEn    = Wire(init = false.B).suggestName("anyDataWrEn")
+    val anyAddressWrEn = WireInit(false.B).suggestName("anyAddressWrEn")
+    val anyDataRdEn    = WireInit(false.B).suggestName("anyDataRdEn")
+    val anyDataWrEn    = WireInit(false.B).suggestName("anyDataWrEn")
 
     // --- SBCS Status Register ---
     val SBCSFieldsReg = Reg(new SBCSFields()).suggestName("SBCSFieldsReg")
 
-    val SBCSFieldsRegReset = Wire(init = (new SBCSFields()).fromBits(0.U))
+    val SBCSFieldsRegReset = WireInit(0.U.asTypeOf(new SBCSFields()))
     SBCSFieldsRegReset.sbversion   := 1.U(1.W) // This code implements a version of the spec after January 1, 2018
     SBCSFieldsRegReset.sbbusy      := (sb2tl.module.io.sbStateOut =/= SystemBusAccessState.Idle.id.U)
     SBCSFieldsRegReset.sbaccess    := 2.U
@@ -56,17 +57,17 @@ object SystemBusAccessModule
     SBCSFieldsRegReset.sbaccess16  := (cfg.maxSupportedSBAccess >=  16).B
     SBCSFieldsRegReset.sbaccess8   := (cfg.maxSupportedSBAccess >=   8).B
 
-    val SBCSRdData         = Wire(init = new SBCSFields().fromBits(0.U)).suggestName("SBCSRdData")
+    val SBCSRdData         = WireInit(0.U.asTypeOf(new SBCSFields())).suggestName("SBCSRdData")
 
-    val SBCSWrDataVal      = Wire(init = 0.U(32.W))
-    val SBCSWrData         = Wire(init = new SBCSFields().fromBits(SBCSWrDataVal))
+    val SBCSWrDataVal      = WireInit(0.U(32.W))
+    val SBCSWrData         = WireInit(SBCSWrDataVal.asTypeOf(new SBCSFields()))
     
-    val sberrorWrEn        = Wire(init = false.B)
-    val sbreadondataWrEn   = Wire(init = false.B)
-    val sbautoincrementWrEn= Wire(init = false.B)
-    val sbaccessWrEn       = Wire(init = false.B)
-    val sbreadonaddrWrEn   = Wire(init = false.B)
-    val sbbusyerrorWrEn    = Wire(init = false.B)
+    val sberrorWrEn        = WireInit(false.B)
+    val sbreadondataWrEn   = WireInit(false.B)
+    val sbautoincrementWrEn= WireInit(false.B)
+    val sbaccessWrEn       = WireInit(false.B)
+    val sbreadonaddrWrEn   = WireInit(false.B)
+    val sbbusyerrorWrEn    = WireInit(false.B)
 
     val sbcsfields = RegFieldGroup("sbcs", Some("system bus access control and status"), Seq(
       RegField.r(1, SBCSRdData.sbaccess8,   RegFieldDesc("sbaccess8",   "8-bit accesses supported",   reset=Some(if (cfg.maxSupportedSBAccess >=   8) 1 else 0))),
@@ -100,13 +101,13 @@ object SystemBusAccessModule
     val hasSBAddr3 = (sb2tl.module.edge.bundle.addressBits >= 97)
     val hasAddr    = Seq(true, hasSBAddr1, hasSBAddr2, hasSBAddr3)
 
-    val SBADDRESSFieldsReg = Seq.fill(4)(Reg (UInt(32.W)))
+    val SBADDRESSFieldsReg = RegInit(VecInit(Seq.fill(4) {0.U(32.W)} ))
     SBADDRESSFieldsReg.zipWithIndex.foreach { case(a,i) => a.suggestName("SBADDRESS"+i+"FieldsReg")}
-    val SBADDRESSWrData    = Seq.fill(4)(Wire(UInt(32.W)))
-    val SBADDRESSRdEn      = Seq.fill(4)(Wire(Bool()))
-    val SBADDRESSWrEn      = Seq.fill(4)(Wire(Bool()))
+    val SBADDRESSWrData    = WireInit(VecInit(Seq.fill(4) {0.U(32.W)} ))
+    val SBADDRESSRdEn      = WireInit(VecInit(Seq.fill(4) {false.B} ))
+    val SBADDRESSWrEn      = WireInit(VecInit(Seq.fill(4) {false.B} ))
 
-    val autoIncrementedAddr = Wire(init = 0.U(128.W))
+    val autoIncrementedAddr = WireInit(0.U(128.W))
     autoIncrementedAddr := Cat(SBADDRESSFieldsReg.reverse) + (1.U << SBCSFieldsReg.sbaccess)
     autoIncrementedAddr.suggestName("autoIncrementedAddr")
 
@@ -138,14 +139,14 @@ object SystemBusAccessModule
     val hasSBData2And3 = (cfg.maxSupportedSBAccess == 128)
     val hasData        = Seq(true, hasSBData1, hasSBData2And3, hasSBData2And3)
 
-    val SBDATAFieldsReg = Seq.fill(4)(Seq.fill(4)(Reg (UInt(8.W))))
+    val SBDATAFieldsReg = RegInit(VecInit(Seq.fill(4) {VecInit(Seq.fill(4) {0.U(8.W)} )} ))
     SBDATAFieldsReg.zipWithIndex.foreach { case(d,i) => d.zipWithIndex.foreach { case(d,j) => d.suggestName("SBDATA"+i+"BYTE"+j) }}
-    val SBDATARdData    = Seq.fill(4)(Wire(UInt(32.W)))
+    val SBDATARdData    = WireInit(VecInit(Seq.fill(4) {0.U(32.W)} ))
     SBDATARdData.zipWithIndex.foreach { case(d,i) => d.suggestName("SBDATARdData"+i) }
-    val SBDATAWrData    = Seq.fill(4)(Wire(UInt(32.W)))
+    val SBDATAWrData    = WireInit(VecInit(Seq.fill(4) {0.U(32.W)} ))
     SBDATAWrData.zipWithIndex.foreach { case(d,i) => d.suggestName("SBDATAWrData"+i) }
-    val SBDATARdEn      = Seq.fill(4)(Wire(Bool()))
-    val SBDATAWrEn      = Seq.fill(4)(Wire(Bool()))
+    val SBDATARdEn      = WireInit(VecInit(Seq.fill(4) {false.B} ))
+    val SBDATAWrEn      = WireInit(VecInit(Seq.fill(4) {false.B} ))
     SBDATAWrEn.zipWithIndex.foreach { case(d,i) => d.suggestName("SBDATAWrEn"+i) }
 
     val sbdatafields: Seq[Seq[RegField]] = SBDATAFieldsReg.zipWithIndex.map { case(d,i) =>
@@ -267,41 +268,41 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val rdEn         = Bool(INPUT)
-      val wrEn         = Bool(INPUT)
-      val addrIn       = UInt(INPUT, 128) // TODO: Parameterize these widths
-      val dataIn       = UInt(INPUT, 128)
-      val sizeIn       = UInt(INPUT, 3)
-      val dmactive     = Bool(INPUT)
-      val rdLegal      = Bool(OUTPUT)
-      val wrLegal      = Bool(OUTPUT)
-      val rdDone       = Bool(OUTPUT)
-      val wrDone       = Bool(OUTPUT)
-      val respError    = Bool(OUTPUT)
-      val dataOut      = UInt(OUTPUT, 8)
-      val rdLoad       = Vec(cfg.maxSupportedSBAccess/8, Bool()).asOutput
-      val sbStateOut   = UInt(OUTPUT, log2Ceil(SystemBusAccessState.maxId))
+      val rdEn         = Input(Bool())
+      val wrEn         = Input(Bool())
+      val addrIn       = Input(UInt(128.W)) // TODO: Parameterize these widths
+      val dataIn       = Input(UInt(128.W))
+      val sizeIn       = Input(UInt(3.W))
+      val dmactive     = Input(Bool())
+      val rdLegal      = Output(Bool())
+      val wrLegal      = Output(Bool())
+      val rdDone       = Output(Bool())
+      val wrDone       = Output(Bool())
+      val respError    = Output(Bool())
+      val dataOut      = Output(UInt(8.W))
+      val rdLoad       = Output(Vec(cfg.maxSupportedSBAccess/8, Bool()))
+      val sbStateOut   = Output(UInt(log2Ceil(SystemBusAccessState.maxId).W))
     })
 
     import SystemBusAccessState._
  
     val (tl, edge) = node.out(0)
 
-    val sbState = Reg(init = 0.U)
+    val sbState = RegInit(0.U)
 
     // --- Drive payloads on bus to TileLink ---
     val d = Queue(tl.d, 2) // Add a small buffer since response could arrive on same cycle as request
     d.ready := (sbState === SBReadResponse.id.U) || (sbState === SBWriteResponse.id.U)
 
-    val muxedData = Wire(init = 0.U(8.W))
+    val muxedData = WireInit(0.U(8.W))
     val requestValid = tl.a.valid
     val requestReady = tl.a.ready
     val responseValid = d.valid
     val responseReady = d.ready
 
-    val counter = Reg(init = 0.U((log2Ceil(cfg.maxSupportedSBAccess/8)+1).W))
+    val counter = RegInit(0.U((log2Ceil(cfg.maxSupportedSBAccess/8)+1).W))
     val vecData   = Wire(Vec(cfg.maxSupportedSBAccess/8, UInt(8.W)))
-    vecData := Vec.tabulate(16) { i => io.dataIn(8*i+7,8*i) }
+    vecData.zipWithIndex.map { case (vd, i) => vd := io.dataIn(8*i+7,8*i) }
     muxedData := vecData(counter)
 
     // Need an additional check to determine if address is safe for Get/Put

--- a/src/main/scala/devices/debug/abstract_commands.scala
+++ b/src/main/scala/devices/debug/abstract_commands.scala
@@ -1,6 +1,6 @@
 package freechips.rocketchip.devices.debug
 
-import Chisel._
+import chisel3._
 
 // This file was auto-generated from the repository at https://github.com/riscv/riscv-debug-spec.git,
 // 'make chisel'

--- a/src/main/scala/devices/debug/dm_registers.scala
+++ b/src/main/scala/devices/debug/dm_registers.scala
@@ -1,6 +1,6 @@
 package freechips.rocketchip.devices.debug
 
-import Chisel._
+import chisel3._
 
 // This file was auto-generated from the repository at https://github.com/riscv/riscv-debug-spec.git,
 // 'make chisel'

--- a/src/main/scala/jtag/JtagShifter.scala
+++ b/src/main/scala/jtag/JtagShifter.scala
@@ -2,11 +2,10 @@
 
 package freechips.rocketchip.jtag
 
-//import chisel3._
-import Chisel._
-import chisel3.core.{Input, Output}
-import chisel3.core.DataMirror
+import chisel3._
+import chisel3.experimental.DataMirror
 import chisel3.internal.firrtl.KnownWidth
+import chisel3.util.{Cat, Valid}
 
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.property._

--- a/src/main/scala/jtag/JtagStateMachine.scala
+++ b/src/main/scala/jtag/JtagStateMachine.scala
@@ -2,10 +2,8 @@
 
 package freechips.rocketchip.jtag
 
-import Chisel._
-import chisel3.{Input, Output}
-import chisel3.experimental.withReset
-
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.util.{AsyncResetRegVec}
 import freechips.rocketchip.util.property._
@@ -78,7 +76,7 @@ class JtagStateMachine(implicit val p: Parameters) extends Module() {
   }
   val io = IO(new StateMachineIO)
 
-  val nextState = Wire(JtagState.State.chiselType())
+  val nextState = WireInit(JtagState.TestLogicReset.U)
   val currStateReg = Module (new AsyncResetRegVec(w = JtagState.State.width,
     init = JtagState.State.toInt(JtagState.TestLogicReset)))
   currStateReg.io.en := true.B

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -4,13 +4,8 @@ package freechips.rocketchip.jtag
 
 import scala.collection.SortedMap
 
-// !!! See Issue #1160.
-// import chisel3._
-import Chisel._
-import chisel3.core.{Input, Output}
+import chisel3._
 import chisel3.util._
-import chisel3.experimental.withReset
-
 import freechips.rocketchip.config.Parameters
 
 /** JTAG signals, viewed from the master side
@@ -119,8 +114,8 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
     nextActiveInstruction := irChain.io.update.bits
     updateInstruction := true.B
   } .otherwise {
-    //!!! Needed when using chisel3._ (See #1160)
-    // nextActiveInstruction := DontCare
+    // Needed when using chisel3._ (See #1160)
+    nextActiveInstruction := DontCare
     updateInstruction := false.B
   }
   io.output.instruction := activeInstruction
@@ -145,8 +140,8 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
     tdo := irChain.io.chainOut.data
     tdo_driven := true.B
   } .otherwise {
-    //!!! Needed when using chisel3._ (See #1160)
-    //tdo := DontCare
+    // Needed when using chisel3._ (See #1160)
+    tdo := DontCare
     tdo_driven := false.B
   }
 }
@@ -232,6 +227,8 @@ object JtagTapGenerator {
       }
     }
 
+    controllerInternal.io.dataChainIn := bypassChain.io.chainOut  // default
+
     def foldOutSelect(res: WhenContext, x: (Chain, Bool)): WhenContext = {
       val (chain, select) = x
       // Continue the WhenContext with if this chain is selected
@@ -256,7 +253,7 @@ object JtagTapGenerator {
 
     chainToSelect.map(mapInSelect)
 
-    controllerInternal.io.jtag <> internalIo.jtag
+    internalIo.jtag <> controllerInternal.io.jtag
     internalIo.control <> controllerInternal.io.control
     internalIo.output <> controllerInternal.io.output
 

--- a/src/main/scala/jtag/JtagUtils.scala
+++ b/src/main/scala/jtag/JtagUtils.scala
@@ -2,8 +2,7 @@
 
 package freechips.rocketchip.jtag
 
-import Chisel._
-//import chisel3._
+import chisel3._
 import chisel3.util._
 
 class JTAGIdcodeBundle extends Bundle {

--- a/src/main/scala/jtag/Utils.scala
+++ b/src/main/scala/jtag/Utils.scala
@@ -2,9 +2,8 @@
 
 package freechips.rocketchip.jtag
 
-import Chisel._
-import chisel3.core.{Input, Output}
-import chisel3.experimental.withClock
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.AsyncResetReg
 
 /** Bundle representing a tristate pin.


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This PR converts the Debug Module and JTAG unit to chisel3. This is to enable them to use the new Chisel3 reset functionality.
