### PR TITLE
[axi4/tilelink] add support to propagate TL to AXI4 user bits

### DIFF
--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -19,7 +19,7 @@ abstract class AXI4BundleA(params: AXI4BundleParameters) extends AXI4BundleBase(
   val cache  = UInt(width = params.cacheBits)
   val prot   = UInt(width = params.protBits)
   val qos    = UInt(width = params.qosBits)  // 0=no QoS, bigger = higher priority
-  val user = if (params.userBits > 0) Some(UInt(width = params.userBits)) else None
+  val user   = if (params.userBits > 0 || params.opaqueBits > 0) Some(UInt(width = params.userBits + params.opaqueBits)) else None
   // val region = UInt(width = 4) // optional
 
   // Number of bytes-1 in this operation
@@ -53,7 +53,7 @@ class AXI4BundleR(params: AXI4BundleParameters) extends AXI4BundleBase(params)
   val id   = UInt(width = params.idBits)
   val data = UInt(width = params.dataBits)
   val resp = UInt(width = params.respBits)
-  val user = if (params.userBits > 0) Some(UInt(width = params.userBits)) else None
+  val user = if (params.userBits > 0 || params.opaqueBits > 0) Some(UInt(width = params.userBits + params.opaqueBits)) else None
   val last = Bool()
 }
 
@@ -61,7 +61,7 @@ class AXI4BundleB(params: AXI4BundleParameters) extends AXI4BundleBase(params)
 {
   val id   = UInt(width = params.idBits)
   val resp = UInt(width = params.respBits)
-  val user = if (params.userBits > 0) Some(UInt(width = params.userBits)) else None
+  val user = if (params.userBits > 0 || params.opaqueBits > 0) Some(UInt(width = params.userBits + params.opaqueBits)) else None
 }
 
 class AXI4Bundle(params: AXI4BundleParameters) extends AXI4BundleBase(params)

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
 case class AXI4ToTLNode(wcorrupt: Boolean = false)(implicit valName: ValName) extends MixedAdapterNode(AXI4Imp, TLImp)(
-  dFn = { case AXI4MasterPortParameters(masters, userBits) =>
+  dFn = { case AXI4MasterPortParameters(masters, opaqueBits, userBits) =>
     masters.foreach { m => require (m.maxFlight.isDefined, "AXI4 must include a transaction maximum per ID to convert to TL") }
     val maxFlight = masters.map(_.maxFlight.get).max
     TLClientPortParameters(

--- a/src/main/scala/amba/axi4/UserYanker.scala
+++ b/src/main/scala/amba/axi4/UserYanker.scala
@@ -22,9 +22,10 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      val bits = edgeIn.bundle.userBits
+      val opaqueBits = edgeIn.bundle.opaqueBits
+      val userBits = edgeIn.bundle.userBits
       val need_bypass = edgeOut.slave.minLatency < 1
-      require (bits > 0) // useless UserYanker!
+      require (userBits > 0) // useless UserYanker!
 
       edgeOut.master.masters.foreach { m =>
         require (m.maxFlight.isDefined, "UserYanker needs a flight cap on each ID")
@@ -33,9 +34,9 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
       def queue(id: Int) = {
         val depth = edgeOut.master.masters.find(_.id.contains(id)).flatMap(_.maxFlight).getOrElse(0)
         if (depth == 0) {
-          Wire(new QueueIO(UInt(width = bits), 1)) // unused ID => undefined value
+          Wire(new QueueIO(UInt(width = userBits), 1)) // unused ID => undefined value
         } else {
-          Module(new Queue(UInt(width = bits), depth, flow=need_bypass)).io
+          Module(new Queue(UInt(width = userBits), depth, flow=need_bypass)).io
         }
       }
 
@@ -47,20 +48,29 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
       in .ar.ready := out.ar.ready && ar_ready
       out.ar.valid := in .ar.valid && ar_ready
       out.ar.bits  := in .ar.bits
+      // propagate opaque bits if present
+      if (opaqueBits > 0) {
+        out.ar.bits.user.get := in.ar.bits.user.get(opaqueBits + userBits - 1, userBits)
+      }
 
       val rid = out.r.bits.id
       val r_valid = Vec(rqueues.map(_.deq.valid))(rid)
       val r_bits = Vec(rqueues.map(_.deq.bits))(rid)
       assert (!out.r.valid || r_valid) // Q must be ready faster than the response
       in.r <> out.r
-      in.r.bits.user.get := r_bits
+      // concatanate the opaque bits if present with the adapter specified user bits
+      if (opaqueBits > 0) {
+        in.r.bits.user.get := r_bits | (out.r.bits.user.get << userBits)
+      } else {
+        in.r.bits.user.get := r_bits
+      }
 
       val arsel = UIntToOH(arid, edgeIn.master.endId).asBools
       val rsel  = UIntToOH(rid,  edgeIn.master.endId).asBools
       (rqueues zip (arsel zip rsel)) foreach { case (q, (ar, r)) =>
         q.deq.ready := out.r .valid && in .r .ready && r && out.r.bits.last
         q.enq.valid := in .ar.valid && out.ar.ready && ar
-        q.enq.bits  := in.ar.bits.user.get
+        q.enq.bits  := in.ar.bits.user.get(userBits-1,0)
       }
 
       val awid = in.aw.bits.id
@@ -68,20 +78,29 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
       in .aw.ready := out.aw.ready && aw_ready
       out.aw.valid := in .aw.valid && aw_ready
       out.aw.bits  := in .aw.bits
+      // propagate opaque bits if present
+      if (opaqueBits > 0) {
+        out.aw.bits.user.get := in.aw.bits.user.get(opaqueBits + userBits - 1, userBits)
+      }
 
       val bid = out.b.bits.id
       val b_valid = Vec(wqueues.map(_.deq.valid))(bid)
       val b_bits = Vec(wqueues.map(_.deq.bits))(bid)
       assert (!out.b.valid || b_valid) // Q must be ready faster than the response
       in.b <> out.b
-      in.b.bits.user.get := b_bits
+      // concatanate the opaque bits if present with the adapter specified user bits
+      if (opaqueBits > 0) {
+        in.b.bits.user.get := b_bits | (out.b.bits.user.get << userBits)
+      } else {
+        in.b.bits.user.get := b_bits
+      }
 
       val awsel = UIntToOH(awid, edgeIn.master.endId).asBools
       val bsel  = UIntToOH(bid,  edgeIn.master.endId).asBools
       (wqueues zip (awsel zip bsel)) foreach { case (q, (aw, b)) =>
         q.deq.ready := out.b .valid && in .b .ready && b
         q.enq.valid := in .aw.valid && out.aw.ready && aw
-        q.enq.bits  := in.aw.bits.user.get
+        q.enq.bits  := in.aw.bits.user.get(userBits-1,0)
       }
 
       out.w <> in.w

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -24,16 +24,17 @@ class WithAMBAUnitTests extends Config((site, here, up) => {
     val txns = 100 * site(TestDurationMultiplier)
     val timeout = 50000 * site(TestDurationMultiplier)
     Seq(
-      Module(new AHBBridgeTest(true, txns=8*txns, timeout=timeout)),
-      Module(new AHBNativeTest(true, txns=6*txns, timeout=timeout)),
-      Module(new AHBNativeTest(false,txns=6*txns, timeout=timeout)),
-      Module(new APBBridgeTest(true, txns=6*txns, timeout=timeout)),
-      Module(new APBBridgeTest(false,txns=6*txns, timeout=timeout)),
-      Module(new AXI4LiteFuzzRAMTest(txns=6*txns, timeout=timeout)),
-      Module(new AXI4FullFuzzRAMTest(txns=3*txns, timeout=timeout)),
-      Module(new AXI4BridgeTest(     txns=3*txns, timeout=timeout)),
-      Module(new AXI4XbarTest(       txns=1*txns, timeout=timeout)),
-      Module(new AXI4RAMAsyncCrossingTest(txns=3*txns, timeout=timeout))) }
+      Module(new AHBBridgeTest(true,         txns=8*txns, timeout=timeout)),
+      Module(new AHBNativeTest(true,         txns=6*txns, timeout=timeout)),
+      Module(new AHBNativeTest(false,        txns=6*txns, timeout=timeout)),
+      Module(new APBBridgeTest(true,         txns=6*txns, timeout=timeout)),
+      Module(new APBBridgeTest(false,        txns=6*txns, timeout=timeout)),
+      Module(new AXI4LiteFuzzRAMTest(        txns=6*txns, timeout=timeout)),
+      Module(new AXI4LiteUserBitsFuzzRAMTest(txns=6*txns, timeout=timeout)),
+      Module(new AXI4FullFuzzRAMTest(        txns=3*txns, timeout=timeout)),
+      Module(new AXI4BridgeTest(             txns=3*txns, timeout=timeout)),
+      Module(new AXI4XbarTest(               txns=1*txns, timeout=timeout)),
+      Module(new AXI4RAMAsyncCrossingTest(   txns=3*txns, timeout=timeout))) }
 })
 
 class WithTLSimpleUnitTests extends Config((site, here, up) => {


### PR DESCRIPTION
This commit adds the support to propagate the TL user bits to the AXI4
channels if present. Some AXI4 adapter implementations currently use the AXI4 user
bits to encode routing control bits. The commit pads the TL user bits as
opaque-bits at msb position of the AXI user-field as shown below:

    opaqueBits+userBits-1    userBits userBits-1   0
    +--------------------------------+---------------+
    |           opaque               |      user     |
    +--------------------------------+---------------+

Changes:

  - axi4/Parameters.scala: add opaqueBits parameter to the AXI4MasterPortParameters
  - axi4/Bundles.scala: userBits and opaqueBits to combine user-bits field
  - axi4/UserYanker.scala: support to propagate opaqueBits if present
  - axi4/Test.scala: added a new test that injects TL userbits
  - tilelink/ToAXI4.scala: plumb TL user-bits to AXI4 channels

NOTE: Longterm we should revisit the solution to make sure we can add more semantic meaning to the AXI user-bits but I guess this is paired with a rework of the "user-bits" for all protocols.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**:  implementation

