### PR TITLE
Debug APB: Prevent aliasing on undefined addresses

### DIFF
--- a/src/main/scala/devices/debug/APB.scala
+++ b/src/main/scala/devices/debug/APB.scala
@@ -10,10 +10,15 @@ import freechips.rocketchip.amba.apb.{APBRegisterNode}
 
 case object APBDebugRegistersKey extends Field[Map[Int, Seq[RegField]]](Map())
 
+object APBDebugConsts {
+  def apbDebugRegBase = 0xF00
+  def apbDebugRegSize = 0x100
+}
+
 class APBDebugRegisters()(implicit p: Parameters) extends LazyModule {
 
   val node = APBRegisterNode(
-    address = AddressSet(base=0xF00, mask=0xFF),
+    address = AddressSet(base=APBDebugConsts.apbDebugRegBase, mask=APBDebugConsts.apbDebugRegSize-1),
     beatBytes = 4,
     executable = false
   )
@@ -23,3 +28,5 @@ class APBDebugRegisters()(implicit p: Parameters) extends LazyModule {
 
   }
 }
+
+

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.regmapper._
 import freechips.rocketchip.rocket.Instructions
 import freechips.rocketchip.tile.MaxHartIdBits
 import freechips.rocketchip.tilelink._
+import freechips.rocketchip.devices.tilelink.{DevNullParams, TLError}
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
@@ -594,6 +595,8 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
 
 class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends LazyModule {
 
+  val cfg = p(DebugModuleKey).get
+
   val dmiXbar = LazyModule (new TLXbar())
 
   val dmi2tlOpt = (!p(ExportDebug).apb).option({
@@ -605,14 +608,18 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
   val apbNodeOpt = p(ExportDebug).apb.option({
     val apb2tl = LazyModule(new APBToTL())
     val apb2tlBuffer = LazyModule(new TLBuffer(BufferParams.pipe))
-    val apbXbar = LazyModule(new APBFanout())
-    val apbRegs = LazyModule(new APBDebugRegisters())
+    val dmTopAddr = (1 << cfg.nDMIAddrSize) << 2
+    val tlErrorParams = DevNullParams(AddressSet.misaligned(dmTopAddr, APBDebugConsts.apbDebugRegBase-dmTopAddr),
+      maxAtomic=0, maxTransfer=4)
+    val tlError  = LazyModule(new TLError(tlErrorParams))
+    val apbXbar  = LazyModule(new APBFanout())
+    val apbRegs  = LazyModule(new APBDebugRegisters())
 
     apbRegs.node := apbXbar.node
     apb2tl.node  := apbXbar.node
     apb2tlBuffer.node := apb2tl.node
     dmiXbar.node := apb2tlBuffer.node
-
+    tlError.node := dmiXbar.node
     apbXbar.node
   })
 
@@ -643,6 +650,7 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
     dmOuter.module.io.hgDebugInt := io.hgDebugInt
     io.hartResetReq.foreach { x => dmOuter.module.io.hartResetReq.foreach {y => x := y}}
     io.dmAuthenticated.foreach { x => dmOuter.module.io.dmAuthenticated.foreach { y => y := x}}
+
   }
 }
 
@@ -655,11 +663,13 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
   val cfg = p(DebugModuleKey).get
   def getCfg = () => cfg
 
+  val dmTopAddr = (1 << cfg.nDMIAddrSize) << 2
+
   val dmiNode = TLRegisterNode(
        // Address is range 0 to 0x1FF except DMCONTROL, HAWINDOWSEL, HAWINDOW which are handled by Outer
     address = AddressSet.misaligned(0, DMI_DMCONTROL << 2) ++
               AddressSet.misaligned((DMI_DMCONTROL + 1) << 2, ((DMI_HAWINDOWSEL << 2) - ((DMI_DMCONTROL + 1) << 2))) ++
-              AddressSet.misaligned((DMI_HAWINDOW + 1) << 2, (0x200 - ((DMI_HAWINDOW + 1) << 2))),
+              AddressSet.misaligned((DMI_HAWINDOW + 1) << 2, (dmTopAddr - ((DMI_HAWINDOW + 1) << 2))),
     device = device,
     beatBytes = 4,
     executable = false


### PR DESCRIPTION
Debug: Fill in undefined addresses in APB interface with TLError device.

Note: making this a follow-on to #2205 would allow this to have less hardware impact

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:   implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Resolve issue in which accesses to the APB Debug interface which targeted undefined addresses would alias to valid addresses. Instead, these accesses will now return an error.
