### PR TITLE
Junction nodes

### DIFF
--- a/src/main/scala/tilelink/Jbar.scala
+++ b/src/main/scala/tilelink/Jbar.scala
@@ -1,0 +1,50 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tilelink
+
+import Chisel._
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+
+class TLJbar(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) extends LazyModule
+{
+  val node = TLJunctionNode(clientRatio, managerRatio,
+    clientFn  = { seq =>
+      Seq.fill(managerRatio)(seq(0).copy(
+        minLatency = seq.map(_.minLatency).min,
+        clients = (TLXbar.mapInputIds(seq) zip seq) flatMap { case (range, port) =>
+          port.clients map { client => client.copy(
+            sourceId = client.sourceId.shift(range.start)
+          )}
+        }
+      ))
+    },
+    managerFn = { seq =>
+      val fifoIdFactory = TLXbar.relabeler()
+      Seq.fill(clientRatio)(seq(0).copy(
+        minLatency = seq.map(_.minLatency).min,
+        endSinkId = TLXbar.mapOutputIds(seq).map(_.end).max,
+        managers = seq.flatMap { port =>
+          require (port.beatBytes == seq(0).beatBytes,
+            s"Xbar data widths don't match: ${port.managers.map(_.name)} has ${port.beatBytes}B vs ${seq(0).managers.map(_.name)} has ${seq(0).beatBytes}B")
+          val fifoIdMapper = fifoIdFactory()
+          port.managers map { manager => manager.copy(
+            fifoId = manager.fifoId.map(fifoIdMapper(_))
+          )}
+        }
+      ))
+    })
+
+  lazy val module = new LazyModuleImp(this) {
+    println(s"JBar info: ${node.in.size}/${clientRatio} vs ${node.out.size}/${managerRatio}")
+    node.inoutGrouped.foreach { case (in, out) => TLXbar.circuit(policy, in, out) }
+  }
+}
+
+object TLJbar
+{
+  def apply(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) = {
+    val jbar = LazyModule(new TLJbar(clientRatio, managerRatio, policy))
+    jbar.node
+  }
+}

--- a/src/main/scala/tilelink/Jbar.scala
+++ b/src/main/scala/tilelink/Jbar.scala
@@ -48,3 +48,29 @@ object TLJbar
     jbar.node
   }
 }
+
+/** Synthesizeable unit tests */
+import freechips.rocketchip.unittest._
+
+class TLJbarTestImp(nClients: Int, nManagers: Int, txns: Int)(implicit p: Parameters) extends LazyModule {
+  val jbar = LazyModule(new TLJbar(nClients, 1))
+
+  val fuzzers = Seq.fill(nClients) {
+    val fuzzer = LazyModule(new TLFuzzer(txns))
+    jbar.node :*= TLXbar() := TLDelayer(0.1) := fuzzer.node
+    fuzzer
+  }
+
+  for (n <- 0 until nManagers) {
+    TLRAM(AddressSet(0x0+0x400*n, 0x3ff)) := TLFragmenter(4, 256) := TLDelayer(0.1) := jbar.node
+  }
+
+  lazy val module = new LazyModuleImp(this) with UnitTestModule {
+    io.finished := fuzzers.map(_.module.io.finished).reduce(_ && _)
+  }
+}
+
+class TLJbarTest(nClients: Int, nManagers: Int, txns: Int = 5000, timeout: Int = 500000)(implicit p: Parameters) extends UnitTest(timeout) {
+  val dut = Module(LazyModule(new TLJbarTestImp(nClients, nManagers, txns)).module)
+  io.finished := dut.io.finished
+}

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -69,29 +69,6 @@ case class TLNexusNode(
 abstract class TLCustomNode(implicit valName: ValName)
   extends CustomNode(TLImp) with TLFormatNode
 
-case class TLSplitterNode(
-  clientFn:  TLClientPortParameters  => TLClientPortParameters  = { s => s },
-  managerFn: Seq[TLManagerPortParameters] => Seq[TLManagerPortParameters] = { s => s })(
-  implicit valName: ValName) extends TLCustomNode {
-
-  def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
-    require (iStars == 0, s"$context does not support :*=")
-    if (oStars > 0) {
-      require (oStars == 2, s"$context can only resolve an input :=* with 2 :=* outputs, but found $oStars")
-      require (oKnown == 0, s"$context can only resolve an input :=* with no := outputs, but found $oKnown")
-      (0, iKnown)
-    } else {
-      require (oKnown == 2*iKnown, s"$context has $oKnown outputs and $iKnown inputs; but 2*$iKnown must be $oKnown")
-      (0, 0)
-    }
-  }
-
-  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] = { p.map(clientFn) ++ p.map(clientFn) }
-
-  // managerFn should halve the size of p by pairwise merging the managers from two downstream paths
-  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] = { managerFn(p) }
-}
-
 // Asynchronous crossings
 
 trait TLAsyncFormatNode extends FormatNode[TLAsyncEdgeParameters, TLAsyncEdgeParameters]

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -43,6 +43,14 @@ case class TLAdapterNode(
   implicit valName: ValName)
   extends AdapterNode(TLImp)(clientFn, managerFn) with TLFormatNode
 
+case class TLJunctionNode(
+  clientRatio:  Int,
+  managerRatio: Int,
+  clientFn:     Seq[TLClientPortParameters]  => Seq[TLClientPortParameters],
+  managerFn:    Seq[TLManagerPortParameters] => Seq[TLManagerPortParameters])(
+  implicit valName: ValName)
+  extends JunctionNode(TLImp)(clientRatio, managerRatio, clientFn, managerFn) with TLFormatNode
+
 case class TLIdentityNode()(implicit valName: ValName) extends IdentityNode(TLImp)() with TLFormatNode
 case class TLEphemeralNode()(implicit valName: ValName) extends EphemeralNode(TLImp)()
 

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -64,15 +64,15 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
       println (s"!!! WARNING !!!")
     }
 
-    crossbar(node.in, node.out)
+    TLXbar.circuit(policy, node.in, node.out)
   }
 }
 
 object TLXbar
 {
-  def crossbar(in: Seq[(TLBundle, TLEdge)], out: Seq[(TLBundle, TLEdge)]) {
-    val (io_in, edgesIn) = in.unzip
-    val (io_out, edgesOut) = out.unzip
+  def circuit(policy: TLArbiter.Policy, seqIn: Seq[(TLBundle, TLEdge)], seqOut: Seq[(TLBundle, TLEdge)]) {
+    val (io_in, edgesIn) = seqIn.unzip
+    val (io_out, edgesOut) = seqOut.unzip
 
     // Not every master need connect to every slave on every channel; determine which connections are necessary
     val reachableIO = edgesIn.map { cp => edgesOut.map { mp =>
@@ -226,7 +226,7 @@ object TLXbar
 
     // Print the ID mapping
     if (false) {
-      println(s"XBar ${name} mapping:")
+      println(s"XBar mapping:")
       (edgesIn zip inputIdRanges).zipWithIndex.foreach { case ((edge, id), i) =>
         println(s"\t$i assigned ${id} for ${edge.client.clients.map(_.name).mkString(", ")}")
       }
@@ -313,7 +313,6 @@ object TLXbar
     input.ready := Mux1H(select, filtered.map(_.ready))
     filtered
   }
-
 }
 
 /** Synthesizeable unit tests */

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -64,8 +64,15 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
       println (s"!!! WARNING !!!")
     }
 
-    val (io_in, edgesIn) = node.in.unzip
-    val (io_out, edgesOut) = node.out.unzip
+    crossbar(node.in, node.out)
+  }
+}
+
+object TLXbar
+{
+  def crossbar(in: Seq[(TLBundle, TLEdge)], out: Seq[(TLBundle, TLEdge)]) {
+    val (io_in, edgesIn) = in.unzip
+    val (io_out, edgesOut) = out.unzip
 
     // Not every master need connect to every slave on every channel; determine which connections are necessary
     val reachableIO = edgesIn.map { cp => edgesOut.map { mp =>
@@ -261,10 +268,7 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
       TLArbiter(policy)(in(i).d, filter(beatsDO zip portsDIO(i), connectDIO(i)):_*)
     }
   }
-}
 
-object TLXbar
-{
   def apply(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters): TLNode =
   {
     val xbar = LazyModule(new TLXbar(policy))
@@ -309,6 +313,7 @@ object TLXbar
     input.ready := Mux1H(select, filtered.map(_.ready))
     filtered
   }
+
 }
 
 /** Synthesizeable unit tests */

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -80,6 +80,7 @@ class WithTLXbarUnitTests extends Config((site, here, up) => {
     val txns = 100 * site(TestDurationMultiplier)
     val timeout = 50000 * site(TestDurationMultiplier)
     Seq(
+      Module(new TLJbarTest(3, 2,           txns=5*txns, timeout=timeout)),
       Module(new TLRAMXbarTest(1,           txns=5*txns, timeout=timeout)),
       Module(new TLRAMXbarTest(2,           txns=5*txns, timeout=timeout)),
       Module(new TLRAMXbarTest(8,           txns=5*txns, timeout=timeout)),


### PR DESCRIPTION
**Type of change**: feature request
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation

**Release Notes**
Junction nodes are a bit esoteric. You need them when you need, for example, a 2:1 arbiter, but several times. Suppose you had N banks of L2 and wanted to connect those to two different driver crossbars. In that case you can do this:

```
l2banks.node :*= jbar.node
jbar.node :*= xbar1.node
jbar.node :*= xbar2.node
```

If the L2 has 4 banks, now there are 4 egress ports on both xbar1 and xbar2 and they are arbitrated by the jbar.