### PR TITLE
AXIS: add diplomatic AXI-Stream support

### DIFF
--- a/src/main/scala/amba/axis/Bundles.scala
+++ b/src/main/scala/amba/axis/Bundles.scala
@@ -1,0 +1,43 @@
+// See LICENSE.SiFive for license details.
+package freechips.rocketchip.amba.axis
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.util._
+
+sealed trait AXISKey
+case object AXISLast extends ControlKey[Bool]("last", _ := true.B) with AXISKey
+case object AXISId   extends ControlKey[UInt]("id",   _ := 0.U)    with AXISKey
+case object AXISDest extends ControlKey[UInt]("dest", _ := 0.U)    with AXISKey
+case object AXISKeep extends DataKey   [UInt]("keep", _ := ~0.U)   with AXISKey
+case object AXISStrb extends DataKey   [UInt]("strb", _ := ~0.U)   with AXISKey
+case object AXISData extends DataKey   [UInt]("data", _ := 0.U)    with AXISKey
+
+class AXISBundleBits(val params: AXISBundleParameters) extends BundleMap(AXISBundle.keys(params)) {
+  override def cloneType: this.type = (new AXISBundleBits(params)).asInstanceOf[this.type]
+  def last = if (params.hasLast) apply(AXISLast) else true.B
+  def id   = if (params.hasId)   apply(AXISId)   else 0.U
+  def dest = if (params.hasDest) apply(AXISDest) else 0.U
+  def keep = if (params.hasKeep) apply(AXISKeep) else ~0.U(params.keepBits.W)
+  def strb = if (params.hasStrb) apply(AXISStrb) else ~0.U(params.strbBits.W)
+  def data = if (params.hasData) apply(AXISData) else 0.U(params.dataBits.W)
+}
+
+class AXISBundle(val params: AXISBundleParameters) extends DecoupledIO(new AXISBundleBits(params)) {
+  override def cloneType: this.type = (new AXISBundle(params)).asInstanceOf[this.type]
+}
+
+object AXISBundle {
+  def apply(params: AXISBundleParameters) = new AXISBundle(params)
+  def standardKeys(params: AXISBundleParameters) = {
+    def maybe(b: Boolean, x: BundleField): Seq[BundleField] = if (b) List(x) else Nil
+    maybe(params.hasLast, AXISLast(Bool()))                  ++
+    maybe(params.hasId,   AXISId  (UInt(params.idBits  .W))) ++
+    maybe(params.hasDest, AXISDest(UInt(params.destBits.W))) ++
+    maybe(params.hasKeep, AXISKeep(UInt(params.keepBits.W))) ++
+    maybe(params.hasStrb, AXISStrb(UInt(params.strbBits.W))) ++
+    maybe(params.hasData, AXISData(UInt(params.dataBits.W)))
+  }
+  def keys(params: AXISBundleParameters) =
+    standardKeys(params) ++ params.userFields
+}

--- a/src/main/scala/amba/axis/Nodes.scala
+++ b/src/main/scala/amba/axis/Nodes.scala
@@ -1,0 +1,36 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.amba.axis
+
+import chisel3._
+import chisel3.util._
+import chisel3.internal.sourceinfo.SourceInfo
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+object AXISImp extends SimpleNodeImp[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
+{
+  def edge(pd: AXISMasterPortParameters, pu: AXISSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXISEdgeParameters.v1(pd, pu, p, sourceInfo)
+  def bundle(e: AXISEdgeParameters) = AXISBundle(e.bundle)
+  def render(e: AXISEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, (e.beatBytes * 8).toString)
+
+  override def mixO(pd: AXISMasterPortParameters, node: OutwardNode[AXISMasterPortParameters, AXISSlavePortParameters, AXISBundle]): AXISMasterPortParameters  =
+    pd.v1copy(masters = pd.masters.map  { c => c.v1copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: AXISSlavePortParameters, node: InwardNode[AXISMasterPortParameters, AXISSlavePortParameters, AXISBundle]): AXISSlavePortParameters =
+    pu.v1copy(slaves  = pu.slaves.map { m => m.v1copy (nodePath = node +: m.nodePath) })
+}
+
+case class AXISMasterNode(portParams: Seq[AXISMasterPortParameters])(implicit valName: ValName) extends SourceNode(AXISImp)(portParams)
+case class AXISSlaveNode(portParams: Seq[AXISSlavePortParameters])(implicit valName: ValName) extends SinkNode(AXISImp)(portParams)
+case class AXISNexusNode(
+  masterFn:       Seq[AXISMasterPortParameters] => AXISMasterPortParameters,
+  slaveFn:        Seq[AXISSlavePortParameters]  => AXISSlavePortParameters)(
+  implicit valName: ValName)
+  extends NexusNode(AXISImp)(masterFn, slaveFn)
+
+case class AXISAdapterNode(
+  masterFn:  AXISMasterPortParameters => AXISMasterPortParameters = { m => m },
+  slaveFn:   AXISSlavePortParameters  => AXISSlavePortParameters  = { s => s })(
+  implicit valName: ValName)
+  extends AdapterNode(AXISImp)(masterFn, slaveFn)
+case class AXISIdentityNode()(implicit valName: ValName) extends IdentityNode(AXISImp)()

--- a/src/main/scala/amba/axis/Parameters.scala
+++ b/src/main/scala/amba/axis/Parameters.scala
@@ -1,0 +1,307 @@
+// See LICENSE.SiFive for license details.
+package freechips.rocketchip.amba.axis
+
+import chisel3._
+import chisel3.util._
+import chisel3.internal.sourceinfo.SourceInfo
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.util.BundleField
+import freechips.rocketchip.diplomacy._
+
+class AXISSlaveParameters private (
+  val name:          String,
+  val supportsSizes: TransferSizes,
+  val destinationId: Int,
+  val resources:     Seq[Resource],
+  val nodePath:      Seq[BaseNode])
+{
+  require (!supportsSizes.none)
+  require (destinationId >= 0)
+
+  def v1copy(
+      name:          String        = name,
+      supportsSizes: TransferSizes = supportsSizes,
+      destinationId: Int           = destinationId,
+      resources:     Seq[Resource] = resources,
+      nodePath:      Seq[BaseNode] = nodePath) =
+  {
+    new AXISSlaveParameters(
+      name         = name,
+      supportsSizes = supportsSizes,
+      destinationId = destinationId,
+      resources     = resources,
+      nodePath      = nodePath)
+  }
+}
+
+object AXISSlaveParameters {
+  def v1(
+      name:          String,
+      supportsSizes: TransferSizes,
+      destinationId: Int           = 0,
+      resources:     Seq[Resource] = Nil,
+      nodePath:      Seq[BaseNode] = Nil) =
+  {
+    new AXISSlaveParameters(
+      name         = name,
+      supportsSizes = supportsSizes,
+      destinationId = destinationId,
+      resources     = resources,
+      nodePath      = nodePath)
+  }
+}
+
+class AXISSlavePortParameters private (
+  val slaves:        Seq[AXISSlaveParameters],
+  val reqAligned:    Boolean, /* 'Position byte's are unsupported */
+  val reqContinuous: Boolean, /* 'Null byte's inside transfers unsupported */
+  val beatBytes:     Option[Int])
+{
+  require (!slaves.isEmpty)
+  beatBytes.foreach { b => require(isPow2(b)) }
+
+  val endDestinationId = slaves.map(_.destinationId).max + 1
+  val supportsCover = TransferSizes.cover(slaves.map(_.supportsSizes))
+
+  def v1copy(
+    slaves:        Seq[AXISSlaveParameters] = slaves,
+    reqAligned:    Boolean                  = reqAligned,
+    reqContinuous: Boolean                  = reqContinuous,
+    beatBytes:     Option[Int]              = beatBytes) =
+  {
+    new AXISSlavePortParameters(
+      slaves        = slaves,
+      reqAligned    = reqAligned,
+      reqContinuous = reqContinuous,
+      beatBytes     = beatBytes)
+  }
+}
+
+object AXISSlavePortParameters {
+  def v1(
+    slaves:        Seq[AXISSlaveParameters],
+    reqAligned:    Boolean     = false,
+    reqContinuous: Boolean     = false,
+    beatBytes:     Option[Int] = None) =
+  {
+    new AXISSlavePortParameters(
+      slaves        = slaves,
+      reqAligned    = reqAligned,
+      reqContinuous = reqContinuous,
+      beatBytes     = beatBytes)
+  }
+}
+
+class AXISMasterParameters private (
+  val name:       String,
+  val emitsSizes: TransferSizes,
+  val sourceId:   IdRange,
+  val nodePath:   Seq[BaseNode])
+{
+  require (!emitsSizes.none)
+  require (!sourceId.isEmpty)
+
+  def v1copy(
+    name:       String        = name,
+    emitsSizes: TransferSizes = emitsSizes,
+    sourceId:   IdRange       = sourceId,
+    nodePath:   Seq[BaseNode] = nodePath) =
+  {
+    new AXISMasterParameters(
+      name       = name,
+      emitsSizes = emitsSizes,
+      sourceId   = sourceId,
+      nodePath   = nodePath)
+  }
+}
+
+object AXISMasterParameters {
+  def v1(
+    name:       String,
+    emitsSizes: TransferSizes,
+    sourceId:   IdRange       = IdRange(0,1),
+    nodePath:   Seq[BaseNode] = Nil) =
+  {
+    new AXISMasterParameters(
+      name       = name,
+      emitsSizes = emitsSizes,
+      sourceId   = sourceId,
+      nodePath   = nodePath)
+  }
+}
+
+class AXISMasterPortParameters private (
+  val masters:      Seq[AXISMasterParameters],
+  val userFields:   Seq[BundleField],
+  val isAligned:    Boolean, /* there are no 'Position byte's in transfers */
+  val isContinuous: Boolean, /* there are no 'Null byte's except at the end of a transfer */
+  val beatBytes:    Option[Int])
+{
+  require (!masters.isEmpty)
+  beatBytes.foreach { b => require(isPow2(b)) }
+
+  val endSourceId = masters.map(_.sourceId.end).max
+  val emitsCover = TransferSizes.cover(masters.map(_.emitsSizes))
+
+  def v1copy(
+    masters:      Seq[AXISMasterParameters] = masters,
+    userFields:   Seq[BundleField]          = userFields,
+    isAligned:    Boolean                   = isAligned,
+    isContinuous: Boolean                   = isContinuous,
+    beatBytes:    Option[Int]               = beatBytes) =
+  {
+    new AXISMasterPortParameters(
+      masters      = masters,
+      userFields   = userFields,
+      isAligned    = isAligned,
+      isContinuous = isContinuous,
+      beatBytes    = beatBytes)
+  }
+}
+
+object AXISMasterPortParameters {
+  def v1(
+    masters:      Seq[AXISMasterParameters],
+    userFields:   Seq[BundleField] = Nil,
+    isAligned:    Boolean          = false,
+    isContinuous: Boolean          = false,
+    beatBytes:    Option[Int]      = None) =
+  {
+    new AXISMasterPortParameters(
+      masters      = masters,
+      userFields   = userFields,
+      isAligned    = isAligned,
+      isContinuous = isContinuous,
+      beatBytes    = beatBytes)
+  }
+}
+
+class AXISBundleParameters private (
+  val idBits:      Int,
+  val destBits:    Int,
+  val dataBits:    Int,
+  val userFields:  Seq[BundleField],
+  val oneBeat:     Boolean,
+  val aligned:     Boolean)
+{
+  require (idBits >= 0)
+  require (destBits >= 0)
+  require (dataBits >= 8)
+  require (isPow2(dataBits))
+
+  val keepBits = dataBits/8
+  val strbBits = dataBits/8
+
+  def hasLast = !oneBeat
+  def hasId   = idBits > 0
+  def hasDest = destBits > 0
+  def hasKeep = true
+  def hasStrb = !aligned
+  def hasData = true
+
+  def union(x: AXISBundleParameters) = new AXISBundleParameters(
+    idBits      = idBits   max x.idBits,
+    destBits    = destBits max x.destBits,
+    dataBits    = dataBits max x.dataBits,
+    userFields  = (userFields ++ x.userFields).distinct,
+    oneBeat     = oneBeat && x.oneBeat,
+    aligned     = aligned && x.aligned)
+
+  def v1copy(
+    idBits:      Int              = idBits,
+    destBits:    Int              = destBits,
+    dataBits:    Int              = dataBits,
+    userFields:  Seq[BundleField] = userFields,
+    oneBeat:     Boolean          = oneBeat,
+    aligned:     Boolean          = aligned) =
+  {
+    new AXISBundleParameters(
+      idBits     = idBits,
+      destBits   = destBits,
+      dataBits   = dataBits,
+      userFields = userFields,
+      oneBeat    = oneBeat,
+      aligned    = aligned)
+  }
+}
+
+object AXISBundleParameters {
+  val emptyBundleParams = new AXISBundleParameters(
+    idBits      = 0,
+    destBits    = 0,
+    dataBits    = 8,
+    userFields  = Nil,
+    oneBeat     = true,
+    aligned     = true)
+  def union(x: Seq[AXISBundleParameters]) = x.foldLeft(emptyBundleParams)((x,y) => x.union(y))
+
+  def v1(
+    idBits:      Int,
+    destBits:    Int,
+    dataBits:    Int,
+    userFields:  Seq[BundleField],
+    oneBeat:     Boolean,
+    aligned:     Boolean) =
+  {
+    new AXISBundleParameters(
+      idBits     = idBits,
+      destBits   = destBits,
+      dataBits   = dataBits,
+      userFields = userFields,
+      oneBeat    = oneBeat,
+      aligned    = aligned)
+  }
+}
+
+class AXISEdgeParameters private (
+  val master:     AXISMasterPortParameters,
+  val slave:      AXISSlavePortParameters,
+  val params:     Parameters,
+  val sourceInfo: SourceInfo)
+{
+  require (!slave.beatBytes.isEmpty || !master.beatBytes.isEmpty,
+    s"Neither master nor slave port specify a bus width (insert an AXISBusBinder between them?) at ${sourceInfo}")
+  require (slave.beatBytes.isEmpty || master.beatBytes.isEmpty || slave.beatBytes == master.beatBytes,
+    s"Master and slave ports specify incompatible bus widths (insert an AXISWidthWidget between them?) at ${sourceInfo}")
+  require (!slave.reqAligned || master.isAligned, s"Slave port requires aligned stream data at ${sourceInfo}")
+  require (!slave.reqContinuous || master.isContinuous, s"Slave port requires continuous stream data at ${sourceInfo}")
+
+  val beatBytes = slave.beatBytes.getOrElse(master.beatBytes.get)
+  val transferSizes = master.emitsCover intersect slave.supportsCover
+
+  val bundle = AXISBundleParameters.v1(
+    idBits      = log2Ceil(master.endSourceId),
+    destBits    = log2Ceil(slave.endDestinationId),
+    dataBits    = beatBytes * 8,
+    userFields  = master.userFields,
+    oneBeat     = transferSizes.max <= beatBytes,
+    aligned     = master.isAligned)
+
+  def v1copy(
+    master:     AXISMasterPortParameters = master,
+    slave:      AXISSlavePortParameters  = slave,
+    params:     Parameters               = params,
+    sourceInfo: SourceInfo               = sourceInfo) =
+  {
+    new AXISEdgeParameters(
+      master     = master,
+      slave      = slave,
+      params     = params,
+      sourceInfo = sourceInfo)
+  }
+}
+
+object AXISEdgeParameters {
+  def v1(
+    master:     AXISMasterPortParameters,
+    slave:      AXISSlavePortParameters,
+    params:     Parameters,
+    sourceInfo: SourceInfo) =
+  {
+    new AXISEdgeParameters(
+      master     = master,
+      slave      = slave,
+      params     = params,
+      sourceInfo = sourceInfo)
+  }
+}

--- a/src/main/scala/amba/axis/Xbar.scala
+++ b/src/main/scala/amba/axis/Xbar.scala
@@ -1,0 +1,133 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.amba.axis
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+class AXISXbar(beatBytes: Int, policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) extends LazyModule
+{
+  val node = AXISNexusNode(
+    masterFn  = { seq =>
+      seq.foreach { port => require(port.userFields == seq(0).userFields) }
+      seq(0).v1copy(
+        beatBytes = Some(beatBytes),
+        masters = (AXISXbar.mapInputIds(seq) zip seq) flatMap { case (range, port) =>
+          port.masters map { master => master.v1copy(sourceId = master.sourceId.shift(range.start))}})},
+    slaveFn = { seq =>
+      seq(0).v1copy(
+        beatBytes = Some(beatBytes),
+        slaves = (AXISXbar.mapOutputIds(seq) zip seq) flatMap { case (range, port) =>
+          port.slaves.map { slave => slave.v1copy(destinationId = slave.destinationId + range.start)}})})
+
+  lazy val module = new LazyModuleImp(this) {
+    val (io_in, edgesIn) = node.in.unzip
+    val (io_out, edgesOut) = node.out.unzip
+
+    // Grab the port ID mapping
+    val inputIdRanges = AXISXbar.mapInputIds(edgesIn.map(_.master))
+    val outputIdRanges = AXISXbar.mapOutputIds(edgesOut.map(_.slave))
+
+    // We need an intermediate size of bundle with the widest possible identifiers
+    val wide_bundle = AXISBundleParameters.union(io_in.map(_.params) ++ io_out.map(_.params))
+
+    // Handle size = 1 gracefully (Chisel3 empty range is broken)
+    def trim(id: UInt, size: Int) = if (size <= 1) 0.U else id(log2Ceil(size)-1, 0)
+
+    // Transform input bundle sources (dest uses global namespace on both sides)
+    val in = Wire(Vec(io_in.size, AXISBundle(wide_bundle)))
+    for (i <- 0 until in.size) {
+      io_in(i).ready := in(i).ready
+      in(i).valid    := io_in(i).valid
+      in(i).bits     := io_in(i).bits
+      if (in(i).params.hasId) {
+        in(i).bits.id  := io_in(i).bits.id | inputIdRanges(i).start.U
+      }
+    }
+
+    // Transform output bundle sinks (id use global namespace on both sides)
+    val out = Wire(Vec(io_out.size, AXISBundle(wide_bundle)))
+    for (o <- 0 until out.size) {
+      out(o).ready        := io_out(o).ready
+      io_out(o).valid     := out(o).valid
+      io_out(o).bits      := out(o).bits
+      if (io_out(o).params.hasDest) {
+        io_out(o).bits.dest := trim(out(o).bits.dest, outputIdRanges(o).size)
+      }
+    }
+
+    // Fanout the input sources to the output sinks
+    val request = in.map { i => outputIdRanges.map { o => o.contains(i.bits.dest) } }
+    val ports = (in zip request) map { case (i, r) => AXISXbar.fanout(i, r) }
+
+    // Arbitrate amongst the sources
+    (out zip ports.transpose) map { case (o, i) => AXISXbar.arbitrate(policy)(o, i) }
+  }
+}
+
+object AXISXbar
+{
+  def apply(beatBytes: Int, policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters): AXISNode =
+  {
+    val xbar = LazyModule(new AXISXbar(beatBytes, policy))
+    xbar.node
+  }
+
+  def mapInputIds (ports: Seq[AXISMasterPortParameters]) = TLXbar.assignRanges(ports.map(_.endSourceId))
+  def mapOutputIds(ports: Seq[AXISSlavePortParameters]) = TLXbar.assignRanges(ports.map(_.endDestinationId))
+
+  def arbitrate(policy: TLArbiter.Policy)(sink: AXISBundle, sources: Seq[AXISBundle]) {
+    if (sources.isEmpty) {
+      sink.valid := false.B
+    } else if (sources.size == 1) {
+      sink.valid := sources.head.valid
+      sink.bits  := sources.head.bits
+      sources.head.ready := sink.ready
+    } else {
+      // The number of beats which remain to be sent
+      val idle = RegInit(true.B)
+      when (sink.fire()) { idle := sink.bits.last }
+
+      // Winner (if any) claims sink
+      val latch = idle && sink.ready
+
+      // Who wants access to the sink?
+      val valids = sources.map(_.valid)
+      // Arbitrate amongst the requests
+      val readys = VecInit(policy(valids.size, Cat(valids.reverse), latch).asBools)
+      // Which request wins arbitration?
+      val winner = VecInit((readys zip valids) map { case (r,v) => r&&v })
+
+      // Confirm the policy works properly
+      require (readys.size == valids.size)
+      // Never two winners
+      val prefixOR = winner.scanLeft(false.B)(_||_).init
+      assert((prefixOR zip winner) map { case (p,w) => !p || !w } reduce {_ && _})
+      // If there was any request, there is a winner
+      assert (!valids.reduce(_||_) || winner.reduce(_||_))
+
+      // The one-hot source granted access in the previous cycle
+      val state = RegInit(VecInit.tabulate(sources.size)(_ => false.B))
+      val muxState = Mux(idle, winner, state)
+      state := muxState
+
+      val allowed = Mux(idle, readys, state)
+      (sources zip allowed) foreach { case (s, r) => s.ready := sink.ready && r }
+      sink.valid := Mux(idle, valids.reduce(_||_), Mux1H(state, valids))
+      sink.bits := Mux1H(muxState, sources.map(_.bits))
+    }
+  }
+
+  def fanout(input: AXISBundle, select: Seq[Bool]): Seq[AXISBundle] = {
+    val filtered = Wire(Vec(select.size, chiselTypeOf(input)))
+    for (i <- 0 until select.size) {
+      filtered(i).bits := input.bits
+      filtered(i).valid := input.valid && (select(i) || (select.size == 1).B)
+    }
+    input.ready := Mux1H(select, filtered.map(_.ready))
+    filtered
+  }
+}

--- a/src/main/scala/amba/axis/package.scala
+++ b/src/main/scala/amba/axis/package.scala
@@ -1,0 +1,13 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.amba
+
+import chisel3._
+import freechips.rocketchip.diplomacy._
+
+package object axis
+{
+  type AXISInwardNode = InwardNodeHandle[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
+  type AXISOutwardNode = OutwardNodeHandle[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
+  type AXISNode = NodeHandle[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle, AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
+}

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -97,15 +97,26 @@ case class TransferSizes(min: Int, max: Int)
     if (x.max < min || max < x.min) TransferSizes.none
     else TransferSizes(scala.math.max(min, x.min), scala.math.min(max, x.max))
   
-  def smallestintervalcover(x: TransferSizes) = TransferSizes(if (min == 0 || x.min == 0) scala.math.max(min, x.min) else scala.math.min(min, x.min), scala.math.max(max, x.max))
+  // Not a union, because the result may contain sizes contained by neither term
+  def cover(x: TransferSizes) = {
+    if (none) {
+      x
+    } else if (x.none) {
+      this
+    } else {
+      TransferSizes(scala.math.min(min, x.min), scala.math.max(max, x.max))
+    }
+  }
 
   override def toString() = "TransferSizes[%d, %d]".format(min, max)
-
 }
 
 object TransferSizes {
   def apply(x: Int) = new TransferSizes(x)
   val none = new TransferSizes(0)
+
+  def cover(seq: Seq[TransferSizes]) = seq.foldLeft(none)(_ cover _)
+  def intersect(seq: Seq[TransferSizes]) = seq.reduce(_ intersect _)
 
   implicit def asBool(x: TransferSizes) = !x.none
 }

--- a/src/main/scala/util/BundleMap.scala
+++ b/src/main/scala/util/BundleMap.scala
@@ -1,0 +1,42 @@
+// See LICENSE.SiFive for license details.
+package freechips.rocketchip.util
+
+import chisel3._
+import chisel3.util._
+import scala.collection.immutable.ListMap
+
+case class BundleField(key: BundleKeyBase, data: Data)
+{
+  def getDefault = {
+    val out = Wire(chiselTypeOf(data))
+    key.setDefault(out)
+    out
+  }
+}
+
+sealed trait BundleKeyBase {
+  def name: String
+  def setDefault(x: Data): Unit
+}
+
+sealed class BundleKey[T <: Data](val name: String, setDefaultArg: T => Unit) extends BundleKeyBase {
+  def apply(data: T) = BundleField(this, data)
+  def setDefault(x: Data): Unit = setDefaultArg(x.asInstanceOf[T])
+}
+
+object BundleKey {
+  def setDefaultZero(x: Data): Unit = {
+    x := 0.U.asTypeOf(x)
+  }
+}
+
+class    DataKey[T <: Data](name: String, setDefaultArg: T => Unit = BundleKey.setDefaultZero(_)) extends BundleKey[T](name, setDefaultArg)
+class ControlKey[T <: Data](name: String, setDefaultArg: T => Unit = BundleKey.setDefaultZero(_)) extends BundleKey[T](name, setDefaultArg)
+
+class BundleMap(val fields: Seq[BundleField]) extends Record {
+  require(fields.map(_.key.name).distinct.size == fields.size)
+  override def cloneType: this.type = (new BundleMap(fields)).asInstanceOf[this.type]
+  val elements = ListMap(fields.map { bf => bf.key.name -> chisel3.experimental.DataMirror.internal.chiselTypeClone(bf.data) } :_*)
+  def apply[T <: Data](key: BundleKey[T]) = elements(key.name).asInstanceOf[T]
+}
+


### PR DESCRIPTION
**Type of change**: feature request
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation
**Release Notes**
This adds support for AXI-Stream connections diplomatically. It also prototypes several innovations we should port back to the other diplomatic busses:
1. BundleMap allows us to systematically add 'user' fields to busses with associated meta-data and categorization which helps adapters operate on fields they don't know anything about
2. beatBytes as an Option. This lets the bus width be controlled by common attachment points instead of slaves.
3. all Parameters are classes with private destructor, without unapply, and with versioned copy and constructors -> this allows us to upgrade the parameter API in a backwards compatible manner
4. all Parameters contain their duals in Master/Slave parameters