### PR TITLE
refactor HasBusAttachmentFunction to be purely abstract

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -105,7 +105,7 @@ trait DeviceInterrupts
   def describeInterrupts(resources: ResourceBindings): Map[String, Seq[ResourceValue]] = {
     val int = resources("int")
 
-    int.foreach { b => require (b.device.isDefined, "Device ${devname} property 'int' is missing user device") }
+    int.foreach { b => require (b.device.isDefined, s"Device ${this} property 'int' is missing user device") }
     val parents = int.map(_.device.get).distinct
     val simple = parents.size == 1 && !alwaysExtended
 


### PR DESCRIPTION
Continued refinement of the new `HasBusAttachmentFunction` trait that allows devices to Config-urably select to which TL bus they would like to be attached.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation
