### PR TITLE
Ignore rs1/rs2 in FENCE.I

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -436,6 +436,11 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     when (id_ctrl.mem_cmd.isOneOf(M_SFENCE, M_FLUSH_ALL)) {
       ex_reg_mem_size := Cat(id_raddr2 =/= UInt(0), id_raddr1 =/= UInt(0))
     }
+    if (tile.dcache.flushOnFenceI) {
+      when (id_ctrl.fence_i) {
+        ex_reg_mem_size := 0
+      }
+    }
 
     for (i <- 0 until id_raddr.size) {
       val do_bypass = id_bypass_src(i).reduce(_||_)


### PR DESCRIPTION
We were failing to ignore rs1/rs2 for configs that require a D$
flush on FENCE.I.  Configs with coherence hubs/L2$ are unaffected.

Software workaround is to keep rs1=rs2=x0 (which software really
should be doing anyway).
