### PR TITLE
Add LazyModule.with* methods for clock/reset scope

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -16,6 +16,9 @@ abstract class LazyModule()(implicit val p: Parameters)
   protected[diplomacy] var info: SourceInfo = UnlocatableSourceInfo
   protected[diplomacy] val parent = LazyModule.scope
 
+  // Wrapper function used for with(Clock|Reset) scoping, see LazyModule.withClock
+  private[diplomacy] var wrap: LazyModuleImpLike => LazyModuleImpLike = identity
+
   // code snippets from 'InModuleBody' injection
   protected[diplomacy] var inModuleBody = List[() => Unit]()
 
@@ -136,6 +139,28 @@ object LazyModule
     if (!bc.suggestedNameVar.isDefined) bc.suggestName(valName.name)
     bc
   }
+
+  import chisel3.{Clock, Reset}
+
+  def withClock[T <: LazyModule](clock: => Clock)(bc: T)(implicit valName: ValName, sourceInfo: SourceInfo): T = {
+    val res = apply(bc)
+    res.wrap = (x: LazyModuleImpLike) => chisel3.withClock(clock)(x)
+    res
+  }
+
+  def withReset[T <: LazyModule](reset: => Reset)(bc: T)(implicit valName: ValName, sourceInfo: SourceInfo): T = {
+    val res = apply(bc)
+    res.wrap = (x: LazyModuleImpLike) => chisel3.withReset(reset)(x)
+    res
+  }
+
+  def withAndClock[T <: LazyModule](clock: => Clock, reset: => Reset)
+                                   (bc: T)
+                                   (implicit valName: ValName, sourceInfo: SourceInfo): T = {
+    val res = apply(bc)
+    res.wrap = (x: LazyModuleImpLike) => chisel3.withClockAndReset(clock, reset)(x)
+    res
+  }
 }
 
 sealed trait LazyModuleImpLike extends RawModule
@@ -155,7 +180,7 @@ sealed trait LazyModuleImpLike extends RawModule
   protected[diplomacy] def instantiate() = {
     val childDangles = wrapper.children.reverse.flatMap { c =>
       implicit val sourceInfo = c.info
-      val mod = Module(c.module)
+      val mod = c.wrap(Module(c.module))
       mod.finishInstantiate()
       mod.dangles
     }


### PR DESCRIPTION
Adds LazyModule.withClock, LazyModule.withReset, and
LazyModule.withClockAndReset to support setting custom clocks and resets
for LazyModuleImps

This enables using Chisels `with*` APIs in `LazyModules`. Currently, child `LazyModuleImps` will get the clock and reset from their parent (defaulting to false in `LazyRawModuleImps`), with the expectation that the user will override via direct connections. this doesn't work for changing the reset type because FIRRTL requires that the type of all reset connections are the same. Arguably, FIRRTL should be changed to allow last-connect semantics to override inferred reset type, but regardless, it seems useful to enable using the `with*` APIs on `LazyModuleImps`.

Example:
```scala
class MyLazyModule extends LazyModule {
  val child = LazyModule.withReset(module.syncReset)(new MyChildLazyModule)

  lazy val module = new LazyModuleImp(this) {
    val syncReset = MyAsyncToSyncConverter(reset)
     ...
  }
}
```

I haven't quite figured out how to test this, so I'm opening this draft PR to show the proposed API.


<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Adds LazyModule.withClock, LazyModule.withReset, and
LazyModule.withClockAndReset to support setting custom clocks and resets
for LazyModuleImps