### PR TITLE
Add chicken bit to disable speculative I$ refill

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -159,7 +159,8 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   icache.io.s1_paddr := tlb.io.resp.paddr
   icache.io.s2_vaddr := s2_pc
   icache.io.s1_kill := s2_redirect || tlb.io.resp.miss || s2_replay
-  icache.io.s2_kill := s2_speculative && !s2_tlb_resp.cacheable || s2_xcpt
+  val s2_can_speculatively_refill = s2_tlb_resp.cacheable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableSpeculativeICacheRefill
+  icache.io.s2_kill := s2_speculative && !s2_can_speculatively_refill || s2_xcpt
   icache.io.s2_prefetch := s2_tlb_resp.prefetchable
 
   fq.io.enq.valid := RegNext(s1_valid) && s2_valid && (icache.io.resp.valid || !s2_tlb_resp.miss && icache.io.s2_kill)

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -76,7 +76,8 @@ class RocketCustomCSRs(implicit p: Parameters) extends CustomCSRs with HasRocket
     val mask = BigInt(
       tileParams.dcache.get.clockGate.toInt << 0 |
       rocketParams.clockGate.toInt << 1 |
-      rocketParams.clockGate.toInt << 2
+      rocketParams.clockGate.toInt << 2 |
+      1 << 3 // disableSpeculativeICacheRefill
     )
     Some(CustomCSR(chickenCSRId, mask, Some(mask)))
   }

--- a/src/main/scala/tile/CustomCSRs.scala
+++ b/src/main/scala/tile/CustomCSRs.scala
@@ -37,6 +37,7 @@ class CustomCSRs(implicit p: Parameters) extends CoreBundle {
   def disableDCacheClockGate = getOrElse(chickenCSR, _.value(0), true.B)
   def disableICacheClockGate = getOrElse(chickenCSR, _.value(1), true.B)
   def disableCoreClockGate = getOrElse(chickenCSR, _.value(2), true.B)
+  def disableSpeculativeICacheRefill = getOrElse(chickenCSR, _.value(3), true.B)
 
   protected def getByIdOrElse[T](id: Int, f: CustomCSRIO => T, alt: T): T = {
     val idx = decls.indexWhere(_.id == id)


### PR DESCRIPTION
This is mostly intended as a post-silicon debug feature to eliminate a common source of spurious events.
