### PR TITLE
Extend I$ speculative refill chicken bit to disable prefetching, too

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -161,7 +161,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   icache.io.s1_kill := s2_redirect || tlb.io.resp.miss || s2_replay
   val s2_can_speculatively_refill = s2_tlb_resp.cacheable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableSpeculativeICacheRefill
   icache.io.s2_kill := s2_speculative && !s2_can_speculatively_refill || s2_xcpt
-  icache.io.s2_prefetch := s2_tlb_resp.prefetchable
+  icache.io.s2_prefetch := s2_tlb_resp.prefetchable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableICachePrefetch
 
   fq.io.enq.valid := RegNext(s1_valid) && s2_valid && (icache.io.resp.valid || !s2_tlb_resp.miss && icache.io.s2_kill)
   fq.io.enq.bits.pc := s2_pc

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -77,10 +77,13 @@ class RocketCustomCSRs(implicit p: Parameters) extends CustomCSRs with HasRocket
       tileParams.dcache.get.clockGate.toInt << 0 |
       rocketParams.clockGate.toInt << 1 |
       rocketParams.clockGate.toInt << 2 |
-      1 << 3 // disableSpeculativeICacheRefill
+      1 << 3 | // disableSpeculativeICacheRefill
+      tileParams.icache.get.prefetch.toInt << 17
     )
     Some(CustomCSR(chickenCSRId, mask, Some(mask)))
   }
+
+  def disableICachePrefetch = getOrElse(chickenCSR, _.value(17), true.B)
 
   def marchid = CustomCSR.constant(CSRs.marchid, BigInt(1))
 


### PR DESCRIPTION
This is also just for post-silicon debug purposes.  Disabling prefetch
doesn't add much extra PSD benefit beyond disabling speculative refill,
because the latter disables prefetching on speculative accesses already,
leaving only next-line prefetches following non-speculative refills.
But it is worth something.
