### PR TITLE
Bump firrtl

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -15,7 +15,7 @@
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "b68443762a1708492f84edc1901a0750c9f37cc4",
+        "commit": "52a1ee81fccdc05c80b662fb2daf236cc5c4560b",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
This enables using FIRRTL's reset inference with Diplomatic LazyModule hierarchies.

Replaces https://github.com/chipsalliance/rocket-chip/pull/2230

### Summary of changes

#### Features
* Reset inference now supports last connect semantics

#### Fixes
* FirrtlOptions and CircuitOptions no longer serialized to anno JSON file

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
* Bumped FIRRTL on release branch `1.2.x` just beyond `1.2.2`