### PR TITLE
Adding case object for looking up base tile params

### DIFF
--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -12,6 +12,8 @@ import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
+case object BuildBaseTile extends Field[Seq[Parameters => BaseTile]](Nil)
+
 case object TileVisibilityNodeKey extends Field[TLEphemeralNode]
 case object TileKey extends Field[TileParams]
 case object ResetVectorBits extends Field[Int]
@@ -67,7 +69,7 @@ trait HasNonDiplomaticTileParameters {
   def masterPortBeatBytes = p(SystemBusKey).beatBytes
 
   // TODO make HellaCacheIO diplomatic and remove this brittle collection of hacks
-  //                  Core   PTW                DTIM                    coprocessors           
+  //                  Core   PTW                DTIM                    coprocessors
   def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + p(BuildRoCC).size + tileParams.core.useVector.toInt
 
   // TODO merge with isaString in CSR.scala


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
-->
Add the case object for creating a sequence of parameters in the base tiles, so its parameters can be looked up from `subsystem/Configs.scala`. For instance, one can specify different clock crossings to different tiles like:
```
... extends Config((site, here, up) => {
  case BuildBaseTile => site(TileKey).hartId match {
    case 0: List(RocketCrossingParams(
      crossingType = SynchronousCrossing()
    case 1: List(RocketCrossingParams(
      crossingType = AsynchronousCrossing()
    ...
})
