### PR TITLE
Fix Dcache Tag ECC coverpoints

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -985,9 +985,9 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
         Seq(CoverBoolean(true.B, Seq("never_flush")))
       }
     val tag_error_cover = Seq(
-      CoverBoolean( !metaArb.io.in(1).valid, Seq("no_tag_error")),
-      CoverBoolean( metaArb.io.in(1).valid && !s2_meta_error_uncorrectable, Seq("tag_correctable_error")),
-      CoverBoolean( metaArb.io.in(1).valid && s2_meta_error_uncorrectable, Seq("tag_uncorrectable_error")))
+      CoverBoolean( !s2_meta_error, Seq("no_tag_error")),
+      CoverBoolean( s2_meta_error && !s2_meta_error_uncorrectable, Seq("tag_correctable_error")),
+      CoverBoolean( s2_meta_error && s2_meta_error_uncorrectable, Seq("tag_uncorrectable_error")))
     cover(new CrossProperty(
       Seq(data_error_type, data_error_dirty, request_source, tag_error_cover),
       Seq(),


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: The ecc coverpoints for the tag array were generated even when there was no ecc enabled in the tag array

<!-- choose one -->
**Type of change**: cover point fix 

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
