### PR TITLE
Fix offsets of DMOuter registers in Object Model.

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -38,11 +38,42 @@ class DebugLogicalTreeNode(
   dmOuter: () => TLDebugModuleOuterAsync,
   dmInner: () => TLDebugModuleInnerAsync
 )(implicit val p: Parameters) extends LogicalTreeNode(() => Some(device)) {
+  /**
+   * Translate register field offsets to account for the fact that the dmOuter
+   * registers are offset from the base DebugModule address.
+   *
+   * Although the rocket-chip regmap helper takes offsets that are relative to
+   * the base of the register address block, for the Object Model we have
+   * decided to collapse the two separate DebugModule register address blocks
+   * into a single one, so we need to account for the dmOuter offset.
+   */
+  private def translateDMOuterRegisterOffsets(regMap: OMRegisterMap): OMRegisterMap = {
+    val addressSets = dmOuter().dmOuter.dmiNode.address
+    addressSets.foreach { addressSet =>
+      require(
+        addressSet.contiguous,
+        s"DebugLogicalTree address logic currently assumes contiguous AddressSets; ${addressSet} is not contiguous"
+      )
+    }
+
+    val baseAddressBytes = addressSets.map(_.base).reduceLeft(_ min _)
+
+    regMap.copy(
+      registerFields = regMap.registerFields.map(
+        field => field.copy(
+          bitRange = field.bitRange.copy(
+            base = field.bitRange.base + baseAddressBytes * 8
+          )
+        )
+      )
+    )
+  }
+
   def getOMDebug(resourceBindings: ResourceBindings): Seq[OMComponent] = {
     val nComponents: Int = dmOuter().dmOuter.module.getNComponents()
     val needCustom: Boolean = dmInner().dmInner.module.getNeedCustom()
     val omInnerRegMap: OMRegisterMap = dmInner().dmInner.module.omRegMap
-    val omOuterRegMap: OMRegisterMap = dmOuter().dmOuter.module.omRegMap
+    val omOuterRegMap: OMRegisterMap = translateDMOuterRegisterOffsets(dmOuter().dmOuter.module.omRegMap)
     val cfg: DebugModuleParams = dmInner().dmInner.getCfg()
 
     val omRegMap = OMRegisterMap(


### PR DESCRIPTION
The previous Object Model implementation did not account for the relative offset of the dmOuter register address block. This commit adds some logic to translate the offsets into absolute addresses.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
There was a bug in the generated Object Model for the Debug Module, where the register field bit offsets were incorrect. This has now been corrected.