### PR TITLE
Rocket Core DCache TileLink: dont require Fifo just yet

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -93,7 +93,6 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   require(eccBytes == 1 || !dECC.isInstanceOf[IdentityCode])
   val usingRMW = eccBytes > 1 || usingAtomicsInCache
   val mmioOffset = outer.firstMMIO
-  edge.manager.requireFifo(TLFIFOFixer.allVolatile)  // TileLink pipelining MMIO requests
 
   val clock_en_reg = Reg(Bool())
   io.cpu.clock_enabled := clock_en_reg


### PR DESCRIPTION
**Related issue**: https://github.com/chipsalliance/rocket-chip/pull/2246 causes problems in downstream repositories
**Type of change**: bug report
**Impact**: no functional change