### PR TITLE
Rocket Core DCache TileLink: require FIFO to allVolatile regions

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -93,6 +93,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   require(eccBytes == 1 || !dECC.isInstanceOf[IdentityCode])
   val usingRMW = eccBytes > 1 || usingAtomicsInCache
   val mmioOffset = outer.firstMMIO
+  edge.manager.requireFifo(TLFIFOFixer.allVolatile)  // TileLink pipelining MMIO requests
 
   val clock_en_reg = Reg(Bool())
   io.cpu.clock_enabled := clock_en_reg

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -115,8 +115,11 @@ case class TLManagerPortParameters(
   require (endSinkId >= 0, "Sink ids cannot be negative")
   require (minLatency >= 0, "Minimum required latency cannot be negative")
 
-  def requireFifo(policy: TLFIFOFixer.Policy = TLFIFOFixer.allFIFO) = managers.filter(m => policy(m)).foreach { m =>
-    require(m.fifoId == managers.head.fifoId, s"${m.name} had fifoId ${m.fifoId}, which was not homogeneous (${managers.map(s => (s.name, s.fifoId))}) ")
+  def requireFifo(policy: TLFIFOFixer.Policy = TLFIFOFixer.allFIFO) = {
+    val relevant = managers.filter(m => policy(m))
+    relevant.foreach { m =>
+      require(m.fifoId == relevant.head.fifoId, s"${m.name} had fifoId ${m.fifoId}, which was not homogeneous (${managers.map(s => (s.name, s.fifoId))}) ")
+    }
   }
 
   // Bounds on required sizes


### PR DESCRIPTION
**Related issue**: #2246 was incomplete
**Type of change**: other enhancement
**Impact**: no functional change
**Development Phase**: implementation