### PR TITLE
GroundTestTileParams Some(ICacheParams)

### DIFF
--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.rocket.{DCache, NonBlockingDCache, RocketCoreParams}
+import freechips.rocketchip.rocket.{DCache, ICacheParams, NonBlockingDCache, RocketCoreParams}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import scala.collection.mutable.ListBuffer
@@ -20,7 +20,7 @@ trait GroundTestTileParams extends TileParams {
 
   def build(i: Int, p: Parameters): GroundTestTile
   
-  val icache = None
+  val icache = Some(ICacheParams())
   val btb = None
   val rocc = Nil
   val core = RocketCoreParams(nPMPs = 0) //TODO remove this


### PR DESCRIPTION
**Related issue**: https://github.com/chipsalliance/rocket-chip/pull/2238

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

TraceGen in downstream repository needs `Some(ICacheParams)` instead of `None` for
`tileParams.icache.get.prefetch.toInt` at
https://github.com/chipsalliance/rocket-chip/blob/9a1da4e01e3e767451d9ee4a4f0ee8a55a3313da/src/main/scala/rocket/RocketCore.scala#L81