### PR TITLE
Correct spelling of TileLink in Object Model protocol description

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -128,7 +128,7 @@ object OMPortMaker {
     AHBProtocol -> "AMBA 3 AHB-Lite Protocol",
     AXI4Protocol -> "AMBA 3 AXI4-Lite Protocol",
     APBProtocol -> "AMBA 3 APB Protocol",
-    TLProtocol -> "Tile Link specification"
+    TLProtocol -> "TileLink specification"
   )
 
   val protocolSpecificationVersions = Map[ProtocolType, String](


### PR DESCRIPTION
**Related issue**:

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change (I think?)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
This PR makes a minor change to the emitted Object Model to properly spell TileLink (no spaces) in the port protocol description.

---

Tagging @john-sifive and @aisha-w-sifive, who I can't assign as reviewers because they don't have commit access to rocket-chip.