### PR TITLE
Debug: Added rf_reset signals needed by RF transform

### DIFF
--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -285,6 +285,7 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
       val rdLoad       = Output(Vec(cfg.maxSupportedSBAccess/8, Bool()))
       val sbStateOut   = Output(UInt(log2Ceil(SystemBusAccessState.maxId).W))
     })
+    val rf_reset       = IO(Input(Reset()))
 
     import SystemBusAccessState._
  


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Added rf_reset signals at each point where the Full Asynchronous Reset Transform should switch from one reset to another.