### PR TITLE
Remove unused type parameter on RegisterRouter.

### DIFF
--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -107,7 +107,7 @@ class AHBRegisterRouter[B <: AHBRegBundleBase, M <: LazyModuleImp]
 }
 
 /** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
-trait HasAHBControlRegMap { this: RegisterRouter[_] =>
+trait HasAHBControlRegMap { this: RegisterRouter =>
   // Externally, this node should be used to connect the register control port to a bus
   val controlNode = AHBRegisterNode(
     address = address.head,

--- a/src/main/scala/amba/apb/RegisterRouter.scala
+++ b/src/main/scala/amba/apb/RegisterRouter.scala
@@ -90,7 +90,7 @@ class APBRegisterRouter[B <: APBRegBundleBase, M <: LazyModuleImp]
 }
 
 /** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
-trait HasAPBControlRegMap { this: RegisterRouter[_] =>
+trait HasAPBControlRegMap { this: RegisterRouter =>
   // Externally, this node should be used to connect the register control port to a bus
   val controlNode = APBRegisterNode(
     address = address.head,

--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -117,7 +117,7 @@ class AXI4RegisterRouter[B <: AXI4RegBundleBase, M <: LazyModuleImp]
 }
 
 /** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
-trait HasAXI4ControlRegMap { this: RegisterRouter[_] =>
+trait HasAXI4ControlRegMap { this: RegisterRouter =>
   protected val controlNode = AXI4RegisterNode(
     address = address.head,
     concurrency = concurrency,

--- a/src/main/scala/interrupts/RegisterRouter.scala
+++ b/src/main/scala/interrupts/RegisterRouter.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 
 /** Mix this trait into a RegisterRouter to be able to attach its interrupt sources to an interrupt bus */
-trait HasInterruptSources { this: RegisterRouter[_] =>
+trait HasInterruptSources { this: RegisterRouter =>
   def nInterrupts: Int
   protected val intnode = IntSourceNode(IntSourcePortSimple(num = nInterrupts, resources = Seq(Resource(device, "int"))))
 

--- a/src/main/scala/regmapper/RegisterRouter.scala
+++ b/src/main/scala/regmapper/RegisterRouter.scala
@@ -18,7 +18,7 @@ case class RegisterRouterParams(
   undefZero: Boolean = true,
   executable: Boolean = false)
 
-abstract class RegisterRouter[T <: Data](devParams: RegisterRouterParams)(implicit p: Parameters)
+abstract class RegisterRouter(devParams: RegisterRouterParams)(implicit p: Parameters)
     extends LazyModule
     with HasClockDomainCrossing {
 

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -172,7 +172,7 @@ class TLRegisterRouter[B <: TLRegBundleBase, M <: LazyModuleImp](
 // !!! eliminate third trait
 
 /** Mix this trait into a RegisterRouter to be able to attach its register map to a TL bus */
-trait HasTLControlRegMap { this: RegisterRouter[_] =>
+trait HasTLControlRegMap { this: RegisterRouter =>
   protected val controlNode = TLRegisterNode(
     address = address,
     device = device,


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification (I guess this is technically backwards incompatible)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
`RegisterRouter` no longer takes a type parameter, as it was not being used.

---

I was trying to read the definition of `RegisterRouter`, and I was having difficulty understanding what its type parameter `T <: Data` was being used for. As far as I can tell, it is not being used by anything, and simply removing it and making it a non-generic type seems to work fine. If it is in fact actually being used for something, I'd love to learn more about it, since at my current level of understanding of Scala, I can't figure out how it is being used, since none of its members or methods depend on it.