### PR TITLE
Enable Tile Link Printing as part of monitors [WIP]

### DIFF
--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -349,7 +349,8 @@ trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val plicOpt  = p(PLICKey).map { params =>
     val tlbus = attach(p(PLICAttachKey).slaveWhere)
     val plic = LazyModule(new TLPLIC(params, tlbus.beatBytes))
-    plic.node := tlbus.coupleTo("plic") { TLFragmenter(tlbus) := _ }
+    val tmp = tlbus.coupleTo("plic") { TLFragmenter(tlbus) := _ }
+    EnableMonitorPrint("PLIC_TL_IFC", implicit p => plic.node := tmp)
     plic.intnode :=* ibus.toPLIC
     plic
   }

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -12,6 +12,7 @@ import scala.util.matching._
 
 case object MonitorsEnabled extends Field[Boolean](true)
 case object RenderFlipped extends Field[Boolean](false)
+case object MonitorPrintPrefix extends Field[Option[String]](None)
 
 case class RenderedEdge(
   colour:  String,

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -61,6 +61,10 @@ package object diplomacy
     case RenderFlipped => !p(RenderFlipped)
   })
 
+  def EnableMonitorPrint[T](prefix: String, body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
+    case MonitorPrintPrefix => Some(prefix)
+  })
+
   implicit def moduleValue[T](value: ModuleValue[T]): T = value.getWrappedValue
 
   implicit def noCrossing(value: NoCrossing.type): ClockCrossingType = SynchronousCrossing(BufferParams.none)

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -20,7 +20,10 @@ abstract class TLMonitorBase(args: TLMonitorArgs) extends Module
   })
 
   def legalize(bundle: TLBundle, edge: TLEdge, reset: Reset): Unit
+  def print_bundle(bundle: TLBundle, edge: TLEdge, reset: Reset): Unit
+
   legalize(io.in, args.edge, reset)
+  print_bundle(io.in, args.edge, reset)
 }
 
 object TLMonitor {
@@ -563,5 +566,17 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     legalizeFormat   (bundle, edge)
     legalizeMultibeat(bundle, edge)
     legalizeUnique   (bundle, edge)
+  }
+
+  def print_bundle(bundle: TLBundle, edge: TLEdge, reset: Reset){ 
+    edge.params(MonitorPrintPrefix).foreach { prefix => 
+       when (bundle.a.valid && bundle.a.ready) { printf(p"$prefix " + p"${bundle.a}")}
+    }
+    // when (bundle.d.valid) { print(bundle.b) }
+    // if (edge.client.anySupportProbe && edge.manager.anySupportAcquireB) {
+    //  when (bundle.b.valid) { print(c) }
+    //  when (bundle.c.valid) { print(d) }
+    //  when (bundle.e.valid) { print(e) }
+    //}
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**:  API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: proposal

One request has been more "printf" style logging similar to what is output for processor trace. This is a a strawman example of how printfs could be selectively added as part of diplomatic monitors. 

The idea is that using the same scoping mechanism by which monitors are included at all, we can add a Prefix option which when set would make the monitors add a `fprintf`.

The PR as currently done adds the following to the monitor on the TL interface to the PLIC, which only happens if both ready and valid are set.

```
    `ifndef SYNTHESIS
    `ifdef PRINTF_COND
      if (`PRINTF_COND) begin
    `endif
        if (_T_702 & _T_112) begin
          $fwrite(32'h80000002,"PLIC_TL_IFC DecoupledIO(ready -> %d, valid -> %d, bits -> TLBundleA(opcode -> %d, param -> %d, size -> %d, source -> %d, address -> %d, mask -> %d, data -> %d, corrupt -> %d))",io_in_a_ready,io_in_a_valid,io_in_a_bits_opcode,io_in_a_bits_param,io_in_a_bits_size,io_in_a_bits_source,io_in_a_bits_address,io_in_a_bits_mask,io_in_a_bits_data,io_in_a_bits_corrupt); // @[Monitor.scala 573:56:freechips.rocketchip.system.DefaultConfig.fir@63461.8]
        end
    `ifdef PRINTF_COND
      end
    `endif
    `endif // SYNTHESIS
```

Potential issues with this approach:
  * logging/prefixing is controlled by designer, not by user of the code, which may be not the level of control desired.
  * prints only happening right now when ready & valid asserted - do we want to show if ready | valid asserted?
  * This may get noisy fast. Maybe want to add a `PlusArgReader` to control the logging at a finer grain?

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

