### PR TITLE
Debug SBA: Don't reset sbState if dmactive is set to 0

### DIFF
--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -199,7 +199,6 @@ object SystemBusAccessModule
     sb2tl.module.io.wrEn     := dmAuthenticated && tryWrEn && !SBCSFieldsReg.sbbusy && !SBCSFieldsReg.sbbusyerror && !SBCSRdData.sberror && !sbAccessError && !sbAlignmentError
     sb2tl.module.io.rdEn     := dmAuthenticated && tryRdEn && !SBCSFieldsReg.sbbusy && !SBCSFieldsReg.sbbusyerror && !SBCSRdData.sberror && !sbAccessError && !sbAlignmentError
     sb2tl.module.io.sizeIn   := SBCSFieldsReg.sbaccess
-    sb2tl.module.io.dmactive := dmactive
 
     val sbBusy = (sb2tl.module.io.sbStateOut =/= SystemBusAccessState.Idle.id.U)
 
@@ -275,7 +274,6 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
       val addrIn       = Input(UInt(128.W)) // TODO: Parameterize these widths
       val dataIn       = Input(UInt(128.W))
       val sizeIn       = Input(UInt(3.W))
-      val dmactive     = Input(Bool())
       val rdLegal      = Output(Bool())
       val wrLegal      = Output(Bool())
       val rdDone       = Output(Bool())
@@ -334,9 +332,7 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
     }
 
     // --- State Machine to interface with TileLink ---
-    when(~io.dmactive){
-      sbState := Idle.id.U
-    }.elsewhen (sbState === Idle.id.U){
+    when (sbState === Idle.id.U){
       sbState := Mux(io.rdEn && io.rdLegal, SBReadRequest.id.U,
                  Mux(io.wrEn && io.wrLegal, SBWriteRequest.id.U, sbState))
     }.elsewhen (sbState === SBReadRequest.id.U){


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
sbState tracks the progress of a TileLink transaction initiated by the debug module SBA interface.  When a read transaction is initiated by the DM, sbState progresses from Idle to SBReadRequest to SBReadResponse and back to idle.  The states control what is driven onto the TL interface, including driving d.ready to 1 when sbState is in the SBReadResponse state.

If there is a TL transaction in progress and the debugger sets dmactive to 0, sbState is immediately returned to Idle, thereby forcing d.ready to 0.  This can potentially hang TileLink.  

This PR disconnects sbState from dmactive so that any transaction started by the DM is followed to completion even if the DM is subsequently disabled.

