### PR TITLE
Port some selected modules to chisel3 for properly inferring resets

### DIFF
--- a/src/main/scala/rocket/Breakpoint.scala
+++ b/src/main/scala/rocket/Breakpoint.scala
@@ -2,21 +2,22 @@
 
 package freechips.rocketchip.rocket
 
-import Chisel._
+import chisel3._
+import chisel3.util.{Cat}
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.tile.{CoreModule, CoreBundle}
+import freechips.rocketchip.tile.{CoreModule, CoreBundle, HasCoreParameters}
 import freechips.rocketchip.util._
 
 class BPControl(implicit p: Parameters) extends CoreBundle()(p) {
-  val ttype = UInt(width = 4)
+  val ttype = UInt(4.W)
   val dmode = Bool()
-  val maskmax = UInt(width = 6)
-  val reserved = UInt(width = xLen - (if (coreParams.useBPWatch) 26 else 24))
-  val action = UInt(width = (if (coreParams.useBPWatch) 3 else 1))
+  val maskmax = UInt(6.W)
+  val reserved = UInt((xLen - (if (coreParams.useBPWatch) 26 else 24)).W)
+  val action = UInt((if (coreParams.useBPWatch) 3 else 1).W)
   val chain = Bool()
-  val zero = UInt(width = 2)
-  val tmatch = UInt(width = 2)
+  val zero = UInt(2.W)
+  val tmatch = UInt(2.W)
   val m = Bool()
   val h = Bool()
   val s = Bool()
@@ -32,7 +33,7 @@ class BPControl(implicit p: Parameters) extends CoreBundle()(p) {
 
 class BP(implicit p: Parameters) extends CoreBundle()(p) {
   val control = new BPControl
-  val address = UInt(width = vaddrBits)
+  val address = UInt(vaddrBits.W)
 
   def mask(dummy: Int = 0) =
     (0 until control.maskMax-1).scanLeft(control.tmatch(0))((m, i) => m && address(i)).asUInt
@@ -51,23 +52,23 @@ class BPWatch (val n: Int) extends Bundle() {
   val valid = Vec(n, Bool())
   val dvalid = Vec(n, Bool())
   val ivalid = Vec(n, Bool())
-  val action = UInt(width = 3)
+  val action = UInt(3.W)
 }
 
-class BreakpointUnit(n: Int)(implicit p: Parameters) extends CoreModule()(p) {
-  val io = new Bundle {
-    val status = new MStatus().asInput
-    val bp = Vec(n, new BP).asInput
-    val pc = UInt(INPUT, vaddrBits)
-    val ea = UInt(INPUT, vaddrBits)
-    val xcpt_if = Bool(OUTPUT)
-    val xcpt_ld = Bool(OUTPUT)
-    val xcpt_st = Bool(OUTPUT)
-    val debug_if = Bool(OUTPUT)
-    val debug_ld = Bool(OUTPUT)
-    val debug_st = Bool(OUTPUT)
-    val bpwatch = Vec(n, new BPWatch(1)).asOutput
-  }
+class BreakpointUnit(n: Int)(implicit val p: Parameters) extends Module with HasCoreParameters {
+  val io = IO(new Bundle {
+    val status = Input(new MStatus())
+    val bp = Input(Vec(n, new BP))
+    val pc = Input(UInt(vaddrBits.W))
+    val ea = Input(UInt(vaddrBits.W))
+    val xcpt_if  = Output(Bool())
+    val xcpt_ld  = Output(Bool())
+    val xcpt_st  = Output(Bool())
+    val debug_if = Output(Bool())
+    val debug_ld = Output(Bool())
+    val debug_st = Output(Bool())
+    val bpwatch  = Output(Vec(n, new BPWatch(1)))
+  })
 
   io.xcpt_if := false
   io.xcpt_ld := false
@@ -76,7 +77,7 @@ class BreakpointUnit(n: Int)(implicit p: Parameters) extends CoreModule()(p) {
   io.debug_ld := false
   io.debug_st := false
 
-  (io.bpwatch zip io.bp).foldLeft((Bool(true), Bool(true), Bool(true))) { case ((ri, wi, xi), (bpw, bp)) =>
+  (io.bpwatch zip io.bp).foldLeft((true.B, true.B, true.B)) { case ((ri, wi, xi), (bpw, bp)) =>
     val en = bp.control.enabled(io.status)
     val r = en && bp.control.r && bp.addressMatch(io.ea)
     val w = en && bp.control.w && bp.addressMatch(io.ea)

--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -3,29 +3,30 @@
 
 package freechips.rocketchip.rocket
 
-import Chisel._
+import chisel3._
+import chisel3.util.{Cat, log2Up, log2Ceil, log2Floor, Log2, Decoupled, Enum, Fill, Valid, Pipe}
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.util._
 import ALU._
 
 class MultiplierReq(dataBits: Int, tagBits: Int) extends Bundle {
-  val fn = Bits(width = SZ_ALU_FN)
-  val dw = Bits(width = SZ_DW)
-  val in1 = Bits(width = dataBits)
-  val in2 = Bits(width = dataBits)
-  val tag = UInt(width = tagBits)
+  val fn = Bits(SZ_ALU_FN.W)
+  val dw = Bits(SZ_DW.W)
+  val in1 = Bits(dataBits.W)
+  val in2 = Bits(dataBits.W)
+  val tag = UInt(tagBits.W)
   override def cloneType = new MultiplierReq(dataBits, tagBits).asInstanceOf[this.type]
 }
 
 class MultiplierResp(dataBits: Int, tagBits: Int) extends Bundle {
-  val data = Bits(width = dataBits)
-  val tag = UInt(width = tagBits)
+  val data = Bits(dataBits.W)
+  val tag = UInt(tagBits.W)
   override def cloneType = new MultiplierResp(dataBits, tagBits).asInstanceOf[this.type]
 }
 
 class MultiplierIO(dataBits: Int, tagBits: Int) extends Bundle {
-  val req = Decoupled(new MultiplierReq(dataBits, tagBits)).flip
-  val kill = Bool(INPUT)
+  val req = Flipped(Decoupled(new MultiplierReq(dataBits, tagBits)))
+  val kill = Input(Bool())
   val resp = Decoupled(new MultiplierResp(dataBits, tagBits))
 }
 
@@ -42,23 +43,23 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
   private def minMulLatency = (cfg.mulUnroll > 0).option(if (cfg.mulEarlyOut) 2 else w/cfg.mulUnroll)
   def minLatency: Int = (minDivLatency ++ minMulLatency).min
 
-  val io = new MultiplierIO(width, log2Up(nXpr))
+  val io = IO(new MultiplierIO(width, log2Up(nXpr)))
   val w = io.req.bits.in1.getWidth
   val mulw = if (cfg.mulUnroll == 0) w else (w + cfg.mulUnroll - 1) / cfg.mulUnroll * cfg.mulUnroll
   val fastMulW = if (cfg.mulUnroll == 0) false else w/2 > cfg.mulUnroll && w % (2*cfg.mulUnroll) == 0
  
-  val s_ready :: s_neg_inputs :: s_mul :: s_div :: s_dummy :: s_neg_output :: s_done_mul :: s_done_div :: Nil = Enum(UInt(), 8)
-  val state = Reg(init=s_ready)
+  val s_ready :: s_neg_inputs :: s_mul :: s_div :: s_dummy :: s_neg_output :: s_done_mul :: s_done_div :: Nil = Enum(8)
+  val state = RegInit(s_ready)
  
-  val req = Reg(io.req.bits)
-  val count = Reg(UInt(width = log2Ceil(
+  val req = Reg(chiselTypeOf(io.req.bits))
+  val count = Reg(UInt(log2Ceil(
     ((cfg.divUnroll != 0).option(w/cfg.divUnroll + 1).toSeq ++
-     (cfg.mulUnroll != 0).option(mulw/cfg.mulUnroll)).reduce(_ max _))))
+     (cfg.mulUnroll != 0).option(mulw/cfg.mulUnroll)).reduce(_ max _)).W))
   val neg_out = Reg(Bool())
   val isHi = Reg(Bool())
   val resHi = Reg(Bool())
-  val divisor = Reg(Bits(width = w+1)) // div only needs w bits
-  val remainder = Reg(Bits(width = 2*mulw+2)) // div only needs 2*w+1 bits
+  val divisor = Reg(Bits((w+1).W)) // div only needs w bits
+  val remainder = Reg(Bits((2*mulw+2).W)) // div only needs 2*w+1 bits
 
   val mulDecode = List(
     FN_MUL    -> List(Y, N, X, X),
@@ -75,7 +76,7 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
       (if (cfg.divUnroll != 0) divDecode else Nil) ++ (if (cfg.mulUnroll != 0) mulDecode else Nil)).map(_.asBool)
 
   require(w == 32 || w == 64)
-  def halfWidth(req: MultiplierReq) = Bool(w > 32) && req.dw === DW_32
+  def halfWidth(req: MultiplierReq) = (w > 32).B && req.dw === DW_32
 
   def sext(x: Bits, halfW: Bool, signed: Bool) = {
     val sign = signed && Mux(halfW, x(w/2-1), x(w-1))
@@ -113,9 +114,9 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
     val nextMulReg = Cat(prod, mplier(mulw-1, cfg.mulUnroll))
     val nextMplierSign = count === mulw/cfg.mulUnroll-2 && neg_out
 
-    val eOutMask = (SInt(BigInt(-1) << mulw) >> (count * cfg.mulUnroll)(log2Up(mulw)-1,0))(mulw-1,0)
-    val eOut = Bool(cfg.mulEarlyOut) && count =/= mulw/cfg.mulUnroll-1 && count =/= 0 &&
-      !isHi && (mplier & ~eOutMask) === UInt(0)
+    val eOutMask = ((BigInt(-1) << mulw).S >> (count * cfg.mulUnroll)(log2Up(mulw)-1,0))(mulw-1,0)
+    val eOut = (cfg.mulEarlyOut).B && count =/= mulw/cfg.mulUnroll-1 && count =/= 0 &&
+      !isHi && (mplier & ~eOutMask) === 0.U
     val eOutRes = (mulReg >> (mulw - count * cfg.mulUnroll)(log2Up(mulw)-1,0))
     val nextMulReg1 = Cat(nextMulReg(2*mulw,mulw), Mux(eOut, eOutRes, nextMulReg)(mulw-1,0))
     remainder := Cat(nextMulReg1 >> w, nextMplierSign, nextMulReg1(w-1,0))
@@ -146,7 +147,7 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
     val divby0 = count === 0 && !subtractor(w)
     if (cfg.divEarlyOut) {
       val align = 1 << log2Floor(cfg.divUnroll max cfg.divEarlyOutGranularity)
-      val alignMask = ~UInt(align-1, log2Ceil(w))
+      val alignMask = ~((align-1).U(log2Ceil(w).W))
       val divisorMSB = Log2(divisor(w-1,0), w) & alignMask
       val dividendMSB = Log2(remainder(w-1,0), w) | ~alignMask
       val eOutPos = ~(dividendMSB - divisorMSB)
@@ -173,19 +174,20 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
   }
 
   val outMul = (state & (s_done_mul ^ s_done_div)) === (s_done_mul & ~s_done_div)
-  val loOut = Mux(Bool(fastMulW) && halfWidth(req) && outMul, result(w-1,w/2), result(w/2-1,0))
+  val loOut = Mux(fastMulW.B && halfWidth(req) && outMul, result(w-1,w/2), result(w/2-1,0))
   val hiOut = Mux(halfWidth(req), Fill(w/2, loOut(w/2-1)), result(w-1,w/2))
-  io.resp.bits <> req
+  io.resp.bits.tag := req.tag
+
   io.resp.bits.data := Cat(hiOut, loOut)
   io.resp.valid := (state === s_done_mul || state === s_done_div)
   io.req.ready := state === s_ready
 }
 
 class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Module with ShouldBeRetimed {
-  val io = new Bundle {
-    val req = Valid(new MultiplierReq(width, log2Ceil(nXpr))).flip
+  val io = IO(new Bundle {
+    val req = Flipped(Valid(new MultiplierReq(width, log2Ceil(nXpr))))
     val resp = Valid(new MultiplierResp(width, log2Ceil(nXpr)))
-  }
+  })
 
   val in = Pipe(io.req)
 
@@ -196,7 +198,7 @@ class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Modu
     FN_MULHSU -> List(Y, Y, N))
   val cmdHi :: lhsSigned :: rhsSigned :: Nil =
     DecodeLogic(in.bits.fn, List(X, X, X), decode).map(_.asBool)
-  val cmdHalf = Bool(width > 32) && in.bits.dw === DW_32
+  val cmdHalf = (width > 32).B && in.bits.dw === DW_32
 
   val lhs = Cat(lhsSigned && in.bits.in1(width-1), in.bits.in1).asSInt
   val rhs = Cat(rhsSigned && in.bits.in2(width-1), in.bits.in2).asSInt

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.rocket
 
-import Chisel._
+import chisel3._
+import chisel3.util.{Cat, log2Ceil}
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.config._
 import freechips.rocketchip.tile._
@@ -11,8 +12,8 @@ import freechips.rocketchip.util.property._
 
 class PMPConfig extends Bundle {
   val l = Bool()
-  val res = UInt(width = 2)
-  val a = UInt(width = 2)
+  val res = UInt(2.W)
+  val a = UInt(2.W)
   val x = Bool()
   val w = Bool()
   val r = Bool()
@@ -23,7 +24,8 @@ object PMP {
 
   def apply(reg: PMPReg): PMP = {
     val pmp = Wire(new PMP()(reg.p))
-    pmp := reg
+    pmp.cfg := reg.cfg
+    pmp.addr := reg.addr
     pmp.mask := pmp.computeMask
     pmp
   }
@@ -31,7 +33,7 @@ object PMP {
 
 class PMPReg(implicit p: Parameters) extends CoreBundle()(p) {
   val cfg = new PMPConfig
-  val addr = UInt(width = paddrBits - PMP.lgAlign)
+  val addr = UInt((paddrBits - PMP.lgAlign).W)
 
   def reset() {
     cfg.a := 0
@@ -50,12 +52,12 @@ class PMPReg(implicit p: Parameters) extends CoreBundle()(p) {
 }
 
 class PMP(implicit p: Parameters) extends PMPReg {
-  val mask = UInt(width = paddrBits)
+  val mask = UInt(paddrBits.W)
 
   import PMP._
   def computeMask = {
     val base = Cat(addr, cfg.a(0)) | ((pmpGranularity - 1) >> lgAlign)
-    Cat(base & ~(base + 1), UInt((1 << lgAlign) - 1))
+    Cat(base & ~(base + 1), ((1 << lgAlign) - 1).U)
   }
   private def comparand = ~(~(addr << lgAlign) | (pmpGranularity - 1))
 
@@ -140,20 +142,20 @@ class PMPHomogeneityChecker(pmps: Seq[PMP])(implicit p: Parameters) {
   }
 }
 
-class PMPChecker(lgMaxSize: Int)(implicit p: Parameters) extends CoreModule()(p)
+class PMPChecker(lgMaxSize: Int)(implicit val p: Parameters) extends Module
     with HasCoreParameters {
-  val io = new Bundle {
-    val prv = UInt(INPUT, PRV.SZ)
-    val pmp = Vec(nPMPs, new PMP).asInput
-    val addr = UInt(INPUT, paddrBits)
-    val size = UInt(INPUT, log2Ceil(lgMaxSize + 1))
-    val r = Bool(OUTPUT)
-    val w = Bool(OUTPUT)
-    val x = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val prv = Input(UInt(PRV.SZ.W))
+    val pmp = Input(Vec(nPMPs, new PMP))
+    val addr = Input(UInt(paddrBits.W))
+    val size = Input(UInt(log2Ceil(lgMaxSize + 1).W))
+    val r = Output(Bool())
+    val w = Output(Bool())
+    val x = Output(Bool())
+  })
 
   val default = if (io.pmp.isEmpty) true.B else io.prv > PRV.S
-  val pmp0 = Wire(init = 0.U.asTypeOf(new PMP))
+  val pmp0 = WireInit(0.U.asTypeOf(new PMP))
   pmp0.cfg.r := default
   pmp0.cfg.w := default
   pmp0.cfg.x := default
@@ -177,7 +179,7 @@ class PMPChecker(lgMaxSize: Int)(implicit p: Parameters) extends CoreModule()(p)
       cover(pmp.cfg.l && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode with lock bit high", "Cover PMP access with lock bit")
     }
 
-    val cur = Wire(init = pmp)
+    val cur = WireInit(pmp)
     cur.cfg.r := aligned && (pmp.cfg.r || ignore)
     cur.cfg.w := aligned && (pmp.cfg.w || ignore)
     cur.cfg.x := aligned && (pmp.cfg.x || ignore)

--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -2,18 +2,19 @@
 
 package freechips.rocketchip.rocket
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
 
 class ExpandedInstruction extends Bundle {
-  val bits = UInt(width = 32)
-  val rd = UInt(width = 5)
-  val rs1 = UInt(width = 5)
-  val rs2 = UInt(width = 5)
-  val rs3 = UInt(width = 5)
+  val bits = UInt(32.W)
+  val rd = UInt(5.W)
+  val rs1 = UInt(5.W)
+  val rs2 = UInt(5.W)
+  val rs3 = UInt(5.W)
 }
 
 class RVCDecoder(x: UInt, xLen: Int) {
@@ -27,81 +28,81 @@ class RVCDecoder(x: UInt, xLen: Int) {
     res
   }
 
-  def rs1p = Cat(UInt(1,2), x(9,7))
-  def rs2p = Cat(UInt(1,2), x(4,2))
+  def rs1p = Cat(1.U(2.W), x(9,7))
+  def rs2p = Cat(1.U(2.W), x(4,2))
   def rs2 = x(6,2)
   def rd = x(11,7)
-  def addi4spnImm = Cat(x(10,7), x(12,11), x(5), x(6), UInt(0,2))
-  def lwImm = Cat(x(5), x(12,10), x(6), UInt(0,2))
-  def ldImm = Cat(x(6,5), x(12,10), UInt(0,3))
-  def lwspImm = Cat(x(3,2), x(12), x(6,4), UInt(0,2))
-  def ldspImm = Cat(x(4,2), x(12), x(6,5), UInt(0,3))
-  def swspImm = Cat(x(8,7), x(12,9), UInt(0,2))
-  def sdspImm = Cat(x(9,7), x(12,10), UInt(0,3))
-  def luiImm = Cat(Fill(15, x(12)), x(6,2), UInt(0,12))
-  def addi16spImm = Cat(Fill(3, x(12)), x(4,3), x(5), x(2), x(6), UInt(0,4))
+  def addi4spnImm = Cat(x(10,7), x(12,11), x(5), x(6), 0.U(2.W))
+  def lwImm = Cat(x(5), x(12,10), x(6), 0.U(2.W))
+  def ldImm = Cat(x(6,5), x(12,10), 0.U(3.W))
+  def lwspImm = Cat(x(3,2), x(12), x(6,4), 0.U(2.W))
+  def ldspImm = Cat(x(4,2), x(12), x(6,5), 0.U(3.W))
+  def swspImm = Cat(x(8,7), x(12,9), 0.U(2.W))
+  def sdspImm = Cat(x(9,7), x(12,10), 0.U(3.W))
+  def luiImm = Cat(Fill(15, x(12)), x(6,2), 0.U(12.W))
+  def addi16spImm = Cat(Fill(3, x(12)), x(4,3), x(5), x(2), x(6), 0.U(4.W))
   def addiImm = Cat(Fill(7, x(12)), x(6,2))
-  def jImm = Cat(Fill(10, x(12)), x(8), x(10,9), x(6), x(7), x(2), x(11), x(5,3), UInt(0,1))
-  def bImm = Cat(Fill(5, x(12)), x(6,5), x(2), x(11,10), x(4,3), UInt(0,1))
+  def jImm = Cat(Fill(10, x(12)), x(8), x(10,9), x(6), x(7), x(2), x(11), x(5,3), 0.U(1.W))
+  def bImm = Cat(Fill(5, x(12)), x(6,5), x(2), x(11,10), x(4,3), 0.U(1.W))
   def shamt = Cat(x(12), x(6,2))
-  def x0 = UInt(0,5)
-  def ra = UInt(1,5)
-  def sp = UInt(2,5)
+  def x0 = 0.U(5.W)
+  def ra = 1.U(5.W)
+  def sp = 2.U(5.W)
 
   def q0 = {
     def addi4spn = {
-      val opc = Mux(x(12,5).orR, UInt(0x13,7), UInt(0x1F,7))
-      inst(Cat(addi4spnImm, sp, UInt(0,3), rs2p, opc), rs2p, sp, rs2p)
+      val opc = Mux(x(12,5).orR, 0x13.U(7.W), 0x1F.U(7.W))
+      inst(Cat(addi4spnImm, sp, 0.U(3.W), rs2p, opc), rs2p, sp, rs2p)
     }
-    def ld = inst(Cat(ldImm, rs1p, UInt(3,3), rs2p, UInt(0x03,7)), rs2p, rs1p, rs2p)
-    def lw = inst(Cat(lwImm, rs1p, UInt(2,3), rs2p, UInt(0x03,7)), rs2p, rs1p, rs2p)
-    def fld = inst(Cat(ldImm, rs1p, UInt(3,3), rs2p, UInt(0x07,7)), rs2p, rs1p, rs2p)
+    def ld = inst(Cat(ldImm, rs1p, 3.U(3.W), rs2p, 0x03.U(7.W)), rs2p, rs1p, rs2p)
+    def lw = inst(Cat(lwImm, rs1p, 2.U(3.W), rs2p, 0x03.U(7.W)), rs2p, rs1p, rs2p)
+    def fld = inst(Cat(ldImm, rs1p, 3.U(3.W), rs2p, 0x07.U(7.W)), rs2p, rs1p, rs2p)
     def flw = {
-      if (xLen == 32) inst(Cat(lwImm, rs1p, UInt(2,3), rs2p, UInt(0x07,7)), rs2p, rs1p, rs2p)
+      if (xLen == 32) inst(Cat(lwImm, rs1p, 2.U(3.W), rs2p, 0x07.U(7.W)), rs2p, rs1p, rs2p)
       else ld
     }
-    def unimp = inst(Cat(lwImm >> 5, rs2p, rs1p, UInt(2,3), lwImm(4,0), UInt(0x3F,7)), rs2p, rs1p, rs2p)
-    def sd = inst(Cat(ldImm >> 5, rs2p, rs1p, UInt(3,3), ldImm(4,0), UInt(0x23,7)), rs2p, rs1p, rs2p)
-    def sw = inst(Cat(lwImm >> 5, rs2p, rs1p, UInt(2,3), lwImm(4,0), UInt(0x23,7)), rs2p, rs1p, rs2p)
-    def fsd = inst(Cat(ldImm >> 5, rs2p, rs1p, UInt(3,3), ldImm(4,0), UInt(0x27,7)), rs2p, rs1p, rs2p)
+    def unimp = inst(Cat(lwImm >> 5, rs2p, rs1p, 2.U(3.W), lwImm(4,0), 0x3F.U(7.W)), rs2p, rs1p, rs2p)
+    def sd = inst(Cat(ldImm >> 5, rs2p, rs1p, 3.U(3.W), ldImm(4,0), 0x23.U(7.W)), rs2p, rs1p, rs2p)
+    def sw = inst(Cat(lwImm >> 5, rs2p, rs1p, 2.U(3.W), lwImm(4,0), 0x23.U(7.W)), rs2p, rs1p, rs2p)
+    def fsd = inst(Cat(ldImm >> 5, rs2p, rs1p, 3.U(3.W), ldImm(4,0), 0x27.U(7.W)), rs2p, rs1p, rs2p)
     def fsw = {
-      if (xLen == 32) inst(Cat(lwImm >> 5, rs2p, rs1p, UInt(2,3), lwImm(4,0), UInt(0x27,7)), rs2p, rs1p, rs2p)
+      if (xLen == 32) inst(Cat(lwImm >> 5, rs2p, rs1p, 2.U(3.W), lwImm(4,0), 0x27.U(7.W)), rs2p, rs1p, rs2p)
       else sd
     }
     Seq(addi4spn, fld, lw, flw, unimp, fsd, sw, fsw)
   }
 
   def q1 = {
-    def addi = inst(Cat(addiImm, rd, UInt(0,3), rd, UInt(0x13,7)), rd, rd, rs2p)
+    def addi = inst(Cat(addiImm, rd, 0.U(3.W), rd, 0x13.U(7.W)), rd, rd, rs2p)
     def addiw = {
-      val opc = Mux(rd.orR, UInt(0x1B,7), UInt(0x1F,7))
-      inst(Cat(addiImm, rd, UInt(0,3), rd, opc), rd, rd, rs2p)
+      val opc = Mux(rd.orR, 0x1B.U(7.W), 0x1F.U(7.W))
+      inst(Cat(addiImm, rd, 0.U(3.W), rd, opc), rd, rd, rs2p)
     }
     def jal = {
-      if (xLen == 32) inst(Cat(jImm(20), jImm(10,1), jImm(11), jImm(19,12), ra, UInt(0x6F,7)), ra, rd, rs2p)
+      if (xLen == 32) inst(Cat(jImm(20), jImm(10,1), jImm(11), jImm(19,12), ra, 0x6F.U(7.W)), ra, rd, rs2p)
       else addiw
     }
-    def li = inst(Cat(addiImm, x0, UInt(0,3), rd, UInt(0x13,7)), rd, x0, rs2p)
+    def li = inst(Cat(addiImm, x0, 0.U(3.W), rd, 0x13.U(7.W)), rd, x0, rs2p)
     def addi16sp = {
-      val opc = Mux(addiImm.orR, UInt(0x13,7), UInt(0x1F,7))
-      inst(Cat(addi16spImm, rd, UInt(0,3), rd, opc), rd, rd, rs2p)
+      val opc = Mux(addiImm.orR, 0x13.U(7.W), 0x1F.U(7.W))
+      inst(Cat(addi16spImm, rd, 0.U(3.W), rd, opc), rd, rd, rs2p)
     }
     def lui = {
-      val opc = Mux(addiImm.orR, UInt(0x37,7), UInt(0x3F,7))
+      val opc = Mux(addiImm.orR, 0x37.U(7.W), 0x3F.U(7.W))
       val me = inst(Cat(luiImm(31,12), rd, opc), rd, rd, rs2p)
       Mux(rd === x0 || rd === sp, addi16sp, me)
     }
-    def j = inst(Cat(jImm(20), jImm(10,1), jImm(11), jImm(19,12), x0, UInt(0x6F,7)), x0, rs1p, rs2p)
-    def beqz = inst(Cat(bImm(12), bImm(10,5), x0, rs1p, UInt(0,3), bImm(4,1), bImm(11), UInt(0x63,7)), rs1p, rs1p, x0)
-    def bnez = inst(Cat(bImm(12), bImm(10,5), x0, rs1p, UInt(1,3), bImm(4,1), bImm(11), UInt(0x63,7)), x0, rs1p, x0)
+    def j = inst(Cat(jImm(20), jImm(10,1), jImm(11), jImm(19,12), x0, 0x6F.U(7.W)), x0, rs1p, rs2p)
+    def beqz = inst(Cat(bImm(12), bImm(10,5), x0, rs1p, 0.U(3.W), bImm(4,1), bImm(11), 0x63.U(7.W)), rs1p, rs1p, x0)
+    def bnez = inst(Cat(bImm(12), bImm(10,5), x0, rs1p, 1.U(3.W), bImm(4,1), bImm(11), 0x63.U(7.W)), x0, rs1p, x0)
     def arith = {
-      def srli = Cat(shamt, rs1p, UInt(5,3), rs1p, UInt(0x13,7))
-      def srai = srli | UInt(1 << 30)
-      def andi = Cat(addiImm, rs1p, UInt(7,3), rs1p, UInt(0x13,7))
+      def srli = Cat(shamt, rs1p, 5.U(3.W), rs1p, 0x13.U(7.W))
+      def srai = srli | (1 << 30).U
+      def andi = Cat(addiImm, rs1p, 7.U(3.W), rs1p, 0x13.U(7.W))
       def rtype = {
         val funct = Seq(0.U, 4.U, 6.U, 7.U, 0.U, 0.U, 2.U, 3.U)(Cat(x(12), x(6,5)))
-        val sub = Mux(x(6,5) === UInt(0), UInt(1 << 30), UInt(0))
-        val opc = Mux(x(12), UInt(0x3B,7), UInt(0x33,7))
+        val sub = Mux(x(6,5) === 0.U, (1 << 30).U, 0.U)
+        val opc = Mux(x(12), 0x3B.U(7.W), 0x33.U(7.W))
         Cat(rs2p, rs1p, funct, rs1p, opc) | sub
       }
       inst(Seq(srli, srai, andi, rtype)(x(11,10)), rs1p, rs1p, rs2p)
@@ -110,31 +111,31 @@ class RVCDecoder(x: UInt, xLen: Int) {
   }
   
   def q2 = {
-    val load_opc = Mux(rd.orR, UInt(0x03,7), UInt(0x1F,7))
-    def slli = inst(Cat(shamt, rd, UInt(1,3), rd, UInt(0x13,7)), rd, rd, rs2)
-    def ldsp = inst(Cat(ldspImm, sp, UInt(3,3), rd, load_opc), rd, sp, rs2)
-    def lwsp = inst(Cat(lwspImm, sp, UInt(2,3), rd, load_opc), rd, sp, rs2)
-    def fldsp = inst(Cat(ldspImm, sp, UInt(3,3), rd, UInt(0x07,7)), rd, sp, rs2)
+    val load_opc = Mux(rd.orR, 0x03.U(7.W), 0x1F.U(7.W))
+    def slli = inst(Cat(shamt, rd, 1.U(3.W), rd, 0x13.U(7.W)), rd, rd, rs2)
+    def ldsp = inst(Cat(ldspImm, sp, 3.U(3.W), rd, load_opc), rd, sp, rs2)
+    def lwsp = inst(Cat(lwspImm, sp, 2.U(3.W), rd, load_opc), rd, sp, rs2)
+    def fldsp = inst(Cat(ldspImm, sp, 3.U(3.W), rd, 0x07.U(7.W)), rd, sp, rs2)
     def flwsp = {
-      if (xLen == 32) inst(Cat(lwspImm, sp, UInt(2,3), rd, UInt(0x07,7)), rd, sp, rs2)
+      if (xLen == 32) inst(Cat(lwspImm, sp, 2.U(3.W), rd, 0x07.U(7.W)), rd, sp, rs2)
       else ldsp
     }
-    def sdsp = inst(Cat(sdspImm >> 5, rs2, sp, UInt(3,3), sdspImm(4,0), UInt(0x23,7)), rd, sp, rs2)
-    def swsp = inst(Cat(swspImm >> 5, rs2, sp, UInt(2,3), swspImm(4,0), UInt(0x23,7)), rd, sp, rs2)
-    def fsdsp = inst(Cat(sdspImm >> 5, rs2, sp, UInt(3,3), sdspImm(4,0), UInt(0x27,7)), rd, sp, rs2)
+    def sdsp = inst(Cat(sdspImm >> 5, rs2, sp, 3.U(3.W), sdspImm(4,0), 0x23.U(7.W)), rd, sp, rs2)
+    def swsp = inst(Cat(swspImm >> 5, rs2, sp, 2.U(3.W), swspImm(4,0), 0x23.U(7.W)), rd, sp, rs2)
+    def fsdsp = inst(Cat(sdspImm >> 5, rs2, sp, 3.U(3.W), sdspImm(4,0), 0x27.U(7.W)), rd, sp, rs2)
     def fswsp = {
-      if (xLen == 32) inst(Cat(swspImm >> 5, rs2, sp, UInt(2,3), swspImm(4,0), UInt(0x27,7)), rd, sp, rs2)
+      if (xLen == 32) inst(Cat(swspImm >> 5, rs2, sp, 2.U(3.W), swspImm(4,0), 0x27.U(7.W)), rd, sp, rs2)
       else sdsp
     }
     def jalr = {
-      val mv = inst(Cat(rs2, x0, UInt(0,3), rd, UInt(0x33,7)), rd, x0, rs2)
-      val add = inst(Cat(rs2, rd, UInt(0,3), rd, UInt(0x33,7)), rd, rd, rs2)
-      val jr = Cat(rs2, rd, UInt(0,3), x0, UInt(0x67,7))
-      val reserved = Cat(jr >> 7, UInt(0x1F,7))
+      val mv = inst(Cat(rs2, x0, 0.U(3.W), rd, 0x33.U(7.W)), rd, x0, rs2)
+      val add = inst(Cat(rs2, rd, 0.U(3.W), rd, 0x33.U(7.W)), rd, rd, rs2)
+      val jr = Cat(rs2, rd, 0.U(3.W), x0, 0x67.U(7.W))
+      val reserved = Cat(jr >> 7, 0x1F.U(7.W))
       val jr_reserved = inst(Mux(rd.orR, jr, reserved), x0, rd, rs2)
       val jr_mv = Mux(rs2.orR, mv, jr_reserved)
-      val jalr = Cat(rs2, rd, UInt(0,3), ra, UInt(0x67,7))
-      val ebreak = Cat(jr >> 7, UInt(0x73,7)) | UInt(1 << 20)
+      val jalr = Cat(rs2, rd, 0.U(3.W), ra, 0x67.U(7.W))
+      val ebreak = Cat(jr >> 7, 0x73.U(7.W)) | (1 << 20).U
       val jalr_ebreak = inst(Mux(rd.orR, jalr, ebreak), ra, rd, rs2)
       val jalr_add = Mux(rs2.orR, add, jalr_ebreak)
       Mux(x(12), jalr_add, jr_mv)
@@ -153,17 +154,17 @@ class RVCDecoder(x: UInt, xLen: Int) {
 }
 
 class RVCExpander(implicit val p: Parameters) extends Module with HasCoreParameters {
-  val io = new Bundle {
-    val in = UInt(INPUT, 32)
-    val out = new ExpandedInstruction
-    val rvc = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val in = Input(UInt(32.W))
+    val out = Output(new ExpandedInstruction)
+    val rvc = Output(Bool())
+  })
 
   if (usingCompressed) {
-    io.rvc := io.in(1,0) =/= UInt(3)
+    io.rvc := io.in(1,0) =/= 3.U
     io.out := new RVCDecoder(io.in, p(XLen)).decode
   } else {
-    io.rvc := Bool(false)
+    io.rvc := false.B
     io.out := new RVCDecoder(io.in, p(XLen)).passthrough
   }
 }

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util.{DecoupledIO, log2Ceil, Cat, RegEnable}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -28,27 +29,27 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
       val hasData = edgeIn.hasData(in.bits)
       val limit   = UIntToOH1(size, keepBits) >> dropBits
 
-      val count  = RegInit(UInt(0, width = countBits))
-      val first  = count === UInt(0)
+      val count  = RegInit(0.U(countBits.W))
+      val first  = count === 0.U
       val last   = count === limit || !hasData
-      val enable = Seq.tabulate(ratio) { i => !((count ^ UInt(i)) & limit).orR }
+      val enable = Seq.tabulate(ratio) { i => !((count ^ i.U) & limit).orR }
 
-      val corrupt_reg = RegInit(Bool(false))
+      val corrupt_reg = RegInit(false.B)
       val corrupt_in = edgeIn.corrupt(in.bits)
       val corrupt_out = corrupt_in || corrupt_reg
 
       when (in.fire()) {
-        count := count + UInt(1)
+        count := count + 1.U
         corrupt_reg := corrupt_out
         when (last) {
-          count := UInt(0)
-          corrupt_reg := Bool(false)
+          count := 0.U
+          corrupt_reg := false.B
         }
       }
 
       def helper(idata: UInt): UInt = {
-        val odata = Seq.fill(ratio) { idata }
-        val rdata = Reg(Vec(ratio-1, idata))
+        val odata = Seq.fill(ratio) { WireInit(idata) }
+        val rdata = Reg(Vec(ratio-1, chiselTypeOf(idata)))
         val pdata = rdata :+ idata
         val mdata = (enable zip (odata zip pdata)) map { case (e, (o, p)) => Mux(e, o, p) }
         when (in.fire() && !last) {
@@ -62,12 +63,12 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
       out.bits := in.bits
 
       // Don't put down hardware if we never carry data
-      edgeOut.data(out.bits) := (if (edgeIn.staticHasData(in.bits) == Some(false)) UInt(0) else helper(edgeIn.data(in.bits)))
+      edgeOut.data(out.bits) := (if (edgeIn.staticHasData(in.bits) == Some(false)) 0.U else helper(edgeIn.data(in.bits)))
       edgeOut.corrupt(out.bits) := corrupt_out
 
       (out.bits, in.bits) match {
-        case (o: TLBundleA, i: TLBundleA) => o.mask := edgeOut.mask(o.address, o.size) & Mux(hasData, helper(i.mask), ~UInt(0, width=outBytes))
-        case (o: TLBundleB, i: TLBundleB) => o.mask := edgeOut.mask(o.address, o.size) & Mux(hasData, helper(i.mask), ~UInt(0, width=outBytes))
+        case (o: TLBundleA, i: TLBundleA) => o.mask := edgeOut.mask(o.address, o.size) & Mux(hasData, helper(i.mask), ~0.U(outBytes.W))
+        case (o: TLBundleB, i: TLBundleB) => o.mask := edgeOut.mask(o.address, o.size) & Mux(hasData, helper(i.mask), ~0.U(outBytes.W))
         case (o: TLBundleC, i: TLBundleC) => ()
         case (o: TLBundleD, i: TLBundleD) => ()
         case _ => require(false, "Impossible bundle combination in WidthWidget")
@@ -86,13 +87,13 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
       val hasData = edgeIn.hasData(in.bits)
       val limit   = UIntToOH1(size, keepBits) >> dropBits
 
-      val count = RegInit(UInt(0, width = countBits))
-      val first = count === UInt(0)
+      val count = RegInit(0.U(countBits.W))
+      val first = count === 0.U
       val last  = count === limit || !hasData
 
       when (out.fire()) {
-        count := count + UInt(1)
-        when (last) { count := UInt(0) }
+        count := count + 1.U
+        when (last) { count := 0.U }
       }
 
       // For sub-beat transfer, extract which part matters
@@ -109,14 +110,16 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
 
       val index  = sel | count
       def helper(idata: UInt, width: Int): UInt = {
-        val mux = Vec.tabulate(ratio) { i => idata((i+1)*outBytes*width-1, i*outBytes*width) }
+        val mux = VecInit.tabulate(ratio) { i => idata((i+1)*outBytes*width-1, i*outBytes*width) }
         mux(index)
       }
 
-      out <> in
+      out.bits := in.bits
+      out.valid := in.valid
+      in.ready := out.ready
 
       // Don't put down hardware if we never carry data
-      edgeOut.data(out.bits) := (if (edgeIn.staticHasData(in.bits) == Some(false)) UInt(0) else helper(edgeIn.data(in.bits), 8))
+      edgeOut.data(out.bits) := (if (edgeIn.staticHasData(in.bits) == Some(false)) 0.U else helper(edgeIn.data(in.bits), 8))
 
       (out.bits, in.bits) match {
         case (o: TLBundleA, i: TLBundleA) => o.mask := helper(i.mask, 1)
@@ -133,12 +136,14 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
     def splice[T <: TLDataChannel](edgeIn: TLEdge, in: DecoupledIO[T], edgeOut: TLEdge, out: DecoupledIO[T], sourceMap: UInt => UInt) = {
       if (edgeIn.manager.beatBytes == edgeOut.manager.beatBytes) {
         // nothing to do; pass it through
-        out <> in
+        out.bits := in.bits
+        out.valid := in.valid
+        in.ready := out.ready
       } else if (edgeIn.manager.beatBytes > edgeOut.manager.beatBytes) {
         // split input to output
         val repeat = Wire(Bool())
         val repeated = Repeater(in, repeat)
-        val cated = Wire(repeated)
+        val cated = Wire(chiselTypeOf(repeated))
         cated <> repeated
         edgeIn.data(cated.bits) := Cat(
           edgeIn.data(repeated.bits)(edgeIn.manager.beatBytes*8-1, edgeOut.manager.beatBytes*8),
@@ -163,14 +168,14 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
         require (edgeOut.manager.beatBytes > edgeIn.manager.beatBytes)
         val keepBits = log2Ceil(edgeOut.manager.beatBytes)
         val dropBits = log2Ceil(edgeIn.manager.beatBytes)
-        val sources  = Reg(Vec(edgeIn.client.endSourceId, UInt(width = keepBits-dropBits)))
+        val sources  = Reg(Vec(edgeIn.client.endSourceId, UInt((keepBits-dropBits).W)))
         val a_sel = in.a.bits.address(keepBits-1, dropBits)
         when (in.a.fire()) {
           sources(in.a.bits.source) := a_sel
         }
 
         // depopulate unused source registers:
-        edgeIn.client.unusedSources.foreach { id => sources(id) := UInt(0) }
+        edgeIn.client.unusedSources.foreach { id => sources(id) := 0.U }
 
         val bypass = in.a.valid && in.a.bits.source === source
         if (edgeIn.manager.minLatency > 0) sources(source)
@@ -185,12 +190,12 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
         splice(edgeIn,  in.c,  edgeOut, out.c, sourceMap)
         out.e <> in.e
       } else {
-        in.b.valid := Bool(false)
-        in.c.ready := Bool(true)
-        in.e.ready := Bool(true)
-        out.b.ready := Bool(true)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
+        in.b.valid := false.B
+        in.c.ready := true.B
+        in.e.ready := true.B
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
       }
     }
   }

--- a/src/main/scala/util/Repeater.scala
+++ b/src/main/scala/util/Repeater.scala
@@ -9,15 +9,17 @@ import chisel3.util.{Decoupled, DecoupledIO}
 // When repeat is asserted, the Repeater copies the input and repeats it next cycle.
 class Repeater[T <: Data](gen: T) extends Module
 {
+  val typ = chiselTypeOf(gen)
+
   val io = IO( new Bundle {
     val repeat = Input(Bool())
     val full = Output(Bool())
-    val enq = Flipped(Decoupled(gen))
-    val deq = Decoupled(gen)
+    val enq = Flipped(Decoupled(typ))
+    val deq = Decoupled(typ)
   } )
 
   val full = RegInit(false.B)
-  val saved = Reg(gen)
+  val saved = Reg(typ)
 
   // When !full, a repeater is pass-through
   io.deq.valid := io.enq.valid || full


### PR DESCRIPTION
This ports some selected modules to `chisel3` so that resets can be properly inferred in those modules.

- [ ] The results have been LEC-ed for consistency.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
