### PR TITLE
Add feature-disable bit to suppress corrupt on GrantData

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -536,7 +536,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
       (whole_opc, whole_opc.isOneOf(uncachedGrantOpcodes), whole_opc.isOneOf(uncachedGrantOpcodesWithData))
     }
   }
-  tl_d_data_encoded := encodeData(tl_out.d.bits.data, tl_out.d.bits.corrupt && !grantIsUncached)
+  tl_d_data_encoded := encodeData(tl_out.d.bits.data, tl_out.d.bits.corrupt && !io.ptw.customCSRs.suppressCorruptOnGrantData && !grantIsUncached)
   val grantIsCached = d_opc.isOneOf(Grant, GrantData)
   val grantIsVoluntary = d_opc === ReleaseAck // Clears a different pending bit
   val grantIsRefill = d_opc === GrantData     // Writes the data array

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -72,12 +72,15 @@ class RocketCustomCSRs(implicit p: Parameters) extends CustomCSRs with HasRocket
     rocketParams.branchPredictionModeCSR.option(CustomCSR(bpmCSRId, BigInt(1), Some(BigInt(0))))
   }
 
+  private def haveDCache = tileParams.dcache.get.scratch.isEmpty
+
   override def chickenCSR = {
     val mask = BigInt(
       tileParams.dcache.get.clockGate.toInt << 0 |
       rocketParams.clockGate.toInt << 1 |
       rocketParams.clockGate.toInt << 2 |
       1 << 3 | // disableSpeculativeICacheRefill
+      haveDCache.toInt << 9 | // suppressCorruptOnGrantData
       tileParams.icache.get.prefetch.toInt << 17
     )
     Some(CustomCSR(chickenCSRId, mask, Some(mask)))

--- a/src/main/scala/tile/CustomCSRs.scala
+++ b/src/main/scala/tile/CustomCSRs.scala
@@ -34,11 +34,11 @@ class CustomCSRs(implicit p: Parameters) extends CoreBundle {
 
   def flushBTB = getOrElse(bpmCSR, _.wen, false.B)
   def bpmStatic = getOrElse(bpmCSR, _.value(0), false.B)
-  def disableDCacheClockGate = getOrElse(chickenCSR, _.value(0), true.B)
-  def disableICacheClockGate = getOrElse(chickenCSR, _.value(1), true.B)
-  def disableCoreClockGate = getOrElse(chickenCSR, _.value(2), true.B)
-  def disableSpeculativeICacheRefill = getOrElse(chickenCSR, _.value(3), true.B)
-  def suppressCorruptOnGrantData = getOrElse(chickenCSR, _.value(9), true.B)
+  def disableDCacheClockGate = getOrElse(chickenCSR, _.value(0), false.B)
+  def disableICacheClockGate = getOrElse(chickenCSR, _.value(1), false.B)
+  def disableCoreClockGate = getOrElse(chickenCSR, _.value(2), false.B)
+  def disableSpeculativeICacheRefill = getOrElse(chickenCSR, _.value(3), false.B)
+  def suppressCorruptOnGrantData = getOrElse(chickenCSR, _.value(9), false.B)
 
   protected def getByIdOrElse[T](id: Int, f: CustomCSRIO => T, alt: T): T = {
     val idx = decls.indexWhere(_.id == id)

--- a/src/main/scala/tile/CustomCSRs.scala
+++ b/src/main/scala/tile/CustomCSRs.scala
@@ -38,6 +38,7 @@ class CustomCSRs(implicit p: Parameters) extends CoreBundle {
   def disableICacheClockGate = getOrElse(chickenCSR, _.value(1), true.B)
   def disableCoreClockGate = getOrElse(chickenCSR, _.value(2), true.B)
   def disableSpeculativeICacheRefill = getOrElse(chickenCSR, _.value(3), true.B)
+  def suppressCorruptOnGrantData = getOrElse(chickenCSR, _.value(9), true.B)
 
   protected def getByIdOrElse[T](id: Int, f: CustomCSRIO => T, alt: T): T = {
     val idx = decls.indexWhere(_.id == id)


### PR DESCRIPTION
Temporarily suppressing corrupt GrantDatas facilitates using normal loads and stores to wipe down uncorrectable errors.


<!-- choose one -->
**Impact**: API addition (no impact on existing code)
