### PR TITLE
TLWidthWidget: one more fix for the port to chisel3

### DIFF
--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -188,7 +188,9 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
       if (edgeOut.manager.anySupportAcquireB && edgeIn.client.anySupportProbe) {
         splice(edgeOut, out.b, edgeIn,  in.b,  sourceMap)
         splice(edgeIn,  in.c,  edgeOut, out.c, sourceMap)
-        out.e <> in.e
+        out.e.valid := in.e.valid
+        out.e.bits := in.e.bits
+        in.e.ready := out.e.ready
       } else {
         in.b.valid := false.B
         in.c.ready := true.B


### PR DESCRIPTION
Need to convert one more chisel2 `<>` to explicit series of `:=`. Rocket-Chip PR regressions don't exercise this code path.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
 Follow up to https://github.com/chipsalliance/rocket-chip/pull/2273

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
