### PR TITLE
Fix regression in support for large ExtMem sizes

### DIFF
--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -35,7 +35,7 @@ class AXI4RAM(
 
   lazy val module = new LazyModuleImp(this) {
     val (in, _) = node.in(0)
-    val (mem, omSRAM, omMem) = makeSinglePortedByteWriteSeqMem(size = 1 << mask.filter(b=>b).size)
+    val (mem, omSRAM, omMem) = makeSinglePortedByteWriteSeqMem(size = 1L << mask.filter(b=>b).size)
 
     parentLogicalTreeNode.map {
       case parentLTN =>


### PR DESCRIPTION
#1969 accidentally reverted the fix implemented by @colinschmidt in #1934. This PR restores support for large ExtMem sizes.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**: implementation

