### PR TITLE
bump FIRRTL for async reset register fixes

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -15,7 +15,7 @@
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "4b1f71e0c8a979ca9248a2ab62256ada12a683df",
+        "commit": "61bf6373bc752d1194f5fdc97db10297f82a0bb4",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -15,7 +15,7 @@
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "52a1ee81fccdc05c80b662fb2daf236cc5c4560b",
+        "commit": "4b1f71e0c8a979ca9248a2ab62256ada12a683df",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
See discussion on https://github.com/freechipsproject/firrtl/pull/1355

<!-- choose one -->
**Type of change**: bug report 

^---- this template question makes no sense for a PR

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Async registers which are only reset, never assigned, will be emitted properly in a way that prevents lint tools from complaining about a latch.