### PR TITLE
Put timebase-frequency in the correct place

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -5,6 +5,7 @@ package freechips.rocketchip.diplomacy
 import Chisel.log2Ceil
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model._
+import freechips.rocketchip.config.Parameters
 
 import scala.collection.immutable.{ListMap, SortedMap}
 import scala.collection.mutable.HashMap
@@ -439,12 +440,14 @@ object ResourceAnchors
     }
   }
 
-  val cpus = new Device {
+  def cpus(implicit p: Parameters) = new Device {
     def describe(resources: ResourceBindings): Description = {
       val width = resources("width").map(_.value)
       Description("cpus", Map(
         "#address-cells" -> width,
-        "#size-cells"    -> Seq(ResourceInt(0))))
+        "#size-cells"    -> Seq(ResourceInt(0)),
+        "timebase-frequency" -> p(DTSTimebase).asProperty	// see LIN-109
+      )),
     }
   }
 


### PR DESCRIPTION
This is WIP to move the timebase-frequency DTS line from the
/cpus/cpu@X/ location to a single instance at /cpus/.

A final version for upstream should have a single entry, as
the current code generates something like:

timebase-frequency = <1000000 1000000>

as there seem to be multiple objects, which should all be checked
to be the same value with something like 'require'

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
