### PR TITLE
Don't raise halt signal on I$ errors

### DIFF
--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -126,7 +126,7 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
   val core = Module(new Rocket(outer)(outer.p))
 
   // Report unrecoverable error conditions; for now the only cause is cache ECC errors
-  outer.reportHalt(List(outer.frontend.module.io.errors, outer.dcache.module.io.errors))
+  outer.reportHalt(List(outer.dcache.module.io.errors))
 
   // Report when the tile has ceased to retire instructions; for now the only cause is clock gating
   outer.reportCease(outer.rocketParams.core.clockGate.option(


### PR DESCRIPTION
I$ accesses can be speculative, and raising the halt signal based upon speculative accesses is problematic.

These errors can still be dealt with using a BusErrorUnit.
