### PR TITLE
make LazyModule.nodes accessable by users.

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -112,12 +112,19 @@ abstract class LazyModule()(implicit val p: Parameters)
     children.filter(!_.omitGraphML).foreach { c => c.edgesGraphML(buf, pad) }
   }
 
-  def nodeIterator(iterfunc: (LazyModule) => Unit): Unit = {
+  def childrenIterator(iterfunc: (LazyModule) => Unit): Unit = {
     iterfunc(this)
-    children.foreach( _.nodeIterator(iterfunc) )
+    children.foreach( _.childrenIterator(iterfunc) )
+  }
+
+  def nodeIterator(iterfunc: (BaseNode) => Unit): Unit = {
+    nodes.foreach(iterfunc)
+    childrenIterator(_.nodes.foreach(iterfunc))
   }
 
   def getChildren = children
+
+  def getNodes = nodes
 }
 
 object LazyModule


### PR DESCRIPTION

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
1. make `LazyModule.nodes` accessable to user for debugging and reuse Nodes.
2. refactor `childrenIterator` to `nodeIterator`, add `nodeIterator` to access all children's `BaseNode`.
