### PR TITLE
bug fix for DeviceRegName

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -150,7 +150,7 @@ trait DeviceRegName
       devname
     } else {
       val (named, bulk) = reg.partition { case (k, v) => DiplomacyUtils.regName(k).isDefined }
-      val mainreg = reg.find(x => DiplomacyUtils.regName(x._1) == "control").getOrElse(reg.head)._2
+      val mainreg = reg.find(x => DiplomacyUtils.regName(x._1).contains("control")).getOrElse(reg.head)._2
       require (!mainreg.isEmpty, s"reg binding for $devname is empty!")
       mainreg.head.value match {
         case x: ResourceAddress => s"${devname}@${x.address.head.base.toString(16)}"

--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -150,7 +150,7 @@ trait DeviceRegName
       devname
     } else {
       val (named, bulk) = reg.partition { case (k, v) => DiplomacyUtils.regName(k).isDefined }
-      val mainreg = reg.find(x => DiplomacyUtils.regName(x._1).contains("control")).getOrElse(reg.head)._2
+      val mainreg = reg.head._2
       require (!mainreg.isEmpty, s"reg binding for $devname is empty!")
       mainreg.head.value match {
         case x: ResourceAddress => s"${devname}@${x.address.head.base.toString(16)}"


### PR DESCRIPTION
**Type of change**: bug report
<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
bug fix to comparing `Option[String]` with `String`
```
DiplomacyUtils.regName(x._1) == "control"
```
will compare between `Option[String]` and `String`, which never equal.
If comparing this equivalency, it should be
```
DiplomacyUtils.regName(x._1).contains("control")
```