### PR TITLE
Resets: convert some test harness files to use async reset inference

### DIFF
--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba.ahb
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{BusMemoryLogicalTreeNode, LogicalModuleTree, LogicalTreeNode}

--- a/src/main/scala/amba/ahb/Test.scala
+++ b/src/main/scala/amba/ahb/Test.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba.ahb
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.devices.tilelink.TLTestRAM
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba.apb
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{BusMemoryLogicalTreeNode, LogicalModuleTree, LogicalTreeNode}

--- a/src/main/scala/amba/apb/Test.scala
+++ b/src/main/scala/amba/apb/Test.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba.apb
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba.axi4
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{BusMemoryLogicalTreeNode, LogicalModuleTree, LogicalTreeNode}

--- a/src/main/scala/amba/axi4/Test.scala
+++ b/src/main/scala/amba/axi4/Test.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba.axi4
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{RawModule, MultiIOModule, withClockAndReset}
 import chisel3.internal.sourceinfo.{SourceInfo, SourceLine, UnlocatableSourceInfo}
 import freechips.rocketchip.config.Parameters

--- a/src/main/scala/util/CompileOptions.scala
+++ b/src/main/scala/util/CompileOptions.scala
@@ -1,0 +1,10 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import chisel3.ExplicitCompileOptions.NotStrict
+
+object CompileOptions {
+  /** Compatibility mode semantics except Module implicit reset should be inferred instead of Bool */
+  implicit val NotStrictInferReset = NotStrict.copy(inferModuleReset = true)
+}


### PR DESCRIPTION
This converts more files to chisel3/DefaultCompileOptionsNonStrictInferReset so that they can have their async reset inferred. This PR touches files generally only used by test harnesses. There should be no functional changes.

Note for `Fuzzer.scala` the Compile Options "hack" was not sufficient for reset inference so I had to convert the whole file.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
