### PR TITLE
Correct VCD dump-start

### DIFF
--- a/src/main/resources/vsrc/TestDriver.v
+++ b/src/main/resources/vsrc/TestDriver.v
@@ -79,11 +79,11 @@ module TestDriver;
     end
 
 `ifdef FSDB
-`define VCDPLUSON $fsdbDumpon;
-`define VCDPLUSCLOSE $fsdbDumpoff;
+`define VCDPLUSON $fsdbDumpon; if ($test$plusargs("vcdfile=")) $dumpon;
+`define VCDPLUSCLOSE $fsdbDumpoff; if ($test$plusargs("vcdfile=")) $dumpoff;
 `elsif VCS
-`define VCDPLUSON $vcdpluson(0); $vcdplusmemon(0);
-`define VCDPLUSCLOSE $vcdplusclose; $dumpoff;
+`define VCDPLUSON $vcdpluson(0); $vcdplusmemon(0); if ($test$plusargs("vcdfile=")) $dumpon;
+`define VCDPLUSCLOSE $vcdplusclose; $dumpoff; if ($test$plusargs("vcdfile=")) $dumpoff;
 `else
 `define VCDPLUSON $dumpon;
 `define VCDPLUSCLOSE $dumpoff;

--- a/src/main/resources/vsrc/TestDriver.v
+++ b/src/main/resources/vsrc/TestDriver.v
@@ -75,6 +75,7 @@ module TestDriver;
     begin
       $dumpfile(vcdfile);
       $dumpvars(0, testHarness);
+      $dumpoff;
     end
 
 `ifdef FSDB


### PR DESCRIPTION
**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation

$dumpvars starts dumping so in order to delay the start we need to turn off dumping before later enabling it

Relevant portion of verilog manual:
```
18.1.3 Stopping and resuming the dump ($dumpoff/$dumpon)
Executing the $dumpvars task causes the value change dumping to start at the end of the current simulation time unit
```
