### PR TITLE
APBToTL: Qualify address alignment assertion

### DIFF
--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -81,7 +81,9 @@ class APBToTL()(implicit p: Parameters) extends LazyModule
       out.a.bits.source  := UInt(0)
       // TL requires addresses be aligned to their size.
       out.a.bits.address := aligned_addr
-      assert(in.paddr === out.a.bits.address, "Do not expect to have to perform alignment in APB2TL Conversion")
+      when (out.a.fire()) {
+        assert(in.paddr === out.a.bits.address, "Do not expect to have to perform alignment in APB2TL Conversion")
+      }
       out.a.bits.data    := in.pwdata
       out.a.bits.mask    := Mux(in.pwrite, in.pstrb, ~0.U(beatBytes.W))
       out.a.bits.corrupt := Bool(false)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Properly qualify address alignment assertion in APBToTL on whether or not there is a transaction being sent.