### PR TITLE
Qualify load and store watchpoints by instruction type

### DIFF
--- a/src/main/scala/rocket/Breakpoint.scala
+++ b/src/main/scala/rocket/Breakpoint.scala
@@ -50,7 +50,8 @@ class BP(implicit p: Parameters) extends CoreBundle()(p) {
 
 class BPWatch (val n: Int) extends Bundle() {
   val valid = Vec(n, Bool())
-  val dvalid = Vec(n, Bool())
+  val rvalid = Vec(n, Bool())
+  val wvalid = Vec(n, Bool())
   val ivalid = Vec(n, Bool())
   val action = UInt(3.W)
 }
@@ -87,11 +88,12 @@ class BreakpointUnit(n: Int)(implicit val p: Parameters) extends Module with Has
 
     bpw.action := action
     bpw.valid(0) := false.B
-    bpw.dvalid(0) := false.B
+    bpw.rvalid(0) := false.B
+    bpw.wvalid(0) := false.B
     bpw.ivalid(0) := false.B
 
-    when (end && r && ri) { io.xcpt_ld := (action === 0.U); io.debug_ld := (action === 1.U); bpw.valid(0) := true.B; bpw.dvalid(0) := true.B }
-    when (end && w && wi) { io.xcpt_st := (action === 0.U); io.debug_st := (action === 1.U); bpw.valid(0) := true.B; bpw.dvalid(0) := true.B }
+    when (end && r && ri) { io.xcpt_ld := (action === 0.U); io.debug_ld := (action === 1.U); bpw.valid(0) := true.B; bpw.rvalid(0) := true.B }
+    when (end && w && wi) { io.xcpt_st := (action === 0.U); io.debug_st := (action === 1.U); bpw.valid(0) := true.B; bpw.wvalid(0) := true.B }
     when (end && x && xi) { io.xcpt_if := (action === 0.U); io.debug_if := (action === 1.U); bpw.valid(0) := true.B; bpw.ivalid(0) := true.B }
 
     (end || r, end || w, end || x)

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -595,7 +595,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     wb_reg_raw_inst := mem_reg_raw_inst
     wb_reg_mem_size := mem_reg_mem_size
     wb_reg_pc := mem_reg_pc
-    wb_reg_wphit := mem_reg_wphit | bpu.io.bpwatch.map { bpw => bpw.dvalid(0) }
+    wb_reg_wphit := mem_reg_wphit | bpu.io.bpwatch.map { bpw => (bpw.rvalid(0) && mem_reg_load) || (bpw.wvalid(0) && mem_reg_store) }
 
   }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->


<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The watchpoint bundle leading out of the core could erroneously indicate a match on a load or store watchpoint.  The logic in the core was not checking that the instruction type (load vs. store) matched the breakpoint programming.