### PR TITLE
BundleMap: improved API for user bits

### DIFF
--- a/src/main/scala/amba/axis/Buffer.scala
+++ b/src/main/scala/amba/axis/Buffer.scala
@@ -14,7 +14,7 @@ class AXISBuffer(val params: BufferParams)(implicit p: Parameters) extends LazyM
   val node = AXISAdapterNode()
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      out :<> params.irrevocable(in)
+      out :<>: params.irrevocable(in)
     }
   }
 }

--- a/src/main/scala/amba/axis/Bundles.scala
+++ b/src/main/scala/amba/axis/Bundles.scala
@@ -6,12 +6,12 @@ import chisel3.util._
 import freechips.rocketchip.util._
 
 sealed trait AXISKey
-case object AXISLast extends RequestKey[Bool]("last") with AXISKey
-case object AXISId   extends RequestKey[UInt]("id")   with AXISKey
-case object AXISDest extends RequestKey[UInt]("dest") with AXISKey
-case object AXISKeep extends DataKey   [UInt]("keep") with AXISKey
-case object AXISStrb extends DataKey   [UInt]("strb") with AXISKey
-case object AXISData extends DataKey   [UInt]("data") with AXISKey
+case object AXISLast extends ControlRequestKey[Bool]("last") with AXISKey
+case object AXISId   extends ControlRequestKey[UInt]("id")   with AXISKey
+case object AXISDest extends ControlRequestKey[UInt]("dest") with AXISKey
+case object AXISKeep extends DataRequestKey   [UInt]("keep") with AXISKey
+case object AXISStrb extends DataRequestKey   [UInt]("strb") with AXISKey
+case object AXISData extends DataRequestKey   [UInt]("data") with AXISKey
 
 case class AXISLastField()           extends SimpleBundleField(AXISLast)(Output(Bool()),        true.B)
 case class AXISIdField  (width: Int) extends SimpleBundleField(AXISId)  (Output(UInt(width.W)), 0.U)

--- a/src/main/scala/amba/axis/Bundles.scala
+++ b/src/main/scala/amba/axis/Bundles.scala
@@ -6,12 +6,12 @@ import chisel3.util._
 import freechips.rocketchip.util._
 
 sealed trait AXISKey
-case object AXISLast extends ControlRequestKey[Bool]("last") with AXISKey
-case object AXISId   extends ControlRequestKey[UInt]("id")   with AXISKey
-case object AXISDest extends ControlRequestKey[UInt]("dest") with AXISKey
-case object AXISKeep extends DataRequestKey   [UInt]("keep") with AXISKey
-case object AXISStrb extends DataRequestKey   [UInt]("strb") with AXISKey
-case object AXISData extends DataRequestKey   [UInt]("data") with AXISKey
+case object AXISLast extends ControlKey[Bool]("last") with AXISKey
+case object AXISId   extends ControlKey[UInt]("id")   with AXISKey
+case object AXISDest extends ControlKey[UInt]("dest") with AXISKey
+case object AXISKeep extends DataKey   [UInt]("keep") with AXISKey
+case object AXISStrb extends DataKey   [UInt]("strb") with AXISKey
+case object AXISData extends DataKey   [UInt]("data") with AXISKey
 
 case class AXISLastField()           extends SimpleBundleField(AXISLast)(Output(Bool()),        true.B)
 case class AXISIdField  (width: Int) extends SimpleBundleField(AXISId)  (Output(UInt(width.W)), 0.U)

--- a/src/main/scala/amba/axis/Bundles.scala
+++ b/src/main/scala/amba/axis/Bundles.scala
@@ -6,12 +6,22 @@ import chisel3.util._
 import freechips.rocketchip.util._
 
 sealed trait AXISKey
-case object AXISLast extends ControlKey[Bool]("last", _ := true.B) with AXISKey
-case object AXISId   extends ControlKey[UInt]("id",   _ := 0.U)    with AXISKey
-case object AXISDest extends ControlKey[UInt]("dest", _ := 0.U)    with AXISKey
-case object AXISKeep extends DataKey   [UInt]("keep", _ := ~0.U)   with AXISKey
-case object AXISStrb extends DataKey   [UInt]("strb", _ := ~0.U)   with AXISKey
-case object AXISData extends DataKey   [UInt]("data", _ := 0.U)    with AXISKey
+case object AXISLast extends RequestKey[Bool]("last") with AXISKey
+case object AXISId   extends RequestKey[UInt]("id")   with AXISKey
+case object AXISDest extends RequestKey[UInt]("dest") with AXISKey
+case object AXISKeep extends DataKey   [UInt]("keep") with AXISKey
+case object AXISStrb extends DataKey   [UInt]("strb") with AXISKey
+case object AXISData extends DataKey   [UInt]("data") with AXISKey
+
+case class AXISLastField()           extends SimpleBundleField(AXISLast)(Output(Bool()),        true.B)
+case class AXISIdField  (width: Int) extends SimpleBundleField(AXISId)  (Output(UInt(width.W)), 0.U)
+case class AXISDestField(width: Int) extends SimpleBundleField(AXISDest)(Output(UInt(width.W)), 0.U)
+case class AXISKeepField(width: Int) extends SimpleBundleField(AXISKeep)(Output(UInt(width.W)), ~0.U(width.W))
+case class AXISStrbField(width: Int) extends SimpleBundleField(AXISStrb)(Output(UInt(width.W)), ~0.U(width.W))
+case class AXISDataField(width: Int) extends BundleField(AXISData) {
+  def data = Output(UInt(width.W))
+  def default(x: UInt) { x := DontCare }
+}
 
 class AXISBundleBits(val params: AXISBundleParameters) extends BundleMap(AXISBundle.keys(params)) {
   override def cloneType: this.type = (new AXISBundleBits(params)).asInstanceOf[this.type]
@@ -30,13 +40,13 @@ class AXISBundle(val params: AXISBundleParameters) extends IrrevocableIO(new AXI
 object AXISBundle {
   def apply(params: AXISBundleParameters) = new AXISBundle(params)
   def standardKeys(params: AXISBundleParameters) = {
-    def maybe(b: Boolean, x: BundleField): Seq[BundleField] = if (b) List(x) else Nil
-    maybe(params.hasLast, AXISLast(Bool()))                  ++
-    maybe(params.hasId,   AXISId  (UInt(params.idBits  .W))) ++
-    maybe(params.hasDest, AXISDest(UInt(params.destBits.W))) ++
-    maybe(params.hasKeep, AXISKeep(UInt(params.keepBits.W))) ++
-    maybe(params.hasStrb, AXISStrb(UInt(params.strbBits.W))) ++
-    maybe(params.hasData, AXISData(UInt(params.dataBits.W)))
+    def maybe(b: Boolean, x: BundleFieldBase): Seq[BundleFieldBase] = if (b) List(x) else Nil
+    maybe(params.hasLast, AXISLastField())                ++
+    maybe(params.hasId,   AXISIdField  (params.idBits  )) ++
+    maybe(params.hasDest, AXISDestField(params.destBits)) ++
+    maybe(params.hasKeep, AXISKeepField(params.keepBits)) ++
+    maybe(params.hasStrb, AXISStrbField(params.strbBits)) ++
+    maybe(params.hasData, AXISDataField(params.dataBits))
   }
   def keys(params: AXISBundleParameters) =
     standardKeys(params) ++ params.userFields

--- a/src/main/scala/amba/axis/Parameters.scala
+++ b/src/main/scala/amba/axis/Parameters.scala
@@ -5,7 +5,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.util.{BundleField, BundleFieldBase}
+import freechips.rocketchip.util._
 import freechips.rocketchip.diplomacy._
 
 class AXISSlaveParameters private (
@@ -208,12 +208,12 @@ class AXISBundleParameters private (
     aligned     = aligned && x.aligned)
 
   def v1copy(
-    idBits:      Int                  = idBits,
-    destBits:    Int                  = destBits,
-    dataBits:    Int                  = dataBits,
+    idBits:      Int = idBits,
+    destBits:    Int = destBits,
+    dataBits:    Int = dataBits,
     userFields:  Seq[BundleFieldBase] = userFields,
-    oneBeat:     Boolean              = oneBeat,
-    aligned:     Boolean              = aligned) =
+    oneBeat:     Boolean = oneBeat,
+    aligned:     Boolean = aligned) =
   {
     new AXISBundleParameters(
       idBits     = idBits,

--- a/src/main/scala/amba/axis/Parameters.scala
+++ b/src/main/scala/amba/axis/Parameters.scala
@@ -5,7 +5,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.util.BundleField
+import freechips.rocketchip.util.{BundleField, BundleFieldBase}
 import freechips.rocketchip.diplomacy._
 
 class AXISSlaveParameters private (
@@ -132,7 +132,7 @@ object AXISMasterParameters {
 
 class AXISMasterPortParameters private (
   val masters:      Seq[AXISMasterParameters],
-  val userFields:   Seq[BundleField],
+  val userFields:   Seq[BundleFieldBase],
   val isAligned:    Boolean, /* there are no 'Position byte's in transfers */
   val isContinuous: Boolean, /* there are no 'Null byte's except at the end of a transfer */
   val beatBytes:    Option[Int])
@@ -145,7 +145,7 @@ class AXISMasterPortParameters private (
 
   def v1copy(
     masters:      Seq[AXISMasterParameters] = masters,
-    userFields:   Seq[BundleField]          = userFields,
+    userFields:   Seq[BundleFieldBase]      = userFields,
     isAligned:    Boolean                   = isAligned,
     isContinuous: Boolean                   = isContinuous,
     beatBytes:    Option[Int]               = beatBytes) =
@@ -162,10 +162,10 @@ class AXISMasterPortParameters private (
 object AXISMasterPortParameters {
   def v1(
     masters:      Seq[AXISMasterParameters],
-    userFields:   Seq[BundleField] = Nil,
-    isAligned:    Boolean          = false,
-    isContinuous: Boolean          = false,
-    beatBytes:    Option[Int]      = None) =
+    userFields:   Seq[BundleFieldBase] = Nil,
+    isAligned:    Boolean              = false,
+    isContinuous: Boolean              = false,
+    beatBytes:    Option[Int]          = None) =
   {
     new AXISMasterPortParameters(
       masters      = masters,
@@ -180,7 +180,7 @@ class AXISBundleParameters private (
   val idBits:      Int,
   val destBits:    Int,
   val dataBits:    Int,
-  val userFields:  Seq[BundleField],
+  val userFields:  Seq[BundleFieldBase],
   val oneBeat:     Boolean,
   val aligned:     Boolean)
 {
@@ -203,17 +203,17 @@ class AXISBundleParameters private (
     idBits      = idBits   max x.idBits,
     destBits    = destBits max x.destBits,
     dataBits    = dataBits max x.dataBits,
-    userFields  = (userFields ++ x.userFields).distinct,
+    userFields  = BundleField.union(userFields ++ x.userFields),
     oneBeat     = oneBeat && x.oneBeat,
     aligned     = aligned && x.aligned)
 
   def v1copy(
-    idBits:      Int              = idBits,
-    destBits:    Int              = destBits,
-    dataBits:    Int              = dataBits,
-    userFields:  Seq[BundleField] = userFields,
-    oneBeat:     Boolean          = oneBeat,
-    aligned:     Boolean          = aligned) =
+    idBits:      Int                  = idBits,
+    destBits:    Int                  = destBits,
+    dataBits:    Int                  = dataBits,
+    userFields:  Seq[BundleFieldBase] = userFields,
+    oneBeat:     Boolean              = oneBeat,
+    aligned:     Boolean              = aligned) =
   {
     new AXISBundleParameters(
       idBits     = idBits,
@@ -239,7 +239,7 @@ object AXISBundleParameters {
     idBits:      Int,
     destBits:    Int,
     dataBits:    Int,
-    userFields:  Seq[BundleField],
+    userFields:  Seq[BundleFieldBase],
     oneBeat:     Boolean,
     aligned:     Boolean) =
   {

--- a/src/main/scala/amba/package.scala
+++ b/src/main/scala/amba/package.scala
@@ -1,0 +1,30 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip
+
+import chisel3._
+import freechips.rocketchip.util._
+
+package object amba {
+  class AMBAProtBundle extends Bundle {
+    val cacheable  = Bool() // false => no need to probe other cores
+    val bufferable = Bool() // writeback caching ok?
+    val modifiable = Bool() // legal to read/write-combine/expand this request?
+    val privileged = Bool() // machine_mode=true,   user_mode=false
+    val secure     = Bool() // secure_master=true,  normal=false
+    val fetch      = Bool() // instruct_fetch=true, load/store=false
+  }
+
+  case object AMBAProt extends ControlKey[AMBAProtBundle]("amba_prot")
+  case class AMBAProtField() extends BundleField(AMBAProt) {
+    def data = Output(new AMBAProtBundle)
+    def default(x: AMBAProtBundle) {
+      x.cacheable  := true.B
+      x.bufferable := true.B
+      x.modifiable := true.B
+      x.privileged := false.B
+      x.secure     := false.B
+      x.fetch      := false.B
+    }
+  }
+}

--- a/src/main/scala/util/BundleMap.scala
+++ b/src/main/scala/util/BundleMap.scala
@@ -6,14 +6,61 @@ import chisel3.util._
 import chisel3.experimental.DataMirror
 import scala.collection.immutable.ListMap
 
-case class BundleField(key: BundleKeyBase, data: Data)
-{
-  def getDefault = {
-    val out = Wire(chiselTypeOf(data))
-    key.setDefault(out)
-    out
+/* BundleMaps include IOs for every BundleField they are constructed with.
+ * A given BundleField in a BundleMap is accessed by a BundleKey.
+ *
+ * So, for example:
+ *   val myBundleMap = BundleMap(Seq(MyBundleDataField(width = 8), ...))
+ *   myBundleMap(MyBundleData) := 7.U
+ *
+ * case object MyBundleData extends DataKey[UInt]("data") // "data" is the name of the IO used in BundleMaps
+ * case class MyBundleDataField(width: Int) extends BundleField(MyBundleData) {
+ *   def data = Output(UInt(width.W))
+ *   def default(x: UInt) { x := 0.U }
+ * }
+ * OR:
+ * case class MyBundleDataField(width: Int) extends SimpleBundleField(MyBundleData)(Output(UInt(width.W)), 0.U)
+ */
+
+trait BundleFieldBase {
+  def key: BundleKeyBase
+  def data: Data // the field's chisel type with a direction
+  def setDataDefault(x: Data): Unit
+
+  // Overload this if there is a way to unify differently parameterized cases of a field
+  // (For example, by selecting the widest width)
+  def unify(that: BundleFieldBase): BundleFieldBase = {
+    require (this == that, s"Attempted to unify two BundleMaps with conflicting fields: ${this} and ${that}")
+    this
   }
-  def isOutput = DataMirror.specifiedDirectionOf(data) match {
+}
+
+/* Always extends BundleField with a case class.
+ * This will ensure that there is an appropriate equals() operator to detect name conflicts.
+ */
+abstract class BundleField[T <: Data](val key: BundleKey[T]) extends BundleFieldBase
+{
+  def data: T
+  def default(x: T): Unit
+  def setDataDefault(x: Data): Unit = default(x.asInstanceOf[T])
+}
+
+abstract class SimpleBundleField[T <: Data](key: BundleKey[T])(typeT: => T, defaultT: => T) extends BundleField[T](key)
+{
+  def data = typeT
+  def default(x: T): Unit = { x := defaultT }
+}
+
+object BundleField {
+  /* Consider an arbiter that receives two request streams A and B and combines them to C.
+   * The output stream C should have the union of all keys from A and B.
+   * When a key from A and B have the same name:
+   *  - it is an error if they are not equal.
+   *  - the union contains only one copy.
+   */
+  def union(fields: Seq[BundleFieldBase]): Seq[BundleFieldBase] =
+    fields.groupBy(_.key.name).map(_._2.reduce(_ unify _)).toList
+  def isOutput(x: Data) = DataMirror.specifiedDirectionOf(x) match {
     case SpecifiedDirection.Unspecified => true
     case SpecifiedDirection.Output      => true
     case SpecifiedDirection.Input       => false
@@ -23,27 +70,42 @@ case class BundleField(key: BundleKeyBase, data: Data)
 
 sealed trait BundleKeyBase {
   def name: String
-  def setDefault(x: Data): Unit
 }
 
-sealed class BundleKey[T <: Data](val name: String, setDefaultArg: T => Unit) extends BundleKeyBase {
-  def apply(data: T) = BundleField(this, data)
-  def setDefault(x: Data): Unit = setDefaultArg(x.asInstanceOf[T])
-}
+sealed class BundleKey[T <: Data](val name: String) extends BundleKeyBase
 
-object BundleKey {
-  def setDefaultZero(x: Data): Unit = {
-    x := 0.U.asTypeOf(x)
-  }
-}
+/* Custom bundle fields have two broad categories:
+ *  - data fields (which are per-beat/byte and should be widened by bus-width adapters)
+ *  - control fields (which are per-burst and are unaffected by width adapters)
+ */
+abstract        class DataKey   [T <: Data](name: String) extends BundleKey[T](name)
+abstract sealed class ControlKey[T <: Data](name: String) extends BundleKey[T](name)
+/* Control signals can be further categorized in a request-response protocol:
+ *  - request fields flow from master to slave
+ *  - response fields flow from slave to master
+ *  - echo fields flow from master to slave to master; a master must receive the same value in the response as he sent in the request
+ */
+abstract class RequestKey [T <: Data](name: String) extends ControlKey[T](name)
+abstract class ResponseKey[T <: Data](name: String) extends ControlKey[T](name)
+abstract class EchoKey    [T <: Data](name: String) extends ControlKey[T](name)
 
-class    DataKey[T <: Data](name: String, setDefaultArg: T => Unit = BundleKey.setDefaultZero(_)) extends BundleKey[T](name, setDefaultArg)
-class ControlKey[T <: Data](name: String, setDefaultArg: T => Unit = BundleKey.setDefaultZero(_)) extends BundleKey[T](name, setDefaultArg)
-
-class BundleMap(val fields: Seq[BundleField]) extends Record {
+// If you extend this class, you must either redefine cloneType or have a fields constructor
+class BundleMap(val fields: Seq[BundleFieldBase]) extends Record with CustomBulkAssignable {
+  // All fields must have distinct key.names
   require(fields.map(_.key.name).distinct.size == fields.size)
-  override def cloneType: this.type = (new BundleMap(fields)).asInstanceOf[this.type]
+
   val elements = ListMap(fields.map { bf => bf.key.name -> chisel3.experimental.DataMirror.internal.chiselTypeClone(bf.data) } :_*)
+  override def cloneType: this.type = {
+    try {
+      this.getClass.getConstructors.head.newInstance(fields).asInstanceOf[this.type]
+    } catch {
+      case e: java.lang.IllegalArgumentException =>
+        throw new Exception("Unable to use BundleMap.cloneType on " +
+                       this.getClass + ", probably because " + this.getClass +
+                       " does not have a constructor accepting BundleFields.  Consider overriding " +
+                       "cloneType() on " + this.getClass, e)
+    }
+  }
 
   def apply[T <: Data](key: BundleKey[T]): T         = elements(key.name).asInstanceOf[T]
   def lift [T <: Data](key: BundleKey[T]): Option[T] = elements.lift(key.name).map(_.asInstanceOf[T])
@@ -51,19 +113,38 @@ class BundleMap(val fields: Seq[BundleField]) extends Record {
   def apply(key: BundleKeyBase): Data         = elements(key.name)
   def lift (key: BundleKeyBase): Option[Data] = elements.lift(key.name)
 
-  // For every key where this.output or that.input
-  def assignL(that: BundleMap): Seq[BundleKeyBase] = {
-    val a = this.fields.filter( _.isOutput).map(_.key)
-    val b = that.fields.filter(!_.isOutput).map(_.key)
-    (a ++ b).toList.distinct
+  // Assign all outputs of this from either:
+  //   outputs of that (if they exist)
+  //   or the default value for the BundleField
+  def assignL(that: CustomBulkAssignable): Unit = {
+    def other = that.asInstanceOf[BundleMap]
+    fields.foreach { field =>
+      val value = apply(field.key)
+      other.lift(field.key) match {
+        case Some(x) => value :<= x
+        case None    => if (BundleField.isOutput(value)) field.setDataDefault(value)
+      }
+    }
   }
 
-  // For every key where this.input or that.output
-  def assignR(that: BundleMap): Seq[BundleKeyBase] = {
-    val a = this.fields.filter(!_.isOutput).map(_.key)
-    val b = that.fields.filter( _.isOutput).map(_.key)
-    (a ++ b).toList.distinct
+  // Assign all inputs of that from either:
+  //   inputs of this (if they exist)
+  //   or the default value for the BundleField
+  def assignR(that: CustomBulkAssignable): Unit = {
+    def other = that.asInstanceOf[BundleMap]
+    other.fields.foreach { field =>
+      val value = other(field.key)
+      lift(field.key) match {
+        case Some(x) => x :=> value
+        case None    => if (!BundleField.isOutput(value)) field.setDataDefault(value)
+      }
+    }
   }
+}
+
+trait CustomBulkAssignable {
+  def assignL(that: CustomBulkAssignable): Unit
+  def assignR(that: CustomBulkAssignable): Unit
 }
 
 // Implement :<= :=> and :<>
@@ -88,6 +169,7 @@ object FixChisel3 {
 
   def assignL(x: Data, y: Data): Unit = {
     (x, y) match {
+      case (cx: CustomBulkAssignable, cy: CustomBulkAssignable) => cx.assignL(cy)
       case (vx: Vec[_], vy: Vec[_]) => {
         require (vx.size == vy.size)
         (vx zip vy) foreach { case (ex, ey) => descendL(ex, ey) }
@@ -106,6 +188,7 @@ object FixChisel3 {
 
   def assignR(x: Data, y: Data) = {
     (x, y) match {
+      case (cx: CustomBulkAssignable, cy: CustomBulkAssignable) => cx.assignR(cy)
       case (vx: Vec[_], vy: Vec[_]) => {
         require (vx.size == vy.size)
         (vx zip vy) foreach { case (ex, ey) => descendR(ex, ey) }

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -234,17 +234,26 @@ package object util {
     map.view.map({ case (k, vs) => k -> vs.toList }).toList
   }
 
-  implicit class EnhancedChisel3Assign(val x: Data) extends AnyVal {
+  implicit class EnhancedChisel3Assign[T <: Data](val x: T) extends AnyVal {
     // Assign all output fields of x from y; note that the actual direction of x is irrelevant
-    def :<= (y: Data): Unit = FixChisel3.assignL(x, y)
+    def :<= (y: T): Unit = FixChisel3.assignL(x, y)
     // Assign all input fields of y from x; note that the actual direction of y is irrelevant
-    def :=> (y: Data): Unit = FixChisel3.assignR(x, y)
+    def :=> (y: T): Unit = FixChisel3.assignR(x, y)
     // Wire-friendly bulk connect
-    def :<> (y: Data): Unit = {
-      x :<= y
-      x :=> y
+    def :<> (y: T): Unit = {
+      FixChisel3.assignL(x, y)
+      FixChisel3.assignR(x, y)
     }
     // x <> y   is an 'actual-direction'-inferred 'x :<> y' or 'y :<> x'
     // x := y   is equivalent to 'x :<= y' + 'y :=> x'
+
+    // Versions of the operators that use the type from the RHS
+    // y :<=: x  ->  x.:<=:(y)  ->  y :<= x  ->  FixChisel3.assignL(y, x)
+    def :<=: (y: T): Unit = { FixChisel3.assignL(y, x) }
+    def :>=: (y: T): Unit = { FixChisel3.assignR(y, x) }
+    def :<>: (y: T): Unit = {
+      FixChisel3.assignL(y, x)
+      FixChisel3.assignR(y, x)
+    }
   }
 }


### PR DESCRIPTION
- Field unification can be customized and defaults to equality required
- Bulk assignment of BundleMaps now uses defaults for missing fields
- You must now define both a Field and Key class

**Type of change**: other enhancement
**Impact**: API modification
**Development Phase**: implementation

**Release Notes**
User bits API composability improved