### PR TITLE
bumping firrtl

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -15,7 +15,7 @@
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "2909fc87f4bb73cd2c0210ff061f5ee9bb14c86f",
+        "commit": "ad31c1143e609f5d870b0f655499cca08b15a1b2",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
Summary of changes (all bug fixes in FIRRTL):
* Do not duplicate modules when there is no reason to
* Clarify spec for divide-by-zero and single-line when-else
* Fix error message for negative width exception
* Revert `not` inlining to fix Verilog emission bug

**Related issue**: https://github.com/freechipsproject/firrtl/pull/1425

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Updating FIRRTL to revert `InlineNots`
