### PR TITLE
Fix D$ miss performance counter

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -932,6 +932,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     lrscCount > 0 || blockProbeAfterGrantCount > 0
 
   // performance events
+  io.cpu.perf.miss := edge.done(tl_out_a)
+  io.cpu.perf.prefetch := false.B
   io.cpu.perf.acquire := edge.done(tl_out_a)
   io.cpu.perf.release := edge.done(tl_out_c)
   io.cpu.perf.grant := tl_out.d.valid && d_last

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -139,6 +139,8 @@ class HellaCacheWriteData(implicit p: Parameters) extends CoreBundle()(p) with H
 class HellaCachePerfEvents extends Bundle {
   val acquire = Bool()
   val release = Bool()
+  val miss = Bool()
+  val prefetch = Bool()
   val grant = Bool()
   val tlbMiss = Bool()
   val blocked = Bool()

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -1007,6 +1007,8 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
   io.cpu.s2_paddr := s2_req.addr
 
   // performance events
+  io.cpu.perf.miss := mshrs.io.resp.fire() && !isPrefetch(mshrs.io.resp.bits.cmd)
+  io.cpu.perf.prefetch := mshrs.io.resp.fire() && isPrefetch(mshrs.io.resp.bits.cmd)
   io.cpu.perf.acquire := edge.done(tl_out.a)
   io.cpu.perf.release := edge.done(tl_out.c)
   io.cpu.perf.tlbMiss := io.ptw.req.fire()

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -155,7 +155,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
         ("fp interlock", () => id_ex_hazard && ex_ctrl.fp || id_mem_hazard && mem_ctrl.fp || id_wb_hazard && wb_ctrl.fp || id_ctrl.fp && id_stall_fpu)))),
     new EventSet((mask, hits) => (mask & hits).orR, Seq(
       ("I$ miss", () => io.imem.perf.acquire),
-      ("D$ miss", () => io.dmem.perf.acquire),
+      ("D$ miss", () => io.dmem.perf.miss),
       ("D$ release", () => io.dmem.perf.release),
       ("ITLB miss", () => io.imem.perf.tlbMiss),
       ("DTLB miss", () => io.dmem.perf.tlbMiss),


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: Performance counter enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
D$ miss event is originally linked to outgoing requests from D$. This assumption is not correct when a D$ prefetcher exists, memory request caused by prefetcher should not be considered as D$ miss.
