### PR TITLE
Multiplier: Make MultiplierIO clone-able

### DIFF
--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -24,7 +24,7 @@ class MultiplierResp(dataBits: Int, tagBits: Int) extends Bundle {
   override def cloneType = new MultiplierResp(dataBits, tagBits).asInstanceOf[this.type]
 }
 
-class MultiplierIO(dataBits: Int, tagBits: Int) extends Bundle {
+class MultiplierIO(val dataBits: Int, val tagBits: Int) extends Bundle {
   val req = Flipped(Decoupled(new MultiplierReq(dataBits, tagBits)))
   val kill = Input(Bool())
   val resp = Decoupled(new MultiplierResp(dataBits, tagBits))


### PR DESCRIPTION
resolving deprecation warning:

```
[deprecated] class freechips.rocketchip.rocket.MultiplierIO (1 calls): Unable to automatically infer cloneType on class freechips.rocketchip.rocket.MultiplierIO: constructor has parameters (dataBits, tagBits) that are not both immutable and accessible. Either make all parameters immutable and accessible (vals) so cloneType can be inferred, or define a custom cloneType method.
[warn] There were 1 deprecated function(s) used. These may stop compiling in a future release - you are encouraged to fix these issues.
```

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Resolve deprecation warnings in MultiplierIO