### PR TITLE
Add hardware-perf-monitor-counters to DTS

### DIFF
--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -214,7 +214,8 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
       "clock-frequency"      -> tileParams.core.bootFreqHz.asProperty,
       "riscv,isa"            -> isaDTS.asProperty,
       "timebase-frequency"   -> p(DTSTimebase).asProperty,
-      "hardware-exec-breakpoint-count" -> tileParams.core.nBreakpoints.asProperty
+      "hardware-exec-breakpoint-count" -> tileParams.core.nBreakpoints.asProperty,
+      "hardware-perf-monitor-counters" -> tileParams.core.nPerfCounters.asProperty
   )
 
   // The boundary buffering needed to cut feed-through paths is


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

DTS now contains additional property `hardware-perf-monitor-counters` in the `cpu` node

Example: 
```
L15: cpus {
#address-cells = <1>;
#size-cells = <0>;
L7: cpu@0 {
...
hardware-perf-monitor-counters = <2>;
...
};
};
