### PR TITLE
Reset mcause to 0

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -364,7 +364,7 @@ class CSRFile(
   }
   val reg_mip = Reg(new MIP)
   val reg_mepc = Reg(UInt(width = vaddrBitsExtended))
-  val reg_mcause = Reg(Bits(width = xLen))
+  val reg_mcause = RegInit(0.U(xLen.W))
   val reg_mtval = Reg(UInt(width = vaddrBitsExtended))
   val reg_mscratch = Reg(Bits(width = xLen))
   val mtvecWidth = paddrBits min xLen


### PR DESCRIPTION
For compliance with this clause in the priv spec:

"The mcause values after reset have implementation-specific interpretation,
but the value 0 should be returned on implementations that do not distinguish
different reset conditions"
