### PR TITLE
Use inferred resets for JTAG and DebugTransport modules

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -644,15 +644,12 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
       val hartResetReq = p(DebugModuleKey).get.hasHartResets.option(Output(Vec(nComponents, Bool())))
       val dmAuthenticated = p(DebugModuleKey).get.hasAuthentication.option(Input(Bool()))
     })
-    val rf_reset = IO(Input(Reset()))
+    val rf_reset = IO(Input(Reset()))    // RF transform
 
     childClock := io.dmi_clock
     childReset := io.dmi_reset
 
     withClockAndReset(childClock, childReset) {
-      dmOuter.module.clock := io.dmi_clock
-      dmOuter.module.reset := io.dmi_reset
-
       dmi2tlOpt.foreach { _.module.io.dmi <> io.dmi.get }
 
       dmiBypass.module.io.bypass := ~io.ctrl.dmactive | ~AsyncResetSynchronizerShiftReg(in=io.ctrl.dmactiveAck, sync=3, name=Some("dmactiveAckSync"))
@@ -1710,7 +1707,7 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int, beatByt
       val hartIsInReset = Input(Vec(getNComponents(), Bool()))
       val auth = p(DebugModuleKey).get.hasAuthentication.option(new DebugAuthenticationIO())
     })
-    val rf_reset = IO(Input(Reset()))
+    val rf_reset = IO(Input(Reset()))    // RF transform
 
     childClock := io.debug_clock
     childReset := io.debug_reset

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -65,24 +65,29 @@ class DTMInfo extends Bundle {
 /** A wrapper around JTAG providing a reset signal and manufacturer id. */
 class SystemJTAGIO extends Bundle {
   val jtag = Flipped(new JTAGIO(hasTRSTn = false))
-  val reset = Input(Bool())
+  val reset = Input(Reset())
   val mfr_id = Input(UInt(11.W))
   val part_number = Input(UInt(16.W))
   val version = Input(UInt(4.W))
 }
 
 class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
-  (implicit val p: Parameters) extends Module  {
+  (implicit val p: Parameters) extends RawModule  {
 
   val io = IO(new Bundle {
+    val jtag_clock = Input(Clock())
+    val jtag_reset = Input(Reset())
+    val tapReset = Input(Bool())
     val dmi = new DMIIO()(p)
     val jtag = Flipped(new JTAGIO(hasTRSTn = false)) // TODO: re-use SystemJTAGIO here?
-    val jtag_reset = Input(Bool())
     val jtag_mfr_id = Input(UInt(11.W))
     val jtag_part_number = Input(UInt(16.W))
     val jtag_version = Input(UInt(4.W))
     val fsmReset = Output(Bool())
   })
+  val rf_reset = IO(Input(Reset()))
+
+  withClockAndReset(io.jtag_clock, io.jtag_reset) {
 
   //--------------------------------------------------------
   // Reg and Wire Declarations
@@ -258,10 +263,20 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   tapIO.jtag <> io.jtag
 
   tapIO.control.jtag_reset := io.jtag_reset
+  tapIO.control.tapReset := io.tapReset
+
+  // Clear state synchronously when TAP is in Test-Logic-Reset
+  when (io.tapReset) {
+    busyReg := false.B
+    stickyBusyReg := false.B
+    stickyNonzeroRespReg := false.B
+    downgradeOpReg := false.B
+    dmiReqValidReg := false.B
+  }
 
   //--------------------------------------------------------
   // Reset Generation (this is fed back to us by the instantiating module,
   // and is used to reset the debug registers).
 
   io.fsmReset := tapIO.output.reset
-}
+}}

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -263,9 +263,9 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   tapIO.control.jtag_reset := io.jtag_reset
 
   //--------------------------------------------------------
-  // TAP Test-Logic-Reset state resets the debug registers.
+  // TAP Test-Logic-Reset state synchronously resets the debug registers.
 
-  when (tapIO.output.reset) {
+  when (tapIO.output.tapIsInTestLogicReset) {
     busyReg := false.B
     stickyBusyReg := false.B
     stickyNonzeroRespReg := false.B

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -159,17 +159,18 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
     debug.map(_.disableDebug.foreach { x => dtm.io.jtag.TMS := sj.jtag.TMS | x })  // force TMS high when debug is disabled
     val psdio = psd.psd.getOrElse(WireInit(0.U.asTypeOf(new PSDTestMode)))
 
-    dtm.clock          := sj.jtag.TCK
+    dtm.io.jtag_clock  := sj.jtag.TCK
     dtm.io.jtag_reset  := sj.reset
     dtm.io.jtag_mfr_id := sj.mfr_id
     dtm.io.jtag_part_number := sj.part_number
     dtm.io.jtag_version := sj.version
-    dtm.reset          := dtm.io.fsmReset
+    dtm.io.tapReset     := dtm.io.fsmReset
+    dtm.rf_reset := sj.reset
 
     outer.debugOpt.map { outerdebug => 
       outerdebug.module.io.dmi.get.dmi <> dtm.io.dmi
       outerdebug.module.io.dmi.get.dmiClock := sj.jtag.TCK
-      outerdebug.module.io.dmi.get.dmiReset := ResetCatchAndSync(sj.jtag.TCK, sj.reset, "dmiResetCatch", psdio)
+      outerdebug.module.io.dmi.get.dmiReset := sj.reset
     }
     dtm
   }
@@ -259,7 +260,7 @@ object Debug {
       }
       debug.systemjtag.foreach { sj =>
         val jtag = Module(new SimJTAG(tickDelay=3)).connect(sj.jtag, c, r, ~r, out)
-        sj.reset := r
+        sj.reset := r.asAsyncReset
         sj.mfr_id := p(JtagDTMKey).idcodeManufId.U(11.W)
         sj.part_number := p(JtagDTMKey).idcodePartNum.U(16.W)
         sj.version := p(JtagDTMKey).idcodeVersion.U(4.W)
@@ -314,7 +315,7 @@ object Debug {
         sj.jtag.TMS := true.B
         sj.jtag.TDI := true.B
         sj.jtag.TRSTn.foreach { r => r := true.B }
-        sj.reset := true.B    // TODO: .asAsyncReset (JTAG does not support abstract reset yet)
+        sj.reset := true.B.asAsyncReset
         sj.mfr_id := 0.U
         sj.part_number := 0.U
         sj.version := 0.U

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -149,7 +149,7 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
     debug
   }
 
-  val dtm = debug.map(_.systemjtag.map { instantiateJtagDTM(_) })
+  val dtm = debug.flatMap(_.systemjtag.map(instantiateJtagDTM(_)))
 
   def instantiateJtagDTM(sj: SystemJTAGIO): DebugTransportModuleJTAG = {
 
@@ -157,14 +157,12 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
     dtm.io.jtag <> sj.jtag
 
     debug.map(_.disableDebug.foreach { x => dtm.io.jtag.TMS := sj.jtag.TMS | x })  // force TMS high when debug is disabled
-    val psdio = psd.psd.getOrElse(WireInit(0.U.asTypeOf(new PSDTestMode)))
 
     dtm.io.jtag_clock  := sj.jtag.TCK
     dtm.io.jtag_reset  := sj.reset
     dtm.io.jtag_mfr_id := sj.mfr_id
     dtm.io.jtag_part_number := sj.part_number
     dtm.io.jtag_version := sj.version
-    dtm.io.tapReset     := dtm.io.fsmReset
     dtm.rf_reset := sj.reset
 
     outer.debugOpt.map { outerdebug => 

--- a/src/main/scala/jtag/JtagStateMachine.scala
+++ b/src/main/scala/jtag/JtagStateMachine.scala
@@ -66,7 +66,7 @@ object JtagState {
   * Usage notes:
   * - 6.1.1.1b state transitions occur on TCK rising edge
   * - 6.1.1.1c actions can occur on the following TCK falling or rising edge
-  *
+  * Implicit reset is AsyncReset
   *
   */
 class JtagStateMachine(implicit val p: Parameters) extends Module() {
@@ -76,13 +76,10 @@ class JtagStateMachine(implicit val p: Parameters) extends Module() {
   }
   val io = IO(new StateMachineIO)
 
-  val nextState = WireInit(JtagState.TestLogicReset.U)
-  val currStateReg = Module (new AsyncResetRegVec(w = JtagState.State.width,
-    init = JtagState.State.toInt(JtagState.TestLogicReset)))
-  currStateReg.io.en := true.B
-  currStateReg.io.d  := nextState
-  val currState = currStateReg.io.q
+  val nextState = Wire(UInt(JtagState.State.width.W))
+  val currState = RegNext(next=nextState, init=JtagState.TestLogicReset.U)
 
+  nextState := JtagState.TestLogicReset.U
   switch (currState) {
     is (JtagState.TestLogicReset.U) {
       nextState := Mux(io.tms, JtagState.TestLogicReset.U, JtagState.RunTestIdle.U)

--- a/src/main/scala/jtag/JtagStateMachine.scala
+++ b/src/main/scala/jtag/JtagStateMachine.scala
@@ -74,7 +74,7 @@ class JtagStateMachine(implicit val p: Parameters) extends Module() {
   }
   val io = IO(new StateMachineIO)
 
-  val nextState = WireInit(JtagState.TestLogicReset.U)  // (JtagState.State.width.W))
+  val nextState = WireInit(JtagState.TestLogicReset.U)
   val currState = RegNext(next=nextState, init=JtagState.TestLogicReset.U)
 
   switch (currState) {

--- a/src/main/scala/jtag/JtagStateMachine.scala
+++ b/src/main/scala/jtag/JtagStateMachine.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.jtag
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.config.{Parameters}
-import freechips.rocketchip.util.{AsyncResetRegVec}
 import freechips.rocketchip.util.property._
 
 object JtagState {
@@ -66,7 +65,6 @@ object JtagState {
   * Usage notes:
   * - 6.1.1.1b state transitions occur on TCK rising edge
   * - 6.1.1.1c actions can occur on the following TCK falling or rising edge
-  * Implicit reset is AsyncReset
   *
   */
 class JtagStateMachine(implicit val p: Parameters) extends Module() {
@@ -76,10 +74,9 @@ class JtagStateMachine(implicit val p: Parameters) extends Module() {
   }
   val io = IO(new StateMachineIO)
 
-  val nextState = Wire(UInt(JtagState.State.width.W))
+  val nextState = WireInit(JtagState.TestLogicReset.U)  // (JtagState.State.width.W))
   val currState = RegNext(next=nextState, init=JtagState.TestLogicReset.U)
 
-  nextState := JtagState.TestLogicReset.U
   switch (currState) {
     is (JtagState.TestLogicReset.U) {
       nextState := Mux(io.tms, JtagState.TestLogicReset.U, JtagState.RunTestIdle.U)

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -25,7 +25,7 @@ class JTAGIO(hasTRSTn: Boolean = false) extends Bundle {
 class JtagOutput(irLength: Int) extends Bundle {
   val state = Output(JtagState.State.chiselType())  // state, transitions on TCK rising edge
   val instruction = Output(UInt(irLength.W))  // current active instruction
-  val reset = Output(Bool())  // synchronous reset asserted in Test-Logic-Reset state, should NOT hold the FSM in reset
+  val tapIsInTestLogicReset = Output(Bool())  // synchronously asserted in Test-Logic-Reset state, should NOT hold the FSM in reset
 
   override def cloneType = new JtagOutput(irLength).asInstanceOf[this.type]
 }
@@ -123,7 +123,7 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
   }
 
   tapIsInTestLogicReset := currState === JtagState.TestLogicReset.U
-  io.output.reset := tapIsInTestLogicReset
+  io.output.tapIsInTestLogicReset := tapIsInTestLogicReset
 
   //
   // Data Register

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -31,7 +31,8 @@ class JtagOutput(irLength: Int) extends Bundle {
 }
 
 class JtagControl extends Bundle {
-  val jtag_reset = Input(Bool())
+  val jtag_reset = Input(Reset())
+  val tapReset = Input(Bool())
 }
 
 /** Aggregate JTAG block IO.
@@ -69,6 +70,8 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
   val tdo = Wire(Bool())  // 4.4.1c TDI should appear here uninverted after shifting
   val tdo_driven = Wire(Bool())
 
+  val clock_falling = WireInit((!clock.asUInt).asClock)
+
   //
   // JTAG state machine
   //
@@ -79,15 +82,19 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
   // combined with any POR, and it should also be
   // synchronized to TCK.
   require(!io.jtag.TRSTn.isDefined, "TRSTn should be absorbed into jtckPOReset outside of JtagTapController.")
-  withReset(io.control.jtag_reset) {
+  withReset(io.control.jtag_reset.asAsyncReset) {
     val stateMachine = Module(new JtagStateMachine)
     stateMachine.suggestName("stateMachine")
     stateMachine.io.tms := io.jtag.TMS
     currState := stateMachine.io.currState
     io.output.state := stateMachine.io.currState
      // 4.5.1a TDO changes on falling edge of TCK, 6.1.2.1d driver active on first TCK falling edge in ShiftIR and ShiftDR states
-    io.jtag.TDO.data := NegEdgeAsyncResetReg(clock, tdo, name = Some("tdoReg"))
-    io.jtag.TDO.driven := NegEdgeAsyncResetReg(clock, tdo_driven, name = Some("tdoeReg"))
+    withClock(clock_falling) {
+      val TDOdata   = RegNext(next=tdo, init=false.B).suggestName("tdoReg")
+      val TDOdriven = RegNext(next=tdo_driven, init=false.B).suggestName("tdoeReg")
+      io.jtag.TDO.data   := TDOdata
+      io.jtag.TDO.driven := TDOdriven
+    }
   }
 
   //
@@ -104,21 +111,15 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
   irChain.io.chainIn.update := currState === JtagState.UpdateIR.U
   irChain.io.capture.bits := "b01".U
 
-  val updateInstruction = Wire(Bool())
-
-  val nextActiveInstruction = Wire(UInt(irLength.W))
-  val activeInstruction = NegEdgeReg(clock, nextActiveInstruction, initialInstruction.U, updateInstruction, name = Some("irReg"))
-   // 7.2.1d active instruction output latches on TCK falling edge
-
-  when (currState === JtagState.UpdateIR.U) {
-    nextActiveInstruction := irChain.io.update.bits
-    updateInstruction := true.B
-  } .otherwise {
-    // Needed when using chisel3._ (See #1160)
-    nextActiveInstruction := DontCare
-    updateInstruction := false.B
+  withClockAndReset(clock_falling, io.control.jtag_reset.asAsyncReset) {
+    val activeInstruction = RegInit(initialInstruction.U(irLength.W))
+    when (io.control.tapReset) {
+      activeInstruction := initialInstruction.U
+    }.elsewhen (currState === JtagState.UpdateIR.U) {
+      activeInstruction := irChain.io.update.bits
+    }
+    io.output.instruction := activeInstruction
   }
-  io.output.instruction := activeInstruction
 
   io.output.reset := currState === JtagState.TestLogicReset.U
 

--- a/src/main/scala/jtag/Utils.scala
+++ b/src/main/scala/jtag/Utils.scala
@@ -4,42 +4,12 @@ package freechips.rocketchip.jtag
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.AsyncResetReg
 
 /** Bundle representing a tristate pin.
   */
 class Tristate extends Bundle {
   val data = Bool()
   val driven = Bool()  // active high, pin is hi-Z when driven is low
-}
-
-/** Generates a register that updates on the falling edge of the input clock signal.
-  */
-object NegEdgeReg {
-  def apply[T <: Data](clock: Clock, next: T, enable: Bool=true.B, name: Option[String] = None): T = {
-    withClock((!clock.asUInt).asClock) {
-      val reg = RegEnable(next = next, enable = enable)
-      name.foreach{reg.suggestName(_)}
-      reg
-    }
-  }
-  def apply[T <: Data](clock: Clock, next: T, init: T, enable: Bool, name: Option[String]): T = {
-    withClock((!clock.asUInt).asClock) {
-      val reg = RegEnable(next = next, init = init, enable = enable)
-      name.foreach{reg.suggestName(_)}
-      reg
-    }
-  }
-}
-
-object NegEdgeAsyncResetReg {
-  def apply[T <: Data](clock: Clock, next: T, init: BigInt=0, enable: Bool=true.B, name: Option[String] = None): T = {
-    withClock((!clock.asUInt).asClock) {
-      val reg = AsyncResetReg(updateData = next.asUInt, resetData = init, enable = enable)
-      name.foreach{reg.suggestName(_)}
-      reg.asTypeOf(next)
-    }
-  }
 }
 
 /** A module that counts transitions on the input clock line, used as a basic sanity check and


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This PR changes the DebugTransport and JTAG modules to use abstract reset.  The jtag_reset signal is driven with an AsyncReset signal in tieoffDebug.  Old-style explicit instantiations of neg-edge registers and async-reset registers have been replaced by standard registers wrapped with the appropriate withClockAndReset.