### PR TITLE
OMAddressing: Only emit RegFields of width > 0

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMAddressing.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMAddressing.scala
@@ -166,7 +166,7 @@ object OMRegister {
         seq.map(_.width).scanLeft(0)(_ + _).zip(seq).map { case (bitOffset, regField) =>
           getRegField(regField, byteOffset, bitOffset)
         }
-    }.sortBy(_.bitRange.base)
+    }.sortBy(_.bitRange.base).filter(_.bitRange.size > 0)
   }
 
   private def makeGroups(mapping: Seq[(Int, Seq[RegField])]): Seq[OMRegFieldGroup] = {


### PR DESCRIPTION
The semantics of a register field with a width = 0 are rather undefined for downstream tools. Are you supposed to define software headers for them? Are you supposed to create documentation for them?

Simplify this confusion by just omitting them from the OM entirely.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

OMRegisterFields are no longer emitted if they are zero-width. They are omitted entirely from the Object Model emission.