### PR TITLE
Add CONTRIBUTING.md with instructions to bump submodules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ You can do this by simply editing the file in your text editor of choice.
 ```bash
 # Add and commit the submodule
 git add <submodule>
+git add wit-manifest.json
 git commit -m "<meaningful message about bumping>"
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+Contributing to Rocket Chip
+=====================
+
+Thank you for your interest in contributing to Rocket Chip!
+
+## Table of Contents
+
++ [Bumping Submodules](#bumping)
+
+### <a name="bumping"></a> Bumping Submodules
+
+Several projects are managed as git submodules as well as [Wit](https://github.com/sifive/wit) dependencies.
+
+### When to bump
+
+Most projects will be bumped by developers as needed; however,
+sometimes users may wish to speed up the bumping process.
+For more stable projects like Chisel 3 and FIRRTL,
+please only bump to stable branches as defined by the specific subproject.
+As of March 2020 these branches are `3.2.x` in Chisel 3 and `1.2.x` in FIRRTL.
+
+### How to bump
+
+1. Bump the Git submodule
+
+```bash
+# Check out a branch (starting at rocket-chip root
+git checkout -b my-bumping-branch
+
+# Check out the commit of the submodule you wish to bump to
+cd <submodule>
+git checkout <commit>
+cd ..
+```
+
+2. Bump the Wit submodule
+
+Update the `commit` field for the specific submodule in `wit-manifest.json`.
+You can do this by simply editing the file in your text editor of choice.
+
+**Tip** `git -C <submodule> rev-parse HEAD` will give you the commit hash
+
+3. Commit the changes
+
+```bash
+# Add and commit the submodule
+git add <submodule>
+git commit -m "<meaningful message about bumping>"
+```
+
+If you are bumping `Chisel 3` or `FIRRTL`, it is ideal to include some notes about
+major feature or performance improvements in your commit message.
+
+4. Open a Pull Request on Github
+
+Please see the Github documentation for [Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests)

--- a/README.md
+++ b/README.md
@@ -650,7 +650,9 @@ Further information about GDB debugging is available [here](https://sourceware.o
 
 ## <a name="contributors"></a> Contributors
 
-Can be found [here](https://github.com/ucb-bar/rocket-chip/graphs/contributors).
+Contributing guidelines can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+A list of contributors can be found [here](https://github.com/chipsalliance/rocket-chip/graphs/contributors).
 
 ## <a name="attribution"></a> Attribution
 


### PR DESCRIPTION
Mainly to mention that chisel3 and firrtl should only be bumped to
stable branches

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: NA

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Add `CONTRIBUTING.md` with instructions to bump submodules
