### PR TITLE
Add SeparateButSynchronousCrossingType

### DIFF
--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -315,6 +315,7 @@ sealed trait ClockCrossingType
 
 case object NoCrossing // converts to SynchronousCrossing(BufferParams.none) via implicit def in package
 case class SynchronousCrossing(params: BufferParams = BufferParams.default) extends ClockCrossingType
+case class SeparateButSynchronousCrossing(params: BufferParams = BufferParams.default) extends ClockCrossingType
 case class RationalCrossing(direction: RationalDirection = FastToSlow) extends ClockCrossingType
 case class AsynchronousCrossing(depth: Int = 8, sourceSync: Int = 3, sinkSync: Int = 3, safe: Boolean = true, narrow: Boolean = false) extends ClockCrossingType
 {

--- a/src/main/scala/interrupts/CrossingHelper.scala
+++ b/src/main/scala/interrupts/CrossingHelper.scala
@@ -12,7 +12,7 @@ case class IntInwardCrossingHelper(name: String, scope: LazyScope, node: IntInwa
         node :*=* scope { IntSyncAsyncCrossingSink(x.sinkSync) :*=* IntSyncNameNode(name) } :*=* IntSyncNameNode(name) :*=* IntSyncCrossingSource(alreadyRegistered)
       case RationalCrossing(_) =>
         node :*=* scope { IntSyncRationalCrossingSink() :*=* IntSyncNameNode(name) } :*=* IntSyncNameNode(name) :*=* IntSyncCrossingSource(alreadyRegistered)
-      case SynchronousCrossing(_) =>
+      case SynchronousCrossing(_) | SeparateButSynchronousCrossing (_) =>
         node :*=* scope { IntSyncSyncCrossingSink() :*=* IntSyncNameNode(name) } :*=* IntSyncNameNode(name) :*=* IntSyncCrossingSource(alreadyRegistered)
     }
   }
@@ -25,7 +25,7 @@ case class IntOutwardCrossingHelper(name: String, scope: LazyScope, node: IntOut
         IntSyncAsyncCrossingSink(x.sinkSync) :*=* IntSyncNameNode(name) :*=* scope { IntSyncNameNode(name) :*=* IntSyncCrossingSource(alreadyRegistered) } :*=* node
       case RationalCrossing(_) =>
         IntSyncRationalCrossingSink() :*=* IntSyncNameNode(name) :*=* scope { IntSyncNameNode(name) :*=* IntSyncCrossingSource(alreadyRegistered) } :*=* node
-      case SynchronousCrossing(buffer) =>
+      case SynchronousCrossing(_) | SeparateButSynchronousCrossing(_)=>
         IntSyncSyncCrossingSink() :*=* IntSyncNameNode(name) :*=* scope { IntSyncNameNode(name) :*=* IntSyncCrossingSource(alreadyRegistered) } :*=* node
     }
   }

--- a/src/main/scala/tilelink/CrossingHelper.scala
+++ b/src/main/scala/tilelink/CrossingHelper.scala
@@ -15,6 +15,8 @@ case class TLInwardCrossingHelper(name: String, scope: LazyScope, node: TLInward
         node :*=* scope { TLRationalCrossingSink(direction.flip) :*=* TLRationalNameNode(name) } :*=* TLRationalNameNode(name) :*=* TLRationalCrossingSource()
       case SynchronousCrossing(buffer) =>
         node :*=* scope { TLBuffer(buffer) :*=* TLNameNode(name) } :*=* TLNameNode(name)
+      case SeparateButSynchronousCrossing(buffer) =>
+        node :*=* scope { TLBuffer(buffer) :*=* TLNameNode(name) } :*=* TLNameNode(name)
     }
   }
 }
@@ -27,6 +29,8 @@ case class TLOutwardCrossingHelper(name: String, scope: LazyScope, node: TLOutwa
       case RationalCrossing(direction) =>
         TLRationalCrossingSink(direction) :*=* TLRationalNameNode(name) :*=* scope { TLRationalNameNode(name) :*=* TLRationalCrossingSource() } :*=* node
       case SynchronousCrossing(buffer) =>
+        TLNameNode(name) :*=* scope { TLNameNode(name) :*=* TLBuffer(buffer) } :*=* node
+      case SeparateButSynchronousCrossing(buffer) =>
         TLNameNode(name) :*=* scope { TLNameNode(name) :*=* TLBuffer(buffer) } :*=* node
     }
   }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Add a new `ClockCrossingType` : `SeparateButSynchronousCrossingType`. This represents an interface which (for whatever reason, perhaps power gating) has a separate reset and clock, but it should be synchronous to the other reset and clock. 

This isn't something that makes a ton of sense generally, so this is only supported in this PR far for interrupt crossings and tile link crossings. Anything else in this codebase would give a `MatchError` if it is attempted.