### PR TITLE
Chisel compile warning: TileLink Parameters v1

### DIFF
--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -11,9 +11,9 @@ import freechips.rocketchip.util._
 
 case class APBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(APBImp, TLImp)(
   dFn = { mp =>
-    TLClientPortParameters(
+    TLMasterPortParameters.v1(
       clients = mp.masters.map { m =>
-        TLClientParameters(name = m.name, nodePath = m.nodePath)
+        TLMasterParameters.v1(name = m.name, nodePath = m.nodePath)
       },
       requestFields = AMBAProtField() +: mp.requestFields,
       responseKeys  = mp.responseKeys)

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -13,10 +13,10 @@ case class AXI4ToTLNode(wcorrupt: Boolean)(implicit valName: ValName) extends Mi
   dFn = { case mp =>
     mp.masters.foreach { m => require (m.maxFlight.isDefined, "AXI4 must include a transaction maximum per ID to convert to TL") }
     val maxFlight = mp.masters.map(_.maxFlight.get).max
-    TLClientPortParameters(
+    TLMasterPortParameters.v1(
       clients = mp.masters.filter(_.maxFlight != Some(0)).flatMap { m =>
         for (id <- m.id.start until m.id.end)
-          yield TLClientParameters(
+          yield TLMasterParameters.v1(
             name        = s"${m.name} ID#${id}",
             sourceId    = IdRange(id * maxFlight*2, (id+1) * maxFlight*2), // R+W ids are distinct
             nodePath    = m.nodePath,

--- a/src/main/scala/devices/debug/DMI.scala
+++ b/src/main/scala/devices/debug/DMI.scala
@@ -84,7 +84,7 @@ class DMIToTL(implicit p: Parameters) extends LazyModule {
   // emitsGet = TransferSizes(4, 4),
   // emitsPutFull = TransferSizes(4, 4),
   // emitsPutPartial = TransferSizes(4, 4)
-  val node = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters("debug")))))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1("debug")))))
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -265,7 +265,7 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
 
   val cfg = p(DebugModuleKey).get
 
-  val node = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters("debug")))))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1("debug")))))
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -23,8 +23,8 @@ case object BootROMParams extends Field[BootROMParams]
 class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], executable: Boolean = true, beatBytes: Int = 4,
   resources: Seq[Resource] = new SimpleDevice("rom", Seq("sifive,rom0")).reg("mem"))(implicit p: Parameters) extends LazyModule
 {
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
+  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
+    Seq(TLSlaveParameters.v1(
       address     = List(AddressSet(base, size-1)),
       resources   = resources,
       regionType  = RegionType.UNCACHED,

--- a/src/main/scala/devices/tilelink/BusBypass.scala
+++ b/src/main/scala/devices/tilelink/BusBypass.scala
@@ -16,8 +16,8 @@ abstract class TLBusBypassBase(beatBytes: Int, deadlock: Boolean = false)(implic
   val node = NodeHandle(nodeIn, nodeOut)
 
   protected val bar = LazyModule(new TLBusBypassBar(dFn = { mp =>
-    mp.copy(managers = mp.managers.map { m =>
-      m.copy(
+    mp.v1copy(managers = mp.managers.map { m =>
+      m.v1copy(
         mayDenyPut = m.mayDenyPut || !deadlock,
         mayDenyGet = m.mayDenyGet || !deadlock)
     })
@@ -43,7 +43,7 @@ class TLBusBypass(beatBytes: Int)(implicit p: Parameters) extends TLBusBypassBas
   }
 }
 
-class TLBypassNode(dFn: TLManagerPortParameters => TLManagerPortParameters)(implicit valName: ValName) extends TLCustomNode
+class TLBypassNode(dFn: TLSlavePortParameters => TLSlavePortParameters)(implicit valName: ValName) extends TLCustomNode
 {
   def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
     require (iStars == 0 && oStars == 0, "TLBypass node does not support :=* or :*=")
@@ -51,11 +51,11 @@ class TLBypassNode(dFn: TLManagerPortParameters => TLManagerPortParameters)(impl
     require (oKnown == 2, "TLBypass node expects exactly two outputs")
     (0, 0)
   }
-  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] = { p ++ p }
-  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] = { Seq(dFn(p.last)) }
+  def mapParamsD(n: Int, p: Seq[TLMasterPortParameters]): Seq[TLMasterPortParameters] = { p ++ p }
+  def mapParamsU(n: Int, p: Seq[TLSlavePortParameters]): Seq[TLSlavePortParameters] = { Seq(dFn(p.last)) }
 }
 
-class TLBusBypassBar(dFn: TLManagerPortParameters => TLManagerPortParameters)(implicit p: Parameters) extends LazyModule
+class TLBusBypassBar(dFn: TLSlavePortParameters => TLSlavePortParameters)(implicit p: Parameters) extends LazyModule
 {
   val node = new TLBypassNode(dFn)
 

--- a/src/main/scala/devices/tilelink/DevNull.scala
+++ b/src/main/scala/devices/tilelink/DevNull.scala
@@ -32,8 +32,8 @@ abstract class DevNullDevice(params: DevNullParams, beatBytes: Int, device: Simp
   val atom = if (params.maxAtomic > 0) TransferSizes(1, params.maxAtomic) else TransferSizes.none
   val acq  = if (params.acquire) xfer else TransferSizes.none
   val hint = if (params.hint) xfer else TransferSizes.none
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
+  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
+    Seq(TLSlaveParameters.v1(
       address            = params.address,
       resources          = device.reg,
       regionType         = params.region,

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -12,8 +12,8 @@ case class MaskROMParams(address: BigInt, name: String, depth: Int = 2048, width
 
 class TLMaskROM(c: MaskROMParams)(implicit p: Parameters) extends LazyModule {
   val beatBytes = c.width/8
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
+  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
+    Seq(TLSlaveParameters.v1(
       address            = AddressSet.misaligned(c.address, c.depth*beatBytes),
       resources          = new SimpleDevice("rom", Seq("sifive,maskrom0")).reg("mem"),
       regionType         = RegionType.UNCACHED,

--- a/src/main/scala/devices/tilelink/MasterMux.scala
+++ b/src/main/scala/devices/tilelink/MasterMux.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-class MasterMuxNode(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(implicit valName: ValName) extends TLCustomNode
+class MasterMuxNode(uFn: Seq[TLMasterPortParameters] => TLMasterPortParameters)(implicit valName: ValName) extends TLCustomNode
 {
   def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
     require (iStars == 0 && oStars == 0, "MasterMux node does not support :=* or :*=")
@@ -16,13 +16,13 @@ class MasterMuxNode(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(
     require (oKnown == 1, "MasterMux node expects exactly one output")
     (0, 0)
   }
-  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] = { Seq(uFn(p)) }
-  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] = { p ++ p }
+  def mapParamsD(n: Int, p: Seq[TLMasterPortParameters]): Seq[TLMasterPortParameters] = { Seq(uFn(p)) }
+  def mapParamsU(n: Int, p: Seq[TLSlavePortParameters]): Seq[TLSlavePortParameters] = { p ++ p }
 }
 
 class MuteMaster(name: String = "MuteMaster", maxProbe: Int = 0)(implicit p: Parameters) extends LazyModule
 {
-  val node = TLClientNode(Seq(TLClientPortParameters(clients = Seq(TLClientParameters(
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(clients = Seq(TLMasterParameters.v1(
     name = name,
     supportsProbe = if (maxProbe > 0) TransferSizes(1, maxProbe) else TransferSizes.none)))))
 
@@ -38,7 +38,7 @@ class MuteMaster(name: String = "MuteMaster", maxProbe: Int = 0)(implicit p: Par
   }
 }
 
-class MasterMux(uFn: Seq[TLClientPortParameters] => TLClientPortParameters)(implicit p: Parameters) extends LazyModule
+class MasterMux(uFn: Seq[TLMasterPortParameters] => TLMasterPortParameters)(implicit p: Parameters) extends LazyModule
 {
   val node = new MasterMuxNode(uFn)
 

--- a/src/main/scala/devices/tilelink/PhysicalFilter.scala
+++ b/src/main/scala/devices/tilelink/PhysicalFilter.scala
@@ -88,8 +88,8 @@ case class PhysicalFilterParams(
 
 class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) extends LazyModule
 {
-  val node = TLAdapterNode(managerFn = { mp => mp.copy(
-    managers      = mp.managers.map(_.copy(alwaysGrantsT = false)),
+  val node = TLAdapterNode(managerFn = { mp => mp.v1copy(
+    managers      = mp.managers.map(_.v1copy(alwaysGrantsT = false)),
     endSinkId     = if (mp.endSinkId == 0) { 0 } else { mp.endSinkId+1 },
     minLatency    = 1 min mp.minLatency)})
 

--- a/src/main/scala/devices/tilelink/TestRAM.scala
+++ b/src/main/scala/devices/tilelink/TestRAM.scala
@@ -13,8 +13,8 @@ class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int 
 {
   val device = new MemoryDevice
 
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
+  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
+    Seq(TLSlaveParameters.v1(
       address            = List(address),
       resources          = device.reg,
       regionType         = RegionType.UNCACHED,

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -177,19 +177,19 @@ abstract class HellaCache(hartid: Int)(implicit p: Parameters) extends LazyModul
     with HasNonDiplomaticTileParameters {
   protected val cfg = tileParams.dcache.get
 
-  protected def cacheClientParameters = cfg.scratch.map(x => Seq()).getOrElse(Seq(TLClientParameters(
+  protected def cacheClientParameters = cfg.scratch.map(x => Seq()).getOrElse(Seq(TLMasterParameters.v1(
     name          = s"Core ${hartid} DCache",
     sourceId      = IdRange(0, 1 max cfg.nMSHRs),
     supportsProbe = TransferSizes(cfg.blockBytes, cfg.blockBytes))))
 
-  protected def mmioClientParameters = Seq(TLClientParameters(
+  protected def mmioClientParameters = Seq(TLMasterParameters.v1(
     name          = s"Core ${hartid} DCache MMIO",
     sourceId      = IdRange(firstMMIO, firstMMIO + cfg.nMMIOs),
     requestFifo   = true))
 
   def firstMMIO = (cacheClientParameters.map(_.sourceId.end) :+ 0).max
 
-  val node = TLClientNode(Seq(TLClientPortParameters(
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(
     cacheClientParameters ++ mmioClientParameters,
     minLatency = 1)))
 

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -51,7 +51,7 @@ class ICacheErrors(implicit p: Parameters) extends CoreBundle()(p)
 
 class ICache(val icacheParams: ICacheParams, val hartId: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new ICacheModule(this)
-  val masterNode = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters(
+  val masterNode = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1(
     sourceId = IdRange(0, 1 + icacheParams.prefetch.toInt), // 0=refill, 1=hint
     name = s"Core ${hartId} ICache")))))
 
@@ -76,8 +76,8 @@ class ICache(val icacheParams: ICacheParams, val hartId: Int)(implicit p: Parame
 
   private val wordBytes = icacheParams.fetchBytes
   val slaveNode =
-    TLManagerNode(icacheParams.itimAddr.toSeq.map { itimAddr => TLManagerPortParameters(
-      Seq(TLManagerParameters(
+    TLManagerNode(icacheParams.itimAddr.toSeq.map { itimAddr => TLSlavePortParameters.v1(
+      Seq(TLSlaveParameters.v1(
         address         = Seq(AddressSet(itimAddr, size-1)),
         resources       = device.reg("mem"),
         regionType      = RegionType.IDEMPOTENT,

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -19,8 +19,8 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
 
   val device = new SimpleDevice("dtim", Seq("sifive,dtim0"))
 
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
+  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
+    Seq(TLSlaveParameters.v1(
       address            = address,
       resources          = device.reg("mem"),
       regionType         = RegionType.IDEMPOTENT,

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -135,8 +135,8 @@ trait CanHaveMasterTLMMIOPort { this: BaseSubsystem =>
 
   val mmioTLNode = TLManagerNode(
     mmioPortParamsOpt.map(params =>
-      TLManagerPortParameters(
-        managers = Seq(TLManagerParameters(
+      TLSlavePortParameters.v1(
+        managers = Seq(TLSlaveParameters.v1(
           address            = AddressSet.misaligned(params.base, params.size),
           resources          = device.ranges,
           executable         = params.executable,
@@ -170,8 +170,8 @@ trait CanHaveSlaveTLPort { this: BaseSubsystem =>
 
   val l2FrontendTLNode = TLClientNode(
     slavePortParamsOpt.map(params =>
-      TLClientPortParameters(
-        clients = Seq(TLClientParameters(
+      TLMasterPortParameters.v1(
+        clients = Seq(TLMasterParameters.v1(
           name     = portName.kebab,
           sourceId = IdRange(0, 1 << params.idBits))))).toSeq)
 

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -236,7 +236,7 @@ class TranslatorExampleModuleImp(outer: TranslatorExample)(implicit p: Parameter
 
 class  CharacterCountExample(opcodes: OpcodeSet)(implicit p: Parameters) extends LazyRoCC(opcodes) {
   override lazy val module = new CharacterCountExampleModuleImp(this)
-  override val atlNode = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters("CharacterCountRoCC")))))
+  override val atlNode = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1("CharacterCountRoCC")))))
 }
 
 class CharacterCountExampleModuleImp(outer: CharacterCountExample)(implicit p: Parameters) extends LazyRoCCModuleImp(outer)

--- a/src/main/scala/tilelink/AtomicAutomata.scala
+++ b/src/main/scala/tilelink/AtomicAutomata.scala
@@ -15,13 +15,13 @@ class TLAtomicAutomata(logical: Boolean = true, arithmetic: Boolean = true, conc
   require (concurrency >= 1)
 
   val node = TLAdapterNode(
-    managerFn = { case mp => mp.copy(managers = mp.managers.map { m =>
+    managerFn = { case mp => mp.v1copy(managers = mp.managers.map { m =>
       val ourSupport = TransferSizes(1, mp.beatBytes)
       def widen(x: TransferSizes) = if (passthrough && x.min <= 2*mp.beatBytes) TransferSizes(1, max(mp.beatBytes, x.max)) else ourSupport
       val canDoit = m.supportsPutFull.contains(ourSupport) && m.supportsGet.contains(ourSupport)
       // Blow up if there are devices to which we cannot add Atomics, because their R|W are too inflexible
       require (!m.supportsPutFull || !m.supportsGet || canDoit, s"${m.name} has $ourSupport, needed PutFull(${m.supportsPutFull}) or Get(${m.supportsGet})")
-      m.copy(
+      m.v1copy(
         supportsArithmetic = if (!arithmetic || !canDoit) m.supportsArithmetic else widen(m.supportsArithmetic),
         supportsLogical    = if (!logical    || !canDoit) m.supportsLogical    else widen(m.supportsLogical),
         mayDenyGet         = m.mayDenyGet || m.mayDenyPut)
@@ -60,7 +60,7 @@ class TLAtomicAutomata(logical: Boolean = true, arithmetic: Boolean = true, conc
       // Don't overprovision the CAM
       val camSize = min(domainsNeedingHelp.size, concurrency)
       // Compact the fifoIds to only those we care about
-      def camFifoId(m: TLManagerParameters) = m.fifoId.map(id => max(0, domainsNeedingHelp.indexOf(id))).getOrElse(0)
+      def camFifoId(m: TLSlaveParameters) = m.fifoId.map(id => max(0, domainsNeedingHelp.indexOf(id))).getOrElse(0)
 
       // CAM entry state machine
       val FREE = UInt(0) // unused                   waiting on Atomic from A

--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -21,8 +21,8 @@ case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCus
     (iStar, oStar)
   }
 
-  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] =
-    (p zip ids) map { case (cp, id) => cp.copy(clients = cp.clients.map { c => c.copy(
+  def mapParamsD(n: Int, p: Seq[TLMasterPortParameters]): Seq[TLMasterPortParameters] =
+    (p zip ids) map { case (cp, id) => cp.v1copy(clients = cp.clients.map { c => c.v1copy(
       visibility         = c.visibility.flatMap { a => a.intersect(AddressSet(id, ~mask))},
       supportsProbe      = c.supportsProbe      intersect maxXfer,
       supportsArithmetic = c.supportsArithmetic intersect maxXfer,
@@ -32,11 +32,11 @@ case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCus
       supportsPutPartial = c.supportsPutPartial intersect maxXfer,
       supportsHint       = c.supportsHint       intersect maxXfer)})}
 
-  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] =
-    (p zip ids) map { case (mp, id) => mp.copy(managers = mp.managers.flatMap { m =>
+  def mapParamsU(n: Int, p: Seq[TLSlavePortParameters]): Seq[TLSlavePortParameters] =
+    (p zip ids) map { case (mp, id) => mp.v1copy(managers = mp.managers.flatMap { m =>
       val addresses = m.address.flatMap(a => a.intersect(AddressSet(id, ~mask)))
       if (addresses.nonEmpty)
-        Some(m.copy(
+        Some(m.v1copy(
           address            = addresses,
           supportsAcquireT   = m.supportsAcquireT   intersect maxXfer,
           supportsAcquireB   = m.supportsAcquireB   intersect maxXfer,

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -15,12 +15,12 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
 
   val node = TLAdapterNode(
     clientFn  = { cp =>
-      cp.copy(clients = Seq(TLClientParameters(
+      cp.v1copy(clients = Seq(TLMasterParameters.v1(
         name     = "TLBroadcast",
         sourceId = IdRange(0, 1 << log2Ceil(cp.endSourceId*4)))))
     },
     managerFn = { mp =>
-      mp.copy(
+      mp.v1copy(
         endSinkId  = numTrackers,
         managers   = mp.managers.map { m =>
           // We are the last level manager
@@ -31,7 +31,7 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
             val lowerBound = max(m.supportsPutFull.min, m.supportsGet.min)
             require (!m.supportsPutFull || m.supportsPutFull.contains(lineBytes), s"${m.name} only supports PutFull(${m.supportsPutFull}), which does not include $lineBytes")
             require (!m.supportsGet     || m.supportsGet    .contains(lineBytes), s"${m.name} only supports Get(${m.supportsGet}), which does not include $lineBytes")
-            m.copy(
+            m.v1copy(
               regionType         = RegionType.TRACKED,
               supportsAcquireB   = TransferSizes(lowerBound, lineBytes),
               supportsAcquireT   = if (m.supportsPutFull) TransferSizes(lowerBound, lineBytes) else TransferSizes.none,

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -13,8 +13,8 @@ class TLBufferNode (
   c: BufferParams,
   d: BufferParams,
   e: BufferParams)(implicit valName: ValName) extends TLAdapterNode(
-    clientFn  = { p => p.copy(minLatency = p.minLatency + b.latency + c.latency) },
-    managerFn = { p => p.copy(minLatency = p.minLatency + a.latency + d.latency) }
+    clientFn  = { p => p.v1copy(minLatency = p.minLatency + b.latency + c.latency) },
+    managerFn = { p => p.v1copy(minLatency = p.minLatency + a.latency + d.latency) }
 ) {
   override lazy val nodedebugstring = s"a:${a.toString}, b:${b.toString}, c:${c.toString}, d:${d.toString}, e:${e.toString}"
 

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -13,13 +13,13 @@ class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Paramet
 {
   val node = TLAdapterNode(
     clientFn  = { case cp =>
-      cp.copy(clients = cp.clients.map { c => c.copy(
+      cp.v1copy(clients = cp.clients.map { c => c.v1copy(
         supportsProbe = TransferSizes.none,
         sourceId = IdRange(c.sourceId.start*2, c.sourceId.end*2))})},
     managerFn = { case mp =>
-      mp.copy(
+      mp.v1copy(
         endSinkId = if (mp.managers.exists(_.regionType == RegionType.UNCACHED)) sinkIds else 0,
-        managers = mp.managers.map { m => m.copy(
+        managers = mp.managers.map { m => m.v1copy(
           supportsAcquireB = if (m.regionType == RegionType.UNCACHED) m.supportsGet     else m.supportsAcquireB,
           supportsAcquireT = if (m.regionType == RegionType.UNCACHED) m.supportsPutFull else m.supportsAcquireT,
           alwaysGrantsT    = if (m.regionType == RegionType.UNCACHED) m.supportsPutFull else m.alwaysGrantsT)})})

--- a/src/main/scala/tilelink/ErrorEvaluator.scala
+++ b/src/main/scala/tilelink/ErrorEvaluator.scala
@@ -36,8 +36,8 @@ object RequestPattern
 // This helps when building unit tests to confirm that errors are propagated correctly.
 class TLErrorEvaluator(test: RequestPattern, testOn: Boolean, testOff: Boolean, deny: Boolean = false)(implicit p: Parameters) extends LazyModule
 {
-  val node = TLAdapterNode(managerFn = { mp => mp.copy(managers =
-    mp.managers.map { m => m.copy(mayDenyPut = true, mayDenyGet = deny || m.mayDenyGet) }) })
+  val node = TLAdapterNode(managerFn = { mp => mp.v1copy(managers =
+    mp.managers.map { m => m.v1copy(mayDenyPut = true, mayDenyGet = deny || m.mayDenyGet) }) })
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>

--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -13,7 +13,7 @@ class TLFilter(
   )(implicit p: Parameters) extends LazyModule
 {
   val node = TLAdapterNode(
-    clientFn  = { cp => cp.copy(clients = cp.clients.flatMap { c =>
+    clientFn  = { cp => cp.v1copy(clients = cp.clients.flatMap { c =>
       val out = cfilter(c)
       out.map { o => // Confirm the filter only REMOVES capability
         require (c.sourceId.contains(o.sourceId))
@@ -47,7 +47,7 @@ class TLFilter(
         }
         out
       }
-      mp.copy(managers = managers,
+      mp.v1copy(managers = managers,
               endSinkId = if (managers.exists(_.supportsAcquireB)) mp.endSinkId else 0)
     })
 
@@ -70,8 +70,8 @@ class TLFilter(
 
 object TLFilter
 {
-  type ManagerFilter = TLManagerParameters => Option[TLManagerParameters]
-  type ClientFilter = TLClientParameters => Option[TLClientParameters]
+  type ManagerFilter = TLSlaveParameters => Option[TLSlaveParameters]
+  type ClientFilter = TLMasterParameters => Option[TLMasterParameters]
 
   // preserve manager visibility
   def mIdentity: ManagerFilter = { m => Some(m) }
@@ -93,12 +93,12 @@ object TLFilter
   }
 
   // adjust supported transfer sizes based on filtered intersection
-  private def transferSizeHelper(m: TLManagerParameters, filtered: Seq[AddressSet], alignment: BigInt): Option[TLManagerParameters] = {
+  private def transferSizeHelper(m: TLSlaveParameters, filtered: Seq[AddressSet], alignment: BigInt): Option[TLSlaveParameters] = {
     val maxTransfer = 1 << 30
     val capTransfer = if (alignment == 0 || alignment > maxTransfer) maxTransfer else alignment.toInt
     val cap = TransferSizes(1, capTransfer)
     if (filtered.isEmpty) { None } else {
-      Some(m.copy(
+      Some(m.v1copy(
         address            = filtered,
         supportsAcquireT   = m.supportsAcquireT  .intersect(cap),
         supportsAcquireB   = m.supportsAcquireB  .intersect(cap),
@@ -114,7 +114,7 @@ object TLFilter
   // hide any fully contained address sets
   def mHideContained(containedBy: AddressSet): ManagerFilter = { m =>
     val filtered = m.address.filterNot(containedBy.contains(_))
-    if (filtered.isEmpty) None else Some(m.copy(address = filtered))
+    if (filtered.isEmpty) None else Some(m.v1copy(address = filtered))
   }
   // hide all cacheable managers
   def mHideCacheable: ManagerFilter = { m =>
@@ -127,7 +127,7 @@ object TLFilter
   // cacheable managers cannot be acquired from
   def mMaskCacheable: ManagerFilter = { m =>
     if (m.supportsAcquireB) {
-      Some(m.copy(
+      Some(m.v1copy(
         regionType       = RegionType.UNCACHED,
         supportsAcquireB = TransferSizes.none,
         supportsAcquireT = TransferSizes.none,
@@ -137,7 +137,7 @@ object TLFilter
   // only cacheable managers are visible, but cannot be acquired from
   def mSelectAndMaskCacheable: ManagerFilter = { m =>
     if (m.supportsAcquireB) {
-      Some(m.copy(
+      Some(m.v1copy(
         regionType       = RegionType.UNCACHED,
         supportsAcquireB = TransferSizes.none,
         supportsAcquireT = TransferSizes.none,

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -43,7 +43,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
     if (!alwaysMin) x else
     if (x.min <= minSize) TransferSizes(x.min, min(minSize, x.max)) else
     TransferSizes.none
-  def mapManager(m: TLManagerParameters) = m.copy(
+  def mapManager(m: TLSlaveParameters) = m.v1copy(
     supportsArithmetic = shrinkTransfer(m.supportsArithmetic),
     supportsLogical    = shrinkTransfer(m.supportsLogical),
     supportsGet        = expandTransfer(m.supportsGet, "Get"),
@@ -54,8 +54,8 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
   val node = TLAdapterNode(
     // We require that all the responses are mutually FIFO
     // Thus we need to compact all of the masters into one big master
-    clientFn  = { c => c.copy(
-      clients = Seq(TLClientParameters(
+    clientFn  = { c => c.v1copy(
+      clients = Seq(TLMasterParameters.v1(
         name        = "TLFragmenter",
         sourceId    = IdRange(0, if (minSize == maxSize) c.endSourceId else (c.endSourceId << addedBits)),
         requestFifo = true))),
@@ -69,7 +69,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         // emitsPutPartial = c.clients.map(_.knownToEmit.get.emitsPutPartial).reduce(_ smallestintervalcover _),
         // emitsHint = c.clients.map(_.knownToEmit.get.emitsHint).reduce(_ smallestintervalcover _)
     },
-    managerFn = { m => m.copy(managers = m.managers.map(mapManager)) })
+    managerFn = { m => m.v1copy(managers = m.managers.map(mapManager)) })
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>

--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -95,18 +95,18 @@ class TLFuzzer(
     require(n > 0, s"nOrdered must be > 0, not $n")
     require((inFlight % n) == 0, s"inFlight (${inFlight}) must be evenly divisible by nOrdered (${nOrdered}).")
     Seq.tabulate(n) {i =>
-      TLClientParameters(name =s"OrderedFuzzer$i",
+      TLMasterParameters.v1(name =s"OrderedFuzzer$i",
         sourceId = IdRange(i * (inFlight/n),  (i + 1)*(inFlight/n)),
         requestFifo = true)
     }
   } else {
-    Seq(TLClientParameters(
+    Seq(TLMasterParameters.v1(
       name = "Fuzzer",
       sourceId = IdRange(0,inFlight)
     ))
   }
 
-  val node = TLClientNode(Seq(TLClientPortParameters(clientParams)))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(clientParams)))
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {

--- a/src/main/scala/tilelink/HintHandler.scala
+++ b/src/main/scala/tilelink/HintHandler.scala
@@ -15,10 +15,10 @@ class TLHintHandler(passthrough: Boolean = true)(implicit p: Parameters) extends
 {
   val node = TLAdapterNode(
     clientFn = { cp =>
-      cp.copy(clients = cp.clients.map { c => c.copy(
+      cp.v1copy(clients = cp.clients.map { c => c.v1copy(
         sourceId = IdRange(c.sourceId.start*2, c.sourceId.end*2))})},
     managerFn = { mp =>
-      mp.copy(managers = mp.managers.map { m => m.copy(
+      mp.v1copy(managers = mp.managers.map { m => m.v1copy(
         supportsHint =
           if (m.supportsHint && passthrough) m.supportsHint
           else if (m.supportsPutPartial) m.supportsPutPartial
@@ -35,8 +35,8 @@ class TLHintHandler(passthrough: Boolean = true)(implicit p: Parameters) extends
       }
 
       val isHint = in.a.bits.opcode === TLMessages.Hint
-      def usePP (m: TLManagerParameters) = !(passthrough && m.supportsHint) && m.supportsPutPartial
-      def useGet(m: TLManagerParameters) = !(passthrough && m.supportsHint) && !m.supportsPutPartial
+      def usePP (m: TLSlaveParameters) = !(passthrough && m.supportsHint) && m.supportsPutPartial
+      def useGet(m: TLSlaveParameters) = !(passthrough && m.supportsHint) && !m.supportsPutPartial
 
       // Does the HintHandler help using PutPartial with this message?
       val helpPP = isHint && edgeOut.manager.fastProperty(in.a.bits.address, usePP, (b:Boolean) => b.B)

--- a/src/main/scala/tilelink/Jbar.scala
+++ b/src/main/scala/tilelink/Jbar.scala
@@ -10,10 +10,10 @@ class TLJbar(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLA
 {
   val node = TLJunctionNode(clientRatio, managerRatio,
     clientFn  = { seq =>
-      Seq.fill(managerRatio)(seq(0).copy(
+      Seq.fill(managerRatio)(seq(0).v1copy(
         minLatency = seq.map(_.minLatency).min,
         clients = (TLXbar.mapInputIds(seq) zip seq) flatMap { case (range, port) =>
-          port.clients map { client => client.copy(
+          port.clients map { client => client.v1copy(
             sourceId = client.sourceId.shift(range.start)
           )}
         }
@@ -21,14 +21,14 @@ class TLJbar(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLA
     },
     managerFn = { seq =>
       val fifoIdFactory = TLXbar.relabeler()
-      Seq.fill(clientRatio)(seq(0).copy(
+      Seq.fill(clientRatio)(seq(0).v1copy(
         minLatency = seq.map(_.minLatency).min,
         endSinkId = TLXbar.mapOutputIds(seq).map(_.end).max,
         managers = seq.flatMap { port =>
           require (port.beatBytes == seq(0).beatBytes,
             s"Xbar data widths don't match: ${port.managers.map(_.name)} has ${port.beatBytes}B vs ${seq(0).managers.map(_.name)} has ${seq(0).beatBytes}B")
           val fifoIdMapper = fifoIdFactory()
-          port.managers map { manager => manager.copy(
+          port.managers map { manager => manager.v1copy(
             fifoId = manager.fifoId.map(fifoIdMapper(_))
           )}
         }

--- a/src/main/scala/tilelink/Map.scala
+++ b/src/main/scala/tilelink/Map.scala
@@ -14,8 +14,8 @@ class TLMap(fn: AddressSet => BigInt)(implicit p: Parameters) extends LazyModule
   val node = TLAdapterNode(
     clientFn = { cp => cp },
     managerFn = { mp =>
-      mp.copy(managers = mp.managers.map(m =>
-        m.copy(address = m.address.map(a =>
+      mp.v1copy(managers = mp.managers.map(m =>
+        m.v1copy(address = m.address.map(a =>
           AddressSet(fn(a), a.mask)))))})
 
   lazy val module = new LazyModuleImp(this) {

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -11,10 +11,10 @@ import scala.collection.mutable.ListBuffer
 
 case object TLMonitorBuilder extends Field[TLMonitorArgs => TLMonitorBase](args => new TLMonitor(args))
 
-object TLImp extends NodeImp[TLClientPortParameters, TLManagerPortParameters, TLEdgeOut, TLEdgeIn, TLBundle]
+object TLImp extends NodeImp[TLMasterPortParameters, TLSlavePortParameters, TLEdgeOut, TLEdgeIn, TLBundle]
 {
-  def edgeO(pd: TLClientPortParameters, pu: TLManagerPortParameters, p: Parameters, sourceInfo: SourceInfo) = new TLEdgeOut(pd, pu, p, sourceInfo)
-  def edgeI(pd: TLClientPortParameters, pu: TLManagerPortParameters, p: Parameters, sourceInfo: SourceInfo) = new TLEdgeIn (pd, pu, p, sourceInfo)
+  def edgeO(pd: TLMasterPortParameters, pu: TLSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = new TLEdgeOut(pd, pu, p, sourceInfo)
+  def edgeI(pd: TLMasterPortParameters, pu: TLSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = new TLEdgeIn (pd, pu, p, sourceInfo)
 
   def bundleO(eo: TLEdgeOut) = TLBundle(eo.bundle)
   def bundleI(ei: TLEdgeIn)  = TLBundle(ei.bundle)
@@ -26,28 +26,28 @@ object TLImp extends NodeImp[TLClientPortParameters, TLManagerPortParameters, TL
     monitor.io.in := bundle
   }
 
-  override def mixO(pd: TLClientPortParameters, node: OutwardNode[TLClientPortParameters, TLManagerPortParameters, TLBundle]): TLClientPortParameters  =
-    pd.copy(clients  = pd.clients.map  { c => c.copy (nodePath = node +: c.nodePath) })
-  override def mixI(pu: TLManagerPortParameters, node: InwardNode[TLClientPortParameters, TLManagerPortParameters, TLBundle]): TLManagerPortParameters =
-    pu.copy(managers = pu.managers.map { m => m.copy (nodePath = node +: m.nodePath) })
+  override def mixO(pd: TLMasterPortParameters, node: OutwardNode[TLMasterPortParameters, TLSlavePortParameters, TLBundle]): TLMasterPortParameters  =
+    pd.v1copy(clients  = pd.clients.map  { c => c.v1copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: TLSlavePortParameters, node: InwardNode[TLMasterPortParameters, TLSlavePortParameters, TLBundle]): TLSlavePortParameters =
+    pu.v1copy(managers = pu.managers.map { m => m.v1copy (nodePath = node +: m.nodePath) })
 }
 
 trait TLFormatNode extends FormatNode[TLEdgeIn, TLEdgeOut] 
 
-case class TLClientNode(portParams: Seq[TLClientPortParameters])(implicit valName: ValName) extends SourceNode(TLImp)(portParams) with TLFormatNode
-case class TLManagerNode(portParams: Seq[TLManagerPortParameters])(implicit valName: ValName) extends SinkNode(TLImp)(portParams) with TLFormatNode
+case class TLClientNode(portParams: Seq[TLMasterPortParameters])(implicit valName: ValName) extends SourceNode(TLImp)(portParams) with TLFormatNode
+case class TLManagerNode(portParams: Seq[TLSlavePortParameters])(implicit valName: ValName) extends SinkNode(TLImp)(portParams) with TLFormatNode
 
 case class TLAdapterNode(
-  clientFn:  TLClientPortParameters  => TLClientPortParameters  = { s => s },
-  managerFn: TLManagerPortParameters => TLManagerPortParameters = { s => s })(
+  clientFn:  TLMasterPortParameters => TLMasterPortParameters = { s => s },
+  managerFn: TLSlavePortParameters  => TLSlavePortParameters  = { s => s })(
   implicit valName: ValName)
   extends AdapterNode(TLImp)(clientFn, managerFn) with TLFormatNode
 
 case class TLJunctionNode(
   clientRatio:  Int,
   managerRatio: Int,
-  clientFn:     Seq[TLClientPortParameters]  => Seq[TLClientPortParameters],
-  managerFn:    Seq[TLManagerPortParameters] => Seq[TLManagerPortParameters])(
+  clientFn:     Seq[TLMasterPortParameters] => Seq[TLMasterPortParameters],
+  managerFn:    Seq[TLSlavePortParameters]  => Seq[TLSlavePortParameters])(
   implicit valName: ValName)
   extends JunctionNode(TLImp)(clientRatio, managerRatio, clientFn, managerFn) with TLFormatNode
 
@@ -61,8 +61,8 @@ object TLNameNode {
 }
 
 case class TLNexusNode(
-  clientFn:        Seq[TLClientPortParameters]  => TLClientPortParameters,
-  managerFn:       Seq[TLManagerPortParameters] => TLManagerPortParameters)(
+  clientFn:        Seq[TLMasterPortParameters] => TLMasterPortParameters,
+  managerFn:       Seq[TLSlavePortParameters]  => TLSlavePortParameters)(
   implicit valName: ValName)
   extends NexusNode(TLImp)(clientFn, managerFn) with TLFormatNode
 
@@ -80,9 +80,9 @@ object TLAsyncImp extends SimpleNodeImp[TLAsyncClientPortParameters, TLAsyncMana
   def render(e: TLAsyncEdgeParameters) = RenderedEdge(colour = "#ff0000" /* red */, label = e.manager.async.depth.toString)
 
   override def mixO(pd: TLAsyncClientPortParameters, node: OutwardNode[TLAsyncClientPortParameters, TLAsyncManagerPortParameters, TLAsyncBundle]): TLAsyncClientPortParameters  =
-   pd.copy(base = pd.base.copy(clients  = pd.base.clients.map  { c => c.copy (nodePath = node +: c.nodePath) }))
+   pd.copy(base = pd.base.v1copy(clients  = pd.base.clients.map  { c => c.v1copy (nodePath = node +: c.nodePath) }))
   override def mixI(pu: TLAsyncManagerPortParameters, node: InwardNode[TLAsyncClientPortParameters, TLAsyncManagerPortParameters, TLAsyncBundle]): TLAsyncManagerPortParameters =
-   pu.copy(base = pu.base.copy(managers = pu.base.managers.map { m => m.copy (nodePath = node +: m.nodePath) }))
+   pu.copy(base = pu.base.v1copy(managers = pu.base.managers.map { m => m.v1copy (nodePath = node +: m.nodePath) }))
 }
 
 case class TLAsyncAdapterNode(
@@ -102,10 +102,10 @@ object TLAsyncNameNode {
 case class TLAsyncSourceNode(sync: Option[Int])(implicit valName: ValName)
   extends MixedAdapterNode(TLImp, TLAsyncImp)(
     dFn = { p => TLAsyncClientPortParameters(p) },
-    uFn = { p => p.base.copy(minLatency = p.base.minLatency + sync.getOrElse(p.async.sync)) }) with FormatNode[TLEdgeIn, TLAsyncEdgeParameters] // discard cycles in other clock domain
+    uFn = { p => p.base.v1copy(minLatency = p.base.minLatency + sync.getOrElse(p.async.sync)) }) with FormatNode[TLEdgeIn, TLAsyncEdgeParameters] // discard cycles in other clock domain
 case class TLAsyncSinkNode(async: AsyncQueueParams)(implicit valName: ValName)
   extends MixedAdapterNode(TLAsyncImp, TLImp)(
-    dFn = { p => p.base.copy(minLatency = p.base.minLatency + async.sync) },
+    dFn = { p => p.base.v1copy(minLatency = p.base.minLatency + async.sync) },
     uFn = { p => TLAsyncManagerPortParameters(async, p) }) with FormatNode[TLAsyncEdgeParameters, TLEdgeOut]
 
 // Rationally related crossings
@@ -119,9 +119,9 @@ object TLRationalImp extends SimpleNodeImp[TLRationalClientPortParameters, TLRat
   def render(e: TLRationalEdgeParameters) = RenderedEdge(colour = "#00ff00" /* green */)
 
   override def mixO(pd: TLRationalClientPortParameters, node: OutwardNode[TLRationalClientPortParameters, TLRationalManagerPortParameters, TLRationalBundle]): TLRationalClientPortParameters  =
-   pd.copy(base = pd.base.copy(clients  = pd.base.clients.map  { c => c.copy (nodePath = node +: c.nodePath) }))
+   pd.copy(base = pd.base.v1copy(clients  = pd.base.clients.map  { c => c.v1copy (nodePath = node +: c.nodePath) }))
   override def mixI(pu: TLRationalManagerPortParameters, node: InwardNode[TLRationalClientPortParameters, TLRationalManagerPortParameters, TLRationalBundle]): TLRationalManagerPortParameters =
-   pu.copy(base = pu.base.copy(managers = pu.base.managers.map { m => m.copy (nodePath = node +: m.nodePath) }))
+   pu.copy(base = pu.base.v1copy(managers = pu.base.managers.map { m => m.v1copy (nodePath = node +: m.nodePath) }))
 }
 
 case class TLRationalAdapterNode(
@@ -141,8 +141,8 @@ object TLRationalNameNode {
 case class TLRationalSourceNode()(implicit valName: ValName)
   extends MixedAdapterNode(TLImp, TLRationalImp)(
     dFn = { p => TLRationalClientPortParameters(p) },
-    uFn = { p => p.base.copy(minLatency = 1) }) with FormatNode[TLEdgeIn, TLRationalEdgeParameters] // discard cycles from other clock domain
+    uFn = { p => p.base.v1copy(minLatency = 1) }) with FormatNode[TLEdgeIn, TLRationalEdgeParameters] // discard cycles from other clock domain
 case class TLRationalSinkNode(direction: RationalDirection)(implicit valName: ValName)
   extends MixedAdapterNode(TLRationalImp, TLImp)(
-    dFn = { p => p.base.copy(minLatency = 1) },
+    dFn = { p => p.base.v1copy(minLatency = 1) },
     uFn = { p => TLRationalManagerPortParameters(direction, p) }) with FormatNode[TLRationalEdgeParameters, TLEdgeOut]

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -283,7 +283,7 @@ class TLSlaveParameters private(
       fifoId        = fifoId)
   }
 
-  @deprecated("Use v1copy","")
+  @deprecated("Use v1copy instead of copy","")
   def copy(
     address:            Seq[AddressSet] = address,
     resources:          Seq[Resource]   = resources,
@@ -369,7 +369,7 @@ object TLSlaveParameters {
 }
 
 object TLManagerParameters {
-  @deprecated("Use TLSlaveParameters.v1() instead of TLManagerParameters()","")
+  @deprecated("Use TLSlaveParameters.v1 instead of TLManagerParameters","")
   def apply(
     address:            Seq[AddressSet],
     resources:          Seq[Resource] = Seq(),
@@ -594,6 +594,7 @@ class TLSlavePortParameters private(
       requestKeys    = requestKeys)
   }
 
+  @deprecated("Use v1copy instead of copy","")
   def copy(
     managers:   Seq[TLSlaveParameters] = slaves,
     beatBytes:  Int = -1,
@@ -632,7 +633,7 @@ object TLSlavePortParameters {
 }
 
 object TLManagerPortParameters {
-  @deprecated("Use TLSlavePortParameters.v1","")
+  @deprecated("Use TLSlavePortParameters.v1 instead of TLManagerPortParameters","")
   def apply(
     managers:   Seq[TLSlaveParameters],
     beatBytes:  Int,
@@ -822,7 +823,7 @@ object TLMasterParameters {
 }
   
 object TLClientParameters {
-  @deprecated("Use TLMasterParameters.v1() instead of TLClientParameters","")
+  @deprecated("Use TLMasterParameters.v1 instead of TLClientParameters","")
   def apply(
     name:                String,
     sourceId:            IdRange         = IdRange(0,1),
@@ -957,7 +958,7 @@ class TLMasterPortParameters private(
       responseKeys  = responseKeys)
   }
 
-  @deprecated("Use v1copy","")
+  @deprecated("Use v1copy instead of copy","")
   def copy(
     clients: Seq[TLClientParameters] = masters,
     minLatency: Int = minLatency,
@@ -975,7 +976,7 @@ class TLMasterPortParameters private(
 }
 
 object TLClientPortParameters {
-  @deprecated("Use TLMasterParameters.v1() instead of TLClientParameters()","")
+  @deprecated("Use TLMasterPortParameters.v1 instead of TLClientPortParameters","")
   def apply(
     clients: Seq[TLClientParameters],
     minLatency: Int = 0,
@@ -1141,13 +1142,13 @@ object ManagerUnification
       map.get(k) match {
         case None => map.update(k, m)
         case Some(n) => {
-          map.update(k, m.copy(
+          map.update(k, m.v1copy(
             address = m.address ++ n.address,
             fifoId  = None)) // Merging means it's not FIFO anymore!
         }
       }
     }
-    map.values.map(m => m.copy(address = AddressSet.unify(m.address))).toList
+    map.values.map(m => m.v1copy(address = AddressSet.unify(m.address))).toList
   }
 }
 

--- a/src/main/scala/tilelink/PatternPusher.scala
+++ b/src/main/scala/tilelink/PatternPusher.scala
@@ -35,7 +35,7 @@ case class ReadExpectPattern(address: BigInt, size: Int, data: BigInt) extends P
 
 class TLPatternPusher(name: String, pattern: Seq[Pattern])(implicit p: Parameters) extends LazyModule
 {
-  val node = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters(name = name)))))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1(name = name)))))
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {

--- a/src/main/scala/tilelink/ProbePicker.scala
+++ b/src/main/scala/tilelink/ProbePicker.scala
@@ -14,14 +14,14 @@ class ProbePicker(implicit p: Parameters) extends LazyModule
     clientFn = { p =>
       // The ProbePicker assembles multiple clients based on the assumption they are contiguous in the clients list
       // This should be true for custers of xbar :=* BankBinder connections
-      def combine(next: TLClientParameters, pair: (TLClientParameters, Seq[TLClientParameters])) = {
+      def combine(next: TLMasterParameters, pair: (TLMasterParameters, Seq[TLMasterParameters])) = {
         val (head, output) = pair
         if (head.visibility.exists(x => next.visibility.exists(_.overlaps(x)))) {
           (next, head +: output) // pair is not banked, push head without merging
         } else {
-          def redact(x: TLClientParameters) = x.copy(sourceId = IdRange(0,1), nodePath = Nil, visibility = Seq(AddressSet(0, ~0)))
+          def redact(x: TLMasterParameters) = x.v1copy(sourceId = IdRange(0,1), nodePath = Nil, visibility = Seq(AddressSet(0, ~0)))
           require (redact(next) == redact(head), s"${redact(next)} != ${redact(head)}")
-          val merge = head.copy(
+          val merge = head.v1copy(
             sourceId = IdRange(
               head.sourceId.start min next.sourceId.start,
               head.sourceId.end   max next.sourceId.end),
@@ -29,9 +29,9 @@ class ProbePicker(implicit p: Parameters) extends LazyModule
           (merge, output)
         }
       }
-      val myNil: Seq[TLClientParameters] = Nil
+      val myNil: Seq[TLMasterParameters] = Nil
       val (head, output) = p.clients.init.foldRight((p.clients.last, myNil))(combine)
-      p.copy(clients = head +: output)
+      p.v1copy(clients = head +: output)
     },
     managerFn = { p => p })
 

--- a/src/main/scala/tilelink/RegionReplication.scala
+++ b/src/main/scala/tilelink/RegionReplication.scala
@@ -19,8 +19,8 @@ class RegionReplicator(mask: BigInt = 0, region: Option[AddressSet] = Some(Addre
 
   val node = TLAdapterNode(
     clientFn  = { cp => cp },
-    managerFn = { mp => mp.copy(managers = mp.managers.map { m =>
-      m.copy(address = m.address.flatMap { a =>
+    managerFn = { mp => mp.v1copy(managers = mp.managers.map { m =>
+      m.v1copy(address = m.address.flatMap { a =>
         if (region.map(_.contains(a)).getOrElse(false)) { ids.map { id => AddressSet(a.base | id, a.mask) } }
         else { Seq(a) }
       })

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -37,8 +37,8 @@ case class TLRegisterNode(
     undefZero:   Boolean = true,
     executable:  Boolean = false)(
     implicit valName: ValName)
-  extends SinkNode(TLImp)(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
+  extends SinkNode(TLImp)(Seq(TLSlavePortParameters.v1(
+    Seq(TLSlaveParameters.v1(
       address            = address,
       resources          = Seq(Resource(device, deviceKey)),
       executable         = executable,

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -34,8 +34,8 @@ class TLRAM(
   require (beatBytes >= 1 && isPow2(beatBytes))
   require (eccBytes <= beatBytes, s"TLRAM eccBytes (${eccBytes}) > beatBytes (${beatBytes}). Use a WidthWidget=>Fragmenter=>SRAM if you need high density and narrow ECC; it will do bursts efficiently")
 
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
+  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
+    Seq(TLSlaveParameters.v1(
       address            = List(address),
       resources          = device.reg("mem"),
       regionType         = if (cacheable) RegionType.UNCACHED else RegionType.IDEMPOTENT,

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -13,13 +13,13 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
   require (maxInFlight > 0)
 
   // The SourceShrinker completely destroys all FIFO property guarantees
-  private val client = TLClientParameters(
+  private val client = TLMasterParameters.v1(
     name     = "TLSourceShrinker",
     sourceId = IdRange(0, maxInFlight))
   val node = TLAdapterNode(
     // We erase all client information since we crush the source Ids
-    clientFn  = { cp => TLClientPortParameters(clients = Seq(client.copy(requestFifo = cp.clients.exists(_.requestFifo)))) },
-    managerFn = { mp => mp.copy(managers = mp.managers.map(m => m.copy(fifoId = if (maxInFlight==1) Some(0) else m.fifoId)))  })
+    clientFn  = { cp => TLMasterPortParameters.v1(clients = Seq(client.v1copy(requestFifo = cp.clients.exists(_.requestFifo)))) },
+    managerFn = { mp => mp.v1copy(managers = mp.managers.map(m => m.v1copy(fifoId = if (maxInFlight==1) Some(0) else m.fifoId)))  })
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -20,7 +20,7 @@ case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends
   },
   uFn = { case sp =>
     val managers = sp.slaves.map { case s =>
-      TLManagerParameters(
+      TLSlaveParameters.v1(
         address            = s.address,
         resources          = s.resources,
         regionType         = s.regionType,
@@ -35,7 +35,7 @@ case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends
         fifoId             = Some(0),
         mayDenyPut         = true)
     }
-    TLManagerPortParameters(
+    TLSlavePortParameters.v1(
       managers   = managers,
       beatBytes  = sp.beatBytes,
       endSinkId  = 0,

--- a/src/main/scala/tilelink/ToAPB.scala
+++ b/src/main/scala/tilelink/ToAPB.scala
@@ -19,7 +19,7 @@ case class TLToAPBNode()(implicit valName: ValName) extends MixedAdapterNode(TLI
   },
   uFn = { sp =>
     val managers = sp.slaves.map { case s =>
-      TLManagerParameters(
+      TLSlaveParameters.v1(
         address            = s.address,
         resources          = s.resources,
         regionType         = s.regionType,
@@ -31,7 +31,7 @@ case class TLToAPBNode()(implicit valName: ValName) extends MixedAdapterNode(TLI
         fifoId             = Some(0), // a common FIFO domain
         mayDenyPut         = true)
     }
-    TLManagerPortParameters(
+    TLSlavePortParameters.v1(
       managers   = managers,
       beatBytes  = sp.beatBytes,
       endSinkId  = 0,

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -24,7 +24,7 @@ case class AXI4TLStateField(sourceBits: Int) extends BundleField(AXI4TLState) {
   }
 }
 
-class TLtoAXI4IdMap(tl: TLClientPortParameters, axi4: AXI4MasterPortParameters) {
+class TLtoAXI4IdMap(tl: TLMasterPortParameters, axi4: AXI4MasterPortParameters) {
   private val axiDigits = String.valueOf(axi4.endId-1).length()
   private val tlDigits = String.valueOf(tl.endSourceId-1).length()
   private val fmt = s"\t[%${axiDigits}d, %${axiDigits}d) <= [%${tlDigits}d, %${tlDigits}d) %s%s%s"
@@ -72,9 +72,9 @@ case class TLToAXI4Node(stripBits: Int = 0, wcorrupt: Boolean = true)(implicit v
       echoFields    = AXI4TLStateField(log2Ceil(p.endSourceId)) +: p.echoFields,
       responseKeys  = p.responseKeys)
   },
-  uFn = { p => TLManagerPortParameters(
+  uFn = { p => TLSlavePortParameters.v1(
     managers = p.slaves.map { case s =>
-      TLManagerParameters(
+      TLSlaveParameters.v1(
         address            = s.address,
         resources          = s.resources,
         regionType         = s.regionType,
@@ -281,7 +281,7 @@ object TLToAXI4
     tl2axi4.node
   }
 
-  def sortByType(a: TLClientParameters, b: TLClientParameters): Boolean = {
+  def sortByType(a: TLMasterParameters, b: TLMasterParameters): Boolean = {
     if ( a.supportsProbe && !b.supportsProbe) return false
     if (!a.supportsProbe &&  b.supportsProbe) return true
     if ( a.requestFifo   && !b.requestFifo  ) return false

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -33,13 +33,13 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
 {
   val node = TLNexusNode(
     clientFn  = { seq =>
-      seq(0).copy(
+      seq(0).v1copy(
         echoFields    = BundleField.union(seq.flatMap(_.echoFields)),
         requestFields = BundleField.union(seq.flatMap(_.requestFields)),
         responseKeys  = seq.flatMap(_.responseKeys).distinct,
         minLatency = seq.map(_.minLatency).min,
         clients = (TLXbar.mapInputIds(seq) zip seq) flatMap { case (range, port) =>
-          port.clients map { client => client.copy(
+          port.clients map { client => client.v1copy(
             sourceId = client.sourceId.shift(range.start)
           )}
         }
@@ -47,7 +47,7 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
     },
     managerFn = { seq =>
       val fifoIdFactory = TLXbar.relabeler()
-      seq(0).copy(
+      seq(0).v1copy(
         responseFields = BundleField.union(seq.flatMap(_.responseFields)),
         requestKeys = seq.flatMap(_.requestKeys).distinct,
         minLatency = seq.map(_.minLatency).min,
@@ -56,7 +56,7 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
           require (port.beatBytes == seq(0).beatBytes,
             s"Xbar data widths don't match: ${port.managers.map(_.name)} has ${port.beatBytes}B vs ${seq(0).managers.map(_.name)} has ${seq(0).beatBytes}B")
           val fifoIdMapper = fifoIdFactory()
-          port.managers map { manager => manager.copy(
+          port.managers map { manager => manager.v1copy(
             fifoId = manager.fifoId.map(fifoIdMapper(_))
           )}
         }
@@ -281,8 +281,8 @@ object TLXbar
     xbar.node
   }
 
-  def mapInputIds (ports: Seq[TLClientPortParameters ]) = assignRanges(ports.map(_.endSourceId))
-  def mapOutputIds(ports: Seq[TLManagerPortParameters]) = assignRanges(ports.map(_.endSinkId))
+  def mapInputIds (ports: Seq[TLMasterPortParameters]) = assignRanges(ports.map(_.endSourceId))
+  def mapOutputIds(ports: Seq[TLSlavePortParameters ]) = assignRanges(ports.map(_.endSinkId))
 
   def assignRanges(sizes: Seq[Int]) = {
     val pow2Sizes = sizes.map { z => if (z == 0) 0 else 1 << log2Ceil(z) }


### PR DESCRIPTION
**Type of change**: other enhancement (paying off technical debt)
**Impact**: (should be) no functional change
**Development Phase**: implementation

fix these Chisel compile warnings:
```
method apply in object TLClientParameters is deprecated: Use TLMasterParameters.v1 instead of TLClientParameters
method apply in object TLClientPortParameters is deprecated: Use TLMasterPortParameters.v1 instead of TLClientPortParameters
method apply in object TLManagerParameters is deprecated: Use TLSlaveParameters.v1 instead of TLManagerParameters
method apply in object TLManagerPortParameters is deprecated: Use TLSlavePortParameters.v1 instead of TLManagerPortParameters
method copy in class TLMasterParameters is deprecated: Use v1copy instead of copy
method copy in class TLMasterPortParameters is deprecated: Use v1copy instead of copy
method copy in class TLSlaveParameters is deprecated: Use v1copy instead of copy
```