### PR TITLE
Chisel compile warning: Use foldLeft instead of /: 

### DIFF
--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -136,7 +136,7 @@ class PMP(implicit p: Parameters) extends PMPReg {
 
 class PMPHomogeneityChecker(pmps: Seq[PMP])(implicit p: Parameters) {
   def apply(addr: UInt, pgLevel: UInt): Bool = {
-    ((true.B, 0.U.asTypeOf(new PMP)) /: pmps) { case ((h, prev), pmp) =>
+    pmps.foldLeft((true.B, 0.U.asTypeOf(new PMP))) { case ((h, prev), pmp) =>
       (h && pmp.homogeneous(addr, pgLevel, prev), pmp)
     }._1
   }
@@ -160,7 +160,7 @@ class PMPChecker(lgMaxSize: Int)(implicit val p: Parameters) extends Module
   pmp0.cfg.w := default
   pmp0.cfg.x := default
 
-  val res = (pmp0 /: (io.pmp zip (pmp0 +: io.pmp)).reverse) { case (prev, (pmp, prevPMP)) =>
+  val res = (io.pmp zip (pmp0 +: io.pmp)).reverse.foldLeft(pmp0) { case (prev, (pmp, prevPMP)) =>
     val hit = pmp.hit(io.addr, io.size, lgMaxSize, prevPMP)
     val ignore = default && !pmp.cfg.l
     val aligned = pmp.aligned(io.addr, io.size, lgMaxSize, prevPMP)

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -29,7 +29,7 @@ package object util {
         val truncIdx =
           if (idx.isWidthKnown && idx.getWidth <= log2Ceil(x.size)) idx
           else (idx | UInt(0, log2Ceil(x.size)))(log2Ceil(x.size)-1, 0)
-        (x.head /: x.zipWithIndex.tail) { case (prev, (cur, i)) => Mux(truncIdx === i.U, cur, prev) }
+        x.zipWithIndex.tail.foldLeft(x.head) { case (prev, (cur, i)) => Mux(truncIdx === i.U, cur, prev) }
       }
     }
 
@@ -40,7 +40,7 @@ package object util {
     def rotate(n: UInt): Seq[T] = {
       require(isPow2(x.size))
       val amt = n.padTo(log2Ceil(x.size))
-      (x /: (0 until log2Ceil(x.size)))((r, i) => (r.rotate(1 << i) zip r).map { case (s, a) => Mux(amt(i), s, a) })
+      (0 until log2Ceil(x.size)).foldLeft(x)((r, i) => (r.rotate(1 << i) zip r).map { case (s, a) => Mux(amt(i), s, a) })
     }
 
     def rotateRight(n: Int): Seq[T] = x.takeRight(n) ++ x.dropRight(n)
@@ -48,7 +48,7 @@ package object util {
     def rotateRight(n: UInt): Seq[T] = {
       require(isPow2(x.size))
       val amt = n.padTo(log2Ceil(x.size))
-      (x /: (0 until log2Ceil(x.size)))((r, i) => (r.rotateRight(1 << i) zip r).map { case (s, a) => Mux(amt(i), s, a) })
+      (0 until log2Ceil(x.size)).foldLeft(x)((r, i) => (r.rotateRight(1 << i) zip r).map { case (s, a) => Mux(amt(i), s, a) })
     }
   }
 
@@ -134,14 +134,14 @@ package object util {
 
     def rotateRight(n: UInt): UInt = {
       val amt = n.padTo(log2Ceil(x.getWidth))
-      (x /: (0 until log2Ceil(x.getWidth)))((r, i) => Mux(amt(i), r.rotateRight(1 << i), r))
+      (0 until log2Ceil(x.getWidth)).foldLeft(x)((r, i) => Mux(amt(i), r.rotateRight(1 << i), r))
     }
 
     def rotateLeft(n: Int): UInt = if (n == 0) x else Cat(x(x.getWidth-1-n,0), x(x.getWidth-1,x.getWidth-n))
 
     def rotateLeft(n: UInt): UInt = {
       val amt = n.padTo(log2Ceil(x.getWidth))
-      (x /: (0 until log2Ceil(x.getWidth)))((r, i) => Mux(amt(i), r.rotateLeft(1 << i), r))
+      (0 until log2Ceil(x.getWidth)).foldLeft(x)((r, i) => Mux(amt(i), r.rotateLeft(1 << i), r))
     }
 
     // compute (this + y) % n, given (this < n) and (y < n)


### PR DESCRIPTION
**Type of change**: other enhancement (paying off technical debt)
**Impact**: no functional change
**Development Phase**: implementation

fix these Chisel compile warnings:
```
[warn] /rocket-chip/src/main/scala/rocket/PMP.scala:139:38: method /: in trait TraversableOnce is deprecated (since 2.12.10): Use foldLeft instead of /:
[warn]     ((true.B, 0.U.asTypeOf(new PMP)) /: pmps) { case ((h, prev), pmp) =>
[warn]                                      ^
[warn] /rocket-chip/src/main/scala/rocket/PMP.scala:163:19: method /: in trait TraversableOnce is deprecated (since 2.12.10): Use foldLeft instead of /:
[warn]   val res = (pmp0 /: (io.pmp zip (pmp0 +: io.pmp)).reverse) { case (prev, (pmp, prevPMP)) =>
[warn]                   ^
[warn] /rocket-chip/src/main/scala/util/package.scala:32:17: method /: in trait TraversableOnce is deprecated (since 2.12.10): Use foldLeft instead of /:
[warn]         (x.head /: x.zipWithIndex.tail) { case (prev, (cur, i)) => Mux(truncIdx === i.U, cur, prev) }
[warn]                 ^
[warn] /rocket-chip/src/main/scala/util/package.scala:43:10: method /: in trait TraversableOnce is deprecated (since 2.12.10): Use foldLeft instead of /:
[warn]       (x /: (0 until log2Ceil(x.size)))((r, i) => (r.rotate(1 << i) zip r).map { case (s, a) => Mux(amt(i), s, a) })
[warn]          ^
[warn] /rocket-chip/src/main/scala/util/package.scala:51:10: method /: in trait TraversableOnce is deprecated (since 2.12.10): Use foldLeft instead of /:
[warn]       (x /: (0 until log2Ceil(x.size)))((r, i) => (r.rotateRight(1 << i) zip r).map { case (s, a) => Mux(amt(i), s, a) })
[warn]          ^
[warn] /rocket-chip/src/main/scala/util/package.scala:137:10: method /: in trait TraversableOnce is deprecated (since 2.12.10): Use foldLeft instead of /:
[warn]       (x /: (0 until log2Ceil(x.getWidth)))((r, i) => Mux(amt(i), r.rotateRight(1 << i), r))
[warn]          ^
[warn] /rocket-chip/src/main/scala/util/package.scala:144:10: method /: in trait TraversableOnce is deprecated (since 2.12.10): Use foldLeft instead of /:
[warn]       (x /: (0 until log2Ceil(x.getWidth)))((r, i) => Mux(amt(i), r.rotateLeft(1 << i), r))
[warn]          ^
```