### PR TITLE
Chisel compile warning: random LFSR16

### DIFF
--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -13,6 +13,7 @@ import freechips.rocketchip.util.{DescribedSRAM, _}
 import freechips.rocketchip.util.property._
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.dontTouch
+import chisel3.util.random.LFSR
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model._
 
@@ -188,7 +189,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
 
   val repl_way = if (isDM) UInt(0) else {
     // pick a way that is not used by the scratchpad
-    val v0 = LFSR16(refill_fire)(log2Up(nWays)-1,0)
+    val v0 = LFSR(16, refill_fire)(log2Up(nWays)-1,0)
     var v = v0
     for (i <- log2Ceil(nWays) - 1 to 0 by -1) {
       val mask = nWays - (BigInt(1) << (i + 1))

--- a/src/main/scala/tilelink/Arbiter.scala
+++ b/src/main/scala/tilelink/Arbiter.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.tilelink
 
 import Chisel._
+import chisel3.util.random.LFSR
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -97,7 +98,7 @@ class TestRobin(txns: Int = 128, timeout: Int = 500000)(implicit p: Parameters) 
   val sink = Wire(DecoupledIO(UInt(width=3)))
   val count = RegInit(UInt(0, width=8))
 
-  val lfsr = LFSR16(Bool(true))
+  val lfsr = LFSR(16, Bool(true))
   val valid = lfsr(0)
   val ready = lfsr(15)
 

--- a/src/main/scala/util/ECC.scala
+++ b/src/main/scala/util/ECC.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.util
 
 import Chisel._
+import chisel3.util.random.LFSR
 
 abstract class Decoding
 {
@@ -183,7 +184,7 @@ object ErrGen
   // generate a 1-bit error with approximate probability 2^-f
   def apply(width: Int, f: Int): UInt = {
     require(width > 0 && f >= 0 && log2Up(width) + f <= 16)
-    UIntToOH(LFSR16()(log2Up(width)+f-1,0))(width-1,0)
+    UIntToOH(LFSR(16)(log2Up(width)+f-1,0))(width-1,0)
   }
   def apply(x: UInt, f: Int): UInt = x ^ apply(x.getWidth, f)
 }

--- a/src/main/scala/util/Misc.scala
+++ b/src/main/scala/util/Misc.scala
@@ -4,6 +4,7 @@
 package freechips.rocketchip.util
 
 import Chisel._
+import chisel3.util.random.LFSR
 import freechips.rocketchip.config.Parameters
 import scala.math._
 
@@ -154,7 +155,7 @@ object Random
   }
   def oneHot(mod: Int): UInt = oneHot(mod, randomizer)
 
-  private def randomizer = LFSR16()
+  private def randomizer = LFSR(16)
   private def partition(value: UInt, slices: Int) =
     Seq.tabulate(slices)(i => value < UInt(((i + 1) << value.getWidth) / slices))
 }

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -4,6 +4,7 @@
 package freechips.rocketchip.util
 
 import Chisel._
+import chisel3.util.random.LFSR
 
 abstract class ReplacementPolicy {
   def way: UInt
@@ -14,7 +15,7 @@ abstract class ReplacementPolicy {
 class RandomReplacement(ways: Int) extends ReplacementPolicy {
   private val replace = Wire(Bool())
   replace := Bool(false)
-  val lfsr = LFSR16(replace)
+  val lfsr = LFSR(16, replace)
 
   def way = Random(ways, lfsr)
   def miss = replace := Bool(true)


### PR DESCRIPTION
**Type of change**: other enhancement (paying off technical debt)
**Impact**: no functional change
**Development Phase**: implementation

fix these Chisel compile warnings:
```
[warn] /rocket-chip/src/main/scala/rocket/ICache.scala:191:14: method apply in object LFSR16 is deprecated (since 3.2): Use chisel3.util.random.LFSR(16) for a 16-bit LFSR
[warn]     val v0 = LFSR16(refill_fire)(log2Up(nWays)-1,0)
[warn]              ^
[warn] /rocket-chip/src/main/scala/tilelink/Arbiter.scala:100:14: method apply in object LFSR16 is deprecated (since 3.2): Use chisel3.util.random.LFSR(16) for a 16-bit LFSR
[warn]   val lfsr = LFSR16(Bool(true))
[warn]              ^
[warn] /rocket-chip/src/main/scala/util/ECC.scala:186:14: method apply in object LFSR16 is deprecated (since 3.2): Use chisel3.util.random.LFSR(16) for a 16-bit LFSR
[warn]     UIntToOH(LFSR16()(log2Up(width)+f-1,0))(width-1,0)
[warn]              ^
[warn] /rocket-chip/src/main/scala/util/Misc.scala:157:28: method apply in object LFSR16 is deprecated (since 3.2): Use chisel3.util.random.LFSR(16) for a 16-bit LFSR
[warn]   private def randomizer = LFSR16()
[warn]                            ^
[warn] /rocket-chip/src/main/scala/util/Replacement.scala:17:14: method apply in object LFSR16 is deprecated (since 3.2): Use chisel3.util.random.LFSR(16) for a 16-bit LFSR
[warn]   val lfsr = LFSR16(replace)
[warn]              ^
```