### PR TITLE
Chisel compile warning: HasBlackBoxResource

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -174,8 +174,8 @@ class SimDTM(implicit p: Parameters) extends BlackBox with HasBlackBoxResource {
     }
   }
 
-  setResource("/vsrc/SimDTM.v")
-  setResource("/csrc/SimDTM.cc")
+  addResource("/vsrc/SimDTM.v")
+  addResource("/csrc/SimDTM.cc")
 }
 
 class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam(tickDelay)))
@@ -210,10 +210,10 @@ class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam
     }
   }
 
-  setResource("/vsrc/SimJTAG.v")
-  setResource("/csrc/SimJTAG.cc")
-  setResource("/csrc/remote_bitbang.h")
-  setResource("/csrc/remote_bitbang.cc")
+  addResource("/vsrc/SimJTAG.v")
+  addResource("/csrc/SimJTAG.cc")
+  addResource("/csrc/remote_bitbang.h")
+  addResource("/csrc/remote_bitbang.cc")
 }
 
 object Debug {

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -360,7 +360,7 @@ class BlackBoxExampleModuleImp(outer: BlackBoxExample, blackBoxFile: String)(imp
                       val rocc = roccIo.cloneType
                     })
         override def desiredName: String = blackBoxFile
-        setResource(s"/vsrc/$blackBoxFile.v")
+        addResource(s"/vsrc/$blackBoxFile.v")
       }
     )
   }


### PR DESCRIPTION
**Type of change**: other enhancement (paying off technical debt)
**Impact**: no functional change
**Development Phase**: implementation

fix these Chisel compile warnings:
```
[warn] /rocket-chip/src/main/scala/devices/debug/Periphery.scala:177:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/vsrc/SimDTM.v")
[warn]   ^
[warn] /rocket-chip/src/main/scala/devices/debug/Periphery.scala:178:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/csrc/SimDTM.cc")
[warn]   ^
[warn] /rocket-chip/src/main/scala/devices/debug/Periphery.scala:213:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/vsrc/SimJTAG.v")
[warn]   ^
[warn] /rocket-chip/src/main/scala/devices/debug/Periphery.scala:214:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/csrc/SimJTAG.cc")
[warn]   ^
[warn] /rocket-chip/src/main/scala/devices/debug/Periphery.scala:215:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/csrc/remote_bitbang.h")
[warn]   ^
[warn] /rocket-chip/src/main/scala/devices/debug/Periphery.scala:216:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/csrc/remote_bitbang.cc")
[warn]   ^
[warn] /rocket-chip/src/main/scala/tile/LazyRoCC.scala:363:9: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]         setResource(s"/vsrc/$blackBoxFile.v")
[warn]         ^
```