### PR TITLE
Chisel compile warning: Chisel3 packages imports

### DIFF
--- a/src/main/scala/amba/ahb/Monitor.scala
+++ b/src/main/scala/amba/ahb/Monitor.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.amba.ahb
 
 import chisel3._
-import chisel3.core.Reset
 import freechips.rocketchip.config.Parameters
 
 case class AHBSlaveMonitorArgs(edge: AHBEdgeParameters)

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.devices.debug
 
 import chisel3._
-import chisel3.core.IntParam
+import chisel3.experimental.IntParam
 import chisel3.util._
 import chisel3.util.HasBlackBoxResource
 import freechips.rocketchip.config.{Field, Parameters}

--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -4,8 +4,7 @@ package freechips.rocketchip.diplomacy
 
 import chisel3._
 import chisel3.internal.sourceinfo.SourceInfo
-import chisel3.core.{DataMirror,ActualDirection}
-import chisel3.experimental.IO
+import chisel3.experimental.{DataMirror,IO}
 import freechips.rocketchip.config.{Parameters,Field}
 
 case class BundleBridgeParams[T <: Data](gen: () => T)

--- a/src/main/scala/prci/ResetWrangler.scala
+++ b/src/main/scala/prci/ResetWrangler.scala
@@ -3,7 +3,6 @@ package freechips.rocketchip.prci
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{withClockAndReset}
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._

--- a/src/main/scala/prci/TestClockSource.scala
+++ b/src/main/scala/prci/TestClockSource.scala
@@ -2,6 +2,7 @@ package freechips.rocketchip.prci
 
 import chisel3._
 import chisel3.util.HasBlackBoxInline
+import chisel3.experimental.DoubleParam
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 
@@ -13,7 +14,7 @@ class ClockSourceIO extends Bundle {
 
 /** This clock source is only intended to be used in test harnesses, and does not work correctly in verilator. */
 class ClockSourceAtFreq(val freqMHz: Double) extends BlackBox(Map(
-  "PERIOD_PS" -> core.DoubleParam(1000000/freqMHz)
+  "PERIOD_PS" -> DoubleParam(1000000/freqMHz)
 )) with HasBlackBoxInline {
   val io = IO(new ClockSourceIO)
 

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.rocket
 
 import Chisel._
 import Chisel.ImplicitConversions._
-import chisel3.experimental._
+import chisel3.withClock
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -5,7 +5,9 @@ package freechips.rocketchip.rocket
 
 import Chisel._
 import Chisel.ImplicitConversions._
-import chisel3.experimental._
+import chisel3.{withClock,withReset}
+import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.experimental.chiselName
 import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.diplomacy._
@@ -13,8 +15,7 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
-import chisel3.internal.sourceinfo.SourceInfo
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{ICacheLogicalTreeNode}
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.ICacheLogicalTreeNode
 
 class FrontendReq(implicit p: Parameters) extends CoreBundle()(p) {
   val pc = UInt(width = vaddrBitsExtended)

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -5,14 +5,15 @@ package freechips.rocketchip.rocket
 
 import Chisel._
 import Chisel.ImplicitConversions._
+import chisel3.withClock
+import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.experimental.chiselName
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.subsystem.CacheBlockBytes
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
-import chisel3.internal.sourceinfo.SourceInfo
-import chisel3.experimental._
 import scala.collection.mutable.ListBuffer
 
 class PTWReq(implicit p: Parameters) extends CoreBundle()(p) {

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -5,7 +5,8 @@ package freechips.rocketchip.rocket
 
 import Chisel._
 import Chisel.ImplicitConversions._
-import chisel3.experimental._
+import chisel3.withClock
+import chisel3.experimental.chiselName
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -5,14 +5,14 @@ package freechips.rocketchip.tile
 
 import Chisel._
 import Chisel.ImplicitConversions._
-
+import chisel3.withClock
+import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.experimental.chiselName
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.rocket.Instructions._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
-import chisel3.internal.sourceinfo.SourceInfo
-import chisel3.experimental._
 
 case class FPUParams(
   fLen: Int = 64,

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -4,13 +4,12 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import chisel3.core.Reset
 import chisel3.internal.sourceinfo.{SourceInfo, SourceLine}
+import chisel3.experimental.chiselName
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.{HeterogeneousBag, PlusArg}
 import freechips.rocketchip.formal._
-import chisel3.experimental.chiselName
 
 case class TLMonitorArgs(edge: TLEdge)
 

--- a/src/main/scala/util/Annotations.scala
+++ b/src/main/scala/util/Annotations.scala
@@ -172,7 +172,7 @@ trait DontTouch { self: RawModule =>
   // TODO: this is a workaround for firrtl #756
   def dontTouch(data: Data): Unit = data match {
      case agg: Aggregate => agg.getElements.foreach(dontTouch)
-     case elt: Element => chisel3.core.dontTouch(elt)
+     case elt: Element => chisel3.dontTouch(elt)
   }
 
   /** Marks every port as don't touch

--- a/src/main/scala/util/DescribedSRAM.scala
+++ b/src/main/scala/util/DescribedSRAM.scala
@@ -4,14 +4,12 @@
 package freechips.rocketchip.util
 
 import chisel3.internal.InstanceId
-import freechips.rocketchip.util.Annotated
-import freechips.rocketchip.diplomacy.DiplomaticSRAM
 import chisel3.{Data, SyncReadMem, Vec}
 import chisel3.util.log2Ceil
 import freechips.rocketchip.amba.axi4.AXI4RAM
+import freechips.rocketchip.diplomacy.DiplomaticSRAM
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model.{OMSRAM, OMRTLModule}
-
 import scala.math.log10
 
 object DescribedSRAM {

--- a/src/main/scala/util/HeterogeneousBag.scala
+++ b/src/main/scala/util/HeterogeneousBag.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.util
 
 import Chisel._
-import chisel3.core.Record
+import chisel3.Record
 import scala.collection.immutable.ListMap
 
 final case class HeterogeneousBag[T <: Data](elts: Seq[T]) extends Record with collection.IndexedSeq[T] {

--- a/src/main/scala/util/ResetCatchAndSync.scala
+++ b/src/main/scala/util/ResetCatchAndSync.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.util
 
 import Chisel._
-import chisel3.experimental.{withClockAndReset, withReset}
+import chisel3.{withClockAndReset, withReset}
 
 /** Reset: asynchronous assert,
   *  synchronous de-assert


### PR DESCRIPTION
**Type of change**: other enhancement (paying off technical debt)
**Impact**: no functional change
**Development Phase**: implementation

fix these Chisel compile warnings:
```
[warn] /rocket-chip/src/main/scala/util/DescribedSRAM.scala:7:34: imported `Annotated' is permanently hidden by definition of object Annotated in package util
[warn] import freechips.rocketchip.util.Annotated
[warn]                                  ^
[warn] /rocket-chip/src/main/scala/amba/ahb/Monitor.scala:17:72: type Reset in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]   def legalize(bundle: AHBSlaveBundle, edge: AHBEdgeParameters, reset: Reset): Unit
[warn]                                                                        ^
[warn] /rocket-chip/src/main/scala/amba/ahb/Monitor.scala:30:73: type Reset in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]   def legalize(bundle: AHBMasterBundle, edge: AHBEdgeParameters, reset: Reset): Unit
[warn]                                                                         ^
[warn] /rocket-chip/src/main/scala/devices/debug/Periphery.scala:181:73: value IntParam in package core is deprecated (since 3.2): Use the version in chisel3.experimental._
[warn] class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam(tickDelay)))
[warn]                                                                         ^
[warn] /rocket-chip/src/main/scala/diplomacy/BundleBridge.scala:63:38: value DataMirror in package core is deprecated (since 3.2): Use the version in chisel3.experimental._
[warn]     getElements(in).foreach { elt => DataMirror.directionOf(elt) match {
[warn]                                      ^
[warn] /rocket-chip/src/main/scala/diplomacy/BundleBridge.scala:64:12: value ActualDirection in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]       case ActualDirection.Output => ()
[warn]            ^
[warn] /rocket-chip/src/main/scala/diplomacy/BundleBridge.scala:65:12: value ActualDirection in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]       case ActualDirection.Unspecified => ()
[warn]            ^
[warn] /rocket-chip/src/main/scala/prci/ResetWrangler.scala:32:21: value withClockAndReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     val debounced = withClockAndReset(slowIn.clock, causes) {
[warn]                     ^
[warn] /rocket-chip/src/main/scala/prci/TestClockSource.scala:16:23: value DoubleParam in package core is deprecated (since 3.2): Use the version in chisel3.experimental._
[warn]   "PERIOD_PS" -> core.DoubleParam(1000000/freqMHz)
[warn]                       ^
[warn] /rocket-chip/src/main/scala/rocket/CSR.scala:393:17: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   val reg_wfi = withClock(io.ungated_clock) { Reg(init=Bool(false)) }
[warn]                 ^
[warn] /rocket-chip/src/main/scala/rocket/CSR.scala:403:57: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   val reg_cycle = if (enableCommitLog) reg_instret else withClock(io.ungated_clock) { WideCounter(64, !io.csr_stall) }
[warn]                                                         ^
[warn] /rocket-chip/src/main/scala/rocket/Frontend.scala:84:12: value withReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   val fq = withReset(reset || io.cpu.req.valid) { Module(new ShiftQueue(new FrontendResp, 5, flow = true)) }
[warn]            ^
[warn] /rocket-chip/src/main/scala/rocket/Frontend.scala:96:3: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   withClock (gated_clock) { // entering gated-clock domain
[warn]   ^
[warn] /rocket-chip/src/main/scala/rocket/PTW.scala:115:3: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   withClock (gated_clock) { // entering gated-clock domain
[warn]   ^
[warn] /rocket-chip/src/main/scala/rocket/RocketCore.scala:927:20: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   val rocketImpl = withClock (gated_clock) { new RocketImpl }
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tile/FPU.scala:938:17: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   val fpuImpl = withClock (gated_clock) { new FPUImpl }
[warn]                 ^
[warn] /rocket-chip/src/main/scala/tilelink/Monitor.scala:23:55: type Reset in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]   def legalize(bundle: TLBundle, edge: TLEdge, reset: Reset): Unit
[warn]                                                       ^
[warn] /rocket-chip/src/main/scala/tilelink/Monitor.scala:745:55: type Reset in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]   def legalize(bundle: TLBundle, edge: TLEdge, reset: Reset) {
[warn]                                                       ^
[warn] /rocket-chip/src/main/scala/util/Annotations.scala:175:40: value dontTouch in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]      case elt: Element => chisel3.core.dontTouch(elt)
[warn]                                        ^
[warn] /rocket-chip/src/main/scala/util/HeterogeneousBag.scala:9:68: type Record in package core is deprecated (since 3.2): Use the version in chisel3._
[warn] final case class HeterogeneousBag[T <: Data](elts: Seq[T]) extends Record with collection.IndexedSeq[T] {
[warn]                                                                    ^
[warn] /rocket-chip/src/main/scala/util/ResetCatchAndSync.scala:27:3: value withReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]   withReset(post_psd_reset) {
[warn]   ^
[warn] /rocket-chip/src/main/scala/util/ResetCatchAndSync.scala:38:5: value withClockAndReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     withClockAndReset(clk, rst) {
[warn]     ^
```