### PR TITLE
D$: guarantee that no-alloc accesses are ordered even if aliased

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -841,6 +841,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     resp.bits.size := uncachedResp.size
     resp.bits.signed := uncachedResp.signed
     resp.bits.data := new LoadGen(uncachedResp.size, uncachedResp.signed, uncachedResp.addr, s1_uncached_data_word, false.B, wordBytes).data
+    resp.bits.data_raw := s1_uncached_data_word
     when (grantIsUncachedData && !resp.ready) {
       tl_out.d.ready := false
     }


### PR DESCRIPTION
Currently, non-allocating accesses can be reordered with allocating
accesses if they are to different virtual synonyms.  Add hardware
to detect and prevent this case.

If there's no possibility of aliasing or non-allocating accesses,
there's no additional HW cost.

I'm not entirely happy with the approach (it adds a lot of fanout to
what is sometimes a critical timing path, so at minimum it's leaky).
Might revisit later.
