### PR TITLE
Async Reset support for Atomics, FPU, and TLBroadcast

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -2,8 +2,7 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel.{defaultCompileOptions => _, _}
-import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
+import Chisel._
 import chisel3.{RawModule, MultiIOModule, withClockAndReset}
 import chisel3.internal.sourceinfo.{SourceInfo, SourceLine, UnlocatableSourceInfo}
 import freechips.rocketchip.config.Parameters

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{RawModule, MultiIOModule, withClockAndReset}
 import chisel3.internal.sourceinfo.{SourceInfo, SourceLine, UnlocatableSourceInfo}
 import freechips.rocketchip.config.Parameters

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -671,8 +671,7 @@ class FPUFMAPipe(val latency: Int, val t: FType)
     when (!(cmd_fma || cmd_addsub)) { in.in3 := zero }
   }
 
-  // See  NOTE-2361 above
-  val fma = withReset(false.B){Module(new MulAddRecFNPipe((latency-1) min 2, t.exp, t.sig))}
+  val fma = Module(new MulAddRecFNPipe((latency-1) min 2, t.exp, t.sig))
   fma.io.validin := valid
   fma.io.op := in.fmaCmd
   fma.io.roundingMode := in.rm

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -914,8 +914,7 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
 
     for (t <- floatTypes) {
       val tag = !mem_ctrl.singleOut // TODO typeTag
-      // See  NOTE-2361 above
-      val divSqrt = withReset(false.B){Module(new hardfloat.DivSqrtRecFN_small(t.exp, t.sig, 0))}
+      val divSqrt = Module(new hardfloat.DivSqrtRecFN_small(t.exp, t.sig, 0))
       divSqrt.io.inValid := mem_reg_valid && tag === typeTag(t) && (mem_ctrl.div || mem_ctrl.sqrt) && !divSqrt_inFlight
       divSqrt.io.sqrtOp := mem_ctrl.sqrt
       divSqrt.io.a := maxType.unsafeConvert(fpiu.io.out.bits.in.in1, t)

--- a/src/main/scala/tilelink/Atomics.scala
+++ b/src/main/scala/tilelink/Atomics.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import TLMessages._
 import TLPermissions._

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._

--- a/src/main/scala/util/CompileOptions.scala
+++ b/src/main/scala/util/CompileOptions.scala
@@ -1,0 +1,10 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import chisel3.ExplicitCompileOptions.NotStrict
+
+object CompileOptions {
+  /** Compatibility mode semantics except Module implicit reset should be inferred instead of Bool */
+  implicit val NotStrictInferReset = NotStrict.copy(inferModuleReset = true)
+}

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "f36127349c5303e32dcc97ccdd3b491f51ec60e9",
+        "commit": "3f88b663c7324cf9a27f9e20b82382908bb4cc11",
         "name": "hardfloat",
         "source": "git@github.com:ucb-bar/berkeley-hardfloat.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -10,7 +10,7 @@
         "source": "git@github.com:sifive/api-chisel3-sifive.git"
     },
     {
-        "commit": "5ee1efa292394429e603dc878643aa1fed4ac020",
+        "commit": "7a343dce95a370f6cb7b9cf80e0694ac82dc94f8",
         "name": "chisel3",
         "source": "git@github.com:freechipsproject/chisel3.git"
     },


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

This contains workarounds for https://github.com/chipsalliance/rocket-chip/issues/2361
This bumps chisel to pick up fix for https://github.com/freechipsproject/chisel3/pull/1253 done in https://github.com/freechipsproject/chisel3/pull/1388

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

FPU, tilelink/Atomics, TLBroadcast are converted to be able to use chisel3 `AsyncReset`. This is done generally with a specific compatibility mode change vs entirely converting them to chisel3 in a new DefaultCompileOptions.NonStrictInferReset

Some withReset(false.B) are added around combinational hardfloat modules in the FPU to avoid having to do this recursively in hardfloat files (hardfloat sequential modules were previously converted to chisel3 so are not an issue). Comments pointing to the linked issue https://github.com/chipsalliance/rocket-chip/issues/2361 are added for these workarounds so they can be deleted once hardfloat is adjusted.