### PR TITLE
Remove jgit-repo resolver

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")


### PR DESCRIPTION
Removes an unneeded (I think?) resolver which fixes some warnings during an sbt build.

Specifically, this gets rid of these three lines:

```
[warn] insecure HTTP request is deprecated 'http://download.eclipse.org/jgit/maven'; switch to HTTPS or opt-in as ("jgit-repo" at "http://download.eclipse.org/jgit/maven").withAllowInsecureProtocol(true)
[warn] insecure HTTP request is deprecated 'http://download.eclipse.org/jgit/maven'; switch to HTTPS or opt-in as ("jgit-repo" at "http://download.eclipse.org/jgit/maven").withAllowInsecureProtocol(true)
[warn] insecure HTTP request is deprecated 'http://download.eclipse.org/jgit/maven'; switch to HTTPS or opt-in as ("jgit-repo" at "http://download.eclipse.org/jgit/maven").withAllowInsecureProtocol(true)

```

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Decrease warnings during sbt build