### PR TITLE
mv clockGate from RocketCoreParams to CoreParams

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -75,7 +75,7 @@ class FrontendBundle(val outer: Frontend) extends CoreBundle()(outer.p)
 
 @chiselName
 class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
-    with HasRocketCoreParameters
+    with HasCoreParameters
     with HasL1ICacheParameters {
   val io = IO(new FrontendBundle(outer))
   implicit val edge = outer.masterNode.edges.out(0)
@@ -89,7 +89,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   io.cpu.clock_enabled := clock_en
   assert(!(io.cpu.req.valid || io.cpu.sfence.valid || io.cpu.flush_icache || io.cpu.bht_update.valid || io.cpu.btb_update.valid) || io.cpu.might_request)
   val gated_clock =
-    if (!rocketParams.clockGate) clock
+    if (!coreParams.clockGate) clock
     else ClockGate(clock, clock_en, "icache_clock_gate")
 
   icache.clock := gated_clock
@@ -332,7 +332,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   io.errors := icache.io.errors
 
   // gate the clock
-  clock_en_reg := !rocketParams.clockGate ||
+  clock_en_reg := !coreParams.clockGate ||
     io.cpu.might_request || // chicken bit
     icache.io.keep_clock_enabled || // I$ miss or ITIM access
     s1_valid || s2_valid || // some fetch in flight

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -89,7 +89,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   io.cpu.clock_enabled := clock_en
   assert(!(io.cpu.req.valid || io.cpu.sfence.valid || io.cpu.flush_icache || io.cpu.bht_update.valid || io.cpu.btb_update.valid) || io.cpu.might_request)
   val gated_clock =
-    if (!coreParams.clockGate) clock
+    if (!clockGate) clock
     else ClockGate(clock, clock_en, "icache_clock_gate")
 
   icache.clock := gated_clock
@@ -332,7 +332,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   io.errors := icache.io.errors
 
   // gate the clock
-  clock_en_reg := !coreParams.clockGate ||
+  clock_en_reg := !clockGate ||
     io.cpu.might_request || // chicken bit
     icache.io.keep_clock_enabled || // I$ miss or ITIM access
     s1_valid || s2_valid || // some fetch in flight

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -39,7 +39,7 @@ case class RocketCoreParams(
   fastLoadWord: Boolean = true,
   fastLoadByte: Boolean = false,
   branchPredictionModeCSR: Boolean = false,
-  //clockGate: Boolean = false,
+  clockGate: Boolean = false,
   mvendorid: Int = 0, // 0 means non-commercial implementation
   mimpid: Int = 0x20181004, // release date in BCD
   mulDiv: Option[MulDivParams] = Some(MulDivParams()),

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -39,7 +39,7 @@ case class RocketCoreParams(
   fastLoadWord: Boolean = true,
   fastLoadByte: Boolean = false,
   branchPredictionModeCSR: Boolean = false,
-  clockGate: Boolean = false,
+  //clockGate: Boolean = false,
   mvendorid: Int = 0, // 0 means non-commercial implementation
   mimpid: Int = 0x20181004, // release date in BCD
   mulDiv: Option[MulDivParams] = Some(MulDivParams()),

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -41,7 +41,7 @@ trait CoreParams {
   val nL2TLBEntries: Int
   val mtvecInit: Option[BigInt]
   val mtvecWritable: Boolean
-  val clockGate: Boolean = false
+  val clockGate: Boolean
   def customCSRs(implicit p: Parameters): CustomCSRs = new CustomCSRs
 
   def instBytes: Int = instBits / 8
@@ -89,6 +89,7 @@ trait HasCoreParameters extends HasTileParameters {
   val nPerfCounters = coreParams.nPerfCounters
   val mtvecInit = coreParams.mtvecInit
   val mtvecWritable = coreParams.mtvecWritable
+  val clockGate = coreParams.clockGate
 
   def vLen = coreParams.vLen
   def sLen = coreParams.sLen

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -41,6 +41,7 @@ trait CoreParams {
   val nL2TLBEntries: Int
   val mtvecInit: Option[BigInt]
   val mtvecWritable: Boolean
+  val clockGate: Boolean = false
   def customCSRs(implicit p: Parameters): CustomCSRs = new CustomCSRs
 
   def instBytes: Int = instBits / 8


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
https://github.com/chipsalliance/rocket-chip/issues/2366

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
clockGate is more a Core Params than a specific Rocket Core Params. With this change, FrontendModule is decouple from RocketCore in Scala code level.
