### PR TITLE
BEU <-> HART link added in DTS

### DIFF
--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -88,11 +88,15 @@ class RocketTile private(
 
   val itimProperty = frontend.icache.itimProperty.toSeq.flatMap(p => Map("sifive,itim" -> p))
 
+  val beuProperty = bus_error_unit.map(d => Map(
+          "sifive,buserror0" -> d.device.asProperty)).getOrElse(Nil)
+
   val cpuDevice: SimpleDevice = new SimpleDevice("cpu", Seq("sifive,rocket0", "riscv")) {
     override def parent = Some(ResourceAnchors.cpus)
     override def describe(resources: ResourceBindings): Description = {
       val Description(name, mapping) = super.describe(resources)
-      Description(name, mapping ++ cpuProperties ++ nextLevelCacheProperty ++ tileProperties ++ dtimProperty ++ itimProperty)
+      Description(name, mapping ++ cpuProperties ++ nextLevelCacheProperty
+                  ++ tileProperties ++ dtimProperty ++ itimProperty ++ beuProperty)
     }
   }
 

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -89,7 +89,7 @@ class RocketTile private(
   val itimProperty = frontend.icache.itimProperty.toSeq.flatMap(p => Map("sifive,itim" -> p))
 
   val beuProperty = bus_error_unit.map(d => Map(
-          "sifive,buserror0" -> d.device.asProperty)).getOrElse(Nil)
+          "sifive,buserror" -> d.device.asProperty)).getOrElse(Nil)
 
   val cpuDevice: SimpleDevice = new SimpleDevice("cpu", Seq("sifive,rocket0", "riscv")) {
     override def parent = Some(ResourceAnchors.cpus)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:implementation

**Release Notes**
The CPU section in the generated DTS file will have link to the associated BEU. This should help downstream software flows.

**Example of the emitted DTS (updated):**
   ```
{
...
	model = "SiFive,FU500";
....
	L34: cpus {
		#address-cells = <1>;
		#size-cells = <0>;
		L9: cpu@0 {
			clock-frequency = <0>;
			...
                         ...
                         ...
			device_type = "cpu";
			....
			sifive,buserror = <&L8>;
			....
		};
	};
	L33: soc {
                ....
                ....
		L8: bus-error-unit@1700000 {
			compatible = "sifive,buserror0";
			interrupt-parent = <&L3>;
			interrupts = <303>;
			reg = <0x1700000 0x1000>;
			reg-names = "control";
		};
                ....
                ....
     }

```