### PR TITLE
fix Chisel compile warnings in PseudoLRU.access(ways: Seq)

### DIFF
--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -44,8 +44,7 @@ class PseudoLRU(n: Int)
     state_reg := get_next_state(state_reg,way)
   }
   def access(ways: Seq[ValidIO[UInt]]) {
-    state_reg := ways.fold(state_reg) { case (prev: UInt, way: ValidIO[UInt]) =>
-      Mux(way.valid, get_next_state(prev, way.bits), prev) }
+    state_reg := ways.foldLeft(state_reg)((prev, way) => Mux(way.valid, get_next_state(prev, way.bits), prev))
   }
   def get_next_state(state: UInt, way: UInt) = {
     var next_state = state << 1


### PR DESCRIPTION
**Related issue**: introduced by me in https://github.com/chipsalliance/rocket-chip/pull/2277/commits/9057b3c1a115b4aedfe2d2d5c8dd93596b4f7d3c
**Type of change**: other enhancement (paying off technical debt)
**Impact**: no functional change
**Development Phase**: implementation

fix these Chisel compile warnings:
```
[warn] /rocket-chip/src/main/scala/util/Replacement.scala:46:39: match may not be exhaustive.
[warn] It would fail on the following inputs: (UInt(), _), (_, Valid()), (_, _)
[warn]     state_reg := ways.fold(state_reg) { case (prev: UInt, way: ValidIO[UInt]) =>
[warn]                                       ^
[warn] /rocket-chip/src/main/scala/util/Replacement.scala:46:64: non-variable type argument Chisel.UInt in type pattern chisel3.util.Valid[Chisel.UInt] (the underlying of Chisel.ValidIO[Chisel.UInt]) is unchecked since it is eliminated by erasure
[warn]     state_reg := ways.fold(state_reg) { case (prev: UInt, way: ValidIO[UInt]) =>
[warn]                                                                ^
```