### PR TITLE
fix Chisel compile warning: Diplomacy AddressRange match may not be exhaustive

### DIFF
--- a/src/main/scala/diplomacy/AddressRange.scala
+++ b/src/main/scala/diplomacy/AddressRange.scala
@@ -53,6 +53,7 @@ object AddressRange
         case Some(z) => z :: tail
         case None => x :: head :: tail
       }
+      case (head, tail) => head ++ Seq(tail)
     }.reverse
   }
   // Set subtraction... O(n*n) b/c I am lazy

--- a/src/main/scala/diplomacy/AddressRange.scala
+++ b/src/main/scala/diplomacy/AddressRange.scala
@@ -48,12 +48,13 @@ object AddressRange
   def unify(seq: Seq[AddressRange]): Seq[AddressRange] = {
     if (seq.isEmpty) return Nil
     val ranges = seq.sorted
-    ranges.tail.foldLeft(Seq(ranges.head)) { case (head :: tail, x) =>
-      head.union(x) match {
-        case Some(z) => z :: tail
-        case None => x :: head :: tail
-      }
-      case (head, tail) => head ++ Seq(tail)
+    ranges.tail.foldLeft(Seq(ranges.head)) {
+      case (head :: tail, x) =>
+        head.union(x) match {
+          case Some(z) => z :: tail
+          case None => x :: head :: tail
+        }
+      case _ => Unreachable()
     }.reverse
   }
   // Set subtraction... O(n*n) b/c I am lazy

--- a/src/main/scala/diplomacy/Unreachable.scala
+++ b/src/main/scala/diplomacy/Unreachable.scala
@@ -1,0 +1,7 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.diplomacy
+
+case object Unreachable {
+  def apply(): Nothing = throw new AssertionError("unreachable code")
+}


### PR DESCRIPTION
**Type of change**: other enhancement (paying off technical debt)
**Impact**: no functional change
**Development Phase**: implementation

fix this Chisel compile Scala warning:
```
[warn] /rocket-chip/src/main/scala/diplomacy/AddressRange.scala:51:44: match may not be exhaustive.
[warn] It would fail on the following input: (_, _)
[warn]     ranges.tail.foldLeft(Seq(ranges.head)) { case (head :: tail, x) =>
[warn]                                            ^
```