### PR TITLE
Only checkout the latest 50 commits of rocket-tools submodules.

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -150,13 +150,15 @@ stamps/other-submodules.stamp:
 	git -C $(abspath $(TOP)) submodule update --init --recursive $(submodule_names)
 	date > $@
 
+ROCKET_TOOLS_CHECKOUT_DEPTH ?= 50
+
 stamps/rocket-tools_checkout.stamp:
 	mkdir -p $(dir $@)
 	git -C $(abspath $(TOP)) clone -n https://github.com/freechipsproject/rocket-tools.git
 	git -C $(RISCV_TOOLS) checkout $(TOOLS_HASH)
-	git -C $(RISCV_TOOLS) submodule update --init --recursive riscv-isa-sim  riscv-tests riscv-pk riscv-openocd fsf-binutils-gdb
-	git -C $(RISCV_TOOLS) submodule update --init riscv-gnu-toolchain
-	git -C $(RISCV_TOOLS)/riscv-gnu-toolchain submodule update --init riscv-binutils-gdb riscv-gcc riscv-newlib
+	git -C $(RISCV_TOOLS) submodule update --init --recursive --depth=$(ROCKET_TOOLS_CHECKOUT_DEPTH) riscv-isa-sim  riscv-tests riscv-pk riscv-openocd fsf-binutils-gdb
+	git -C $(RISCV_TOOLS) submodule update --init --depth=$(ROCKET_TOOLS_CHECKOUT_DEPTH) riscv-gnu-toolchain
+	git -C $(RISCV_TOOLS)/riscv-gnu-toolchain submodule update --init --depth=$(ROCKET_TOOLS_CHECKOUT_DEPTH) riscv-binutils-gdb riscv-gcc riscv-newlib
 	rm -f $(RISCV_TOOLS)/.travis.yml
 	mkdir -p $(dir $@)
 	date > $@


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
I think this should speed up the rocket-tools checkout step by not cloning the entire history of the whole `gcc` Git repo. I chose 50 since it's what Travis CI defaults to and because it seems to be a good balance of keeping the checkouts small while also pulling more history if it's useful.

I have not tested this and plan to rely on Travis CI to test it for me.