### PR TITLE
amba: combine modifiable+cacheable and add {read,write}alloc

### DIFF
--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -110,9 +110,10 @@ class AHBToTL()(implicit p: Parameters) extends LazyModule
             x.fetch      := !in.hprot(0)
             x.privileged :=  in.hprot(1)
             x.bufferable :=  in.hprot(2)
-            x.cacheable  :=  in.hprot(3)
-            x.secure     := false.B
             x.modifiable :=  in.hprot(3)
+            x.secure     := false.B
+            x.readalloc  :=  in.hprot(3)
+            x.writealloc :=  in.hprot(3)
           }
         }
       }

--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -92,8 +92,9 @@ class APBToTL()(implicit p: Parameters) extends LazyModule
         prot.secure     := !in.pprot(1)
         prot.fetch      :=  in.pprot(2)
         prot.bufferable :=  true.B
-        prot.cacheable  :=  true.B
         prot.modifiable :=  true.B
+        prot.readalloc  :=  true.B
+        prot.writealloc :=  true.B
       }
       when (out.a.fire()) {
         assert(in.paddr === out.a.bits.address, "Do not expect to have to perform alignment in APB2TL Conversion")

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -97,7 +97,8 @@ class AXI4ToTL(wcorrupt: Boolean)(implicit p: Parameters) extends LazyModule
         rprot.fetch      :=  in.ar.bits.prot(2)
         rprot.bufferable :=  in.ar.bits.cache(0)
         rprot.modifiable :=  in.ar.bits.cache(1)
-        rprot.cacheable  :=  in.ar.bits.cache(2) || in.ar.bits.cache(3)
+        rprot.readalloc  :=  in.ar.bits.cache(2)
+        rprot.writealloc :=  in.ar.bits.cache(3)
       }
 
       val r_sel = UIntToOH(in.ar.bits.id, numIds)
@@ -132,7 +133,8 @@ class AXI4ToTL(wcorrupt: Boolean)(implicit p: Parameters) extends LazyModule
         wprot.fetch      :=  in.aw.bits.prot(2)
         wprot.bufferable :=  in.aw.bits.cache(0)
         wprot.modifiable :=  in.aw.bits.cache(1)
-        wprot.cacheable  :=  in.aw.bits.cache(2) || in.aw.bits.cache(3)
+        wprot.readalloc  :=  in.aw.bits.cache(2)
+        wprot.writealloc :=  in.aw.bits.cache(3)
       }
 
       val w_sel = UIntToOH(in.aw.bits.id, numIds)

--- a/src/main/scala/amba/package.scala
+++ b/src/main/scala/amba/package.scala
@@ -7,9 +7,10 @@ import freechips.rocketchip.util._
 
 package object amba {
   class AMBAProtBundle extends Bundle {
-    val cacheable  = Bool() // false => no need to probe other cores
     val bufferable = Bool() // writeback caching ok?
     val modifiable = Bool() // legal to read/write-combine/expand this request?
+    val readalloc  = Bool()
+    val writealloc = Bool()
     val privileged = Bool() // machine_mode=true,   user_mode=false
     val secure     = Bool() // secure_master=true,  normal=false
     val fetch      = Bool() // instruct_fetch=true, load/store=false
@@ -19,9 +20,10 @@ package object amba {
   case class AMBAProtField() extends BundleField(AMBAProt) {
     def data = Output(new AMBAProtBundle)
     def default(x: AMBAProtBundle) {
-      x.cacheable  := false.B
       x.bufferable := false.B
       x.modifiable := false.B
+      x.readalloc  := false.B
+      x.writealloc := false.B
       x.privileged := true.B
       x.secure     := true.B
       x.fetch      := false.B

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -554,7 +554,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
 
   // Drive APROT Bits
   tl_out_a.bits.user.lift(AMBAProt).foreach { x =>
-    val user_bit_cacheable = edge.manager.supportsAcquireTFast(access_address, a_size)
+    val user_bit_cacheable = s2_pma.cacheable
 
     x.privileged  := s2_req.dprv === PRV.M || user_bit_cacheable
     // if the address is cacheable, enable outer caches

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -557,13 +557,15 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     val user_bit_cacheable = edge.manager.supportsAcquireTFast(access_address, a_size)
 
     x.privileged  := s2_req.dprv === PRV.M || user_bit_cacheable
-    x.cacheable   := user_bit_cacheable
+    // if the address is cacheable, enable outer caches
+    x.bufferable  := user_bit_cacheable
+    x.modifiable  := user_bit_cacheable
+    x.readalloc   := user_bit_cacheable
+    x.writealloc  := user_bit_cacheable
 
     // Following are always tied off
     x.fetch       := false.B
     x.secure      := true.B
-    x.bufferable  := false.B
-    x.modifiable  := false.B
   }
 
   // Set pending bits for outstanding TileLink transaction

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -163,7 +163,6 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   val s2_can_speculatively_refill = s2_tlb_resp.cacheable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableSpeculativeICacheRefill
   icache.io.s2_kill := s2_speculative && !s2_can_speculatively_refill || s2_xcpt
   icache.io.s2_prefetch := s2_tlb_resp.prefetchable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableICachePrefetch
-  icache.io.privileged := io.ptw.status.prv === PRV.M
 
   fq.io.enq.valid := RegNext(s1_valid) && s2_valid && (icache.io.resp.valid || !s2_tlb_resp.miss && icache.io.s2_kill)
   fq.io.enq.bits.pc := s2_pc

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -445,11 +445,10 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   }
   // Drive APROT information
   tl_out.a.bits.user.lift(AMBAProt).foreach { x =>
-    val user_bit_cacheable = edge_out.manager.supportsAcquireTFast(refill_paddr, lgCacheBlockBytes.U)
+    x.privileged  := io.privileged  // privileged if machine mode or memory port
 
-    x.privileged  := io.privileged || user_bit_cacheable    // privileged if machine mode or memory port
-
-    // enable outer caches for cacheable address PMAs
+    // enable outer caches for all fetches
+    val user_bit_cacheable = true.B
     x.bufferable  := user_bit_cacheable
     x.modifiable  := user_bit_cacheable
     x.readalloc   := user_bit_cacheable

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -124,8 +124,6 @@ class ICacheBundle(val outer: ICache) extends CoreBundle()(outer.p) {
 
   val clock_enabled = Bool(INPUT)
   val keep_clock_enabled = Bool(OUTPUT)
-
-  val privileged = Bool(INPUT)
 }
 
 class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
@@ -445,10 +443,12 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   }
   // Drive APROT information
   tl_out.a.bits.user.lift(AMBAProt).foreach { x =>
-    x.privileged  := io.privileged  // privileged if machine mode or memory port
+    // Rocket caches all fetch requests, and it's difficult to differentiate privileged/unprivileged on
+    // cached data, so mark as privileged
+    val user_bit_cacheable = true.B
 
     // enable outer caches for all fetches
-    val user_bit_cacheable = true.B
+    x.privileged  := user_bit_cacheable
     x.bufferable  := user_bit_cacheable
     x.modifiable  := user_bit_cacheable
     x.readalloc   := user_bit_cacheable

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -448,13 +448,16 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
     val user_bit_cacheable = edge_out.manager.supportsAcquireTFast(refill_paddr, lgCacheBlockBytes.U)
 
     x.privileged  := io.privileged || user_bit_cacheable    // privileged if machine mode or memory port
-    x.cacheable   := user_bit_cacheable
+
+    // enable outer caches for cacheable address PMAs
+    x.bufferable  := user_bit_cacheable
+    x.modifiable  := user_bit_cacheable
+    x.readalloc   := user_bit_cacheable
+    x.writealloc  := user_bit_cacheable
 
     // Following are always tied off
     x.fetch       := true.B
     x.secure      := true.B
-    x.bufferable  := false.B
-    x.modifiable  := false.B
   }
   tl_out.b.ready := Bool(true)
   tl_out.c.valid := Bool(false)

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -192,7 +192,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
         hprot(0) := !x.fetch
         hprot(1) :=  x.privileged
         hprot(2) :=  x.bufferable
-        hprot(3) :=  x.cacheable
+        hprot(3) :=  x.modifiable
         out.hprot := Cat(hprot.reverse)
       }
 

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -189,8 +189,8 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
         prot(2) :=  x.fetch
         cache(0) := x.bufferable
         cache(1) := x.modifiable
-        cache(2) := x.cacheable
-        cache(3) := x.cacheable
+        cache(2) := x.readalloc
+        cache(3) := x.writealloc
         arw.prot  := Cat(prot.reverse)
         arw.cache := Cat(cache.reverse)
       }


### PR DESCRIPTION
I misunderstood the AMBA specifications:
  HPROT[3] (cacheable)
and
  ARPROT[1] (modifiable)
are supposed to be the same, despite using different names in AHB vs. AXI4.

This mismatch then led me to incorrectly map ARPROT[2]+ARPROT[3] to
the AHB cacheable bit.

Add explicit readalloc+writealloc bits to fully cover the AXI4 bits.

Also, in most places, where we say 'cacheable', we mean set all of the bits:
  bufferable (writeback ok)
  modifiable (write-combining / fetch whole blocks ok)
  readalloc  (use outer caches for reads)
  writealloc (use outer caches for writes)

... I updated rocket accordingly.
