### PR TITLE
bump FIRRTL along 1.2.x to get rid of stray debug info

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -15,7 +15,7 @@
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "e1f4a0d94859f79758b5da32d1f84ff5c1968f87",
+        "commit": "eb637777e3c4d77435cfd13358c521ed1b766ba8",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:   implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Bump FIRRTL along 1.2.x branch because the previous commit had a stray debug print. While not causing any functional issues, it did cause a fairly noisy output during FIRRTL emission. This removes that debug print.