### PR TITLE
AsyncResetReg: use chisel3 resets

### DIFF
--- a/src/main/scala/util/AsyncResetReg.scala
+++ b/src/main/scala/util/AsyncResetReg.scala
@@ -2,7 +2,9 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
+
 import chisel3.{withClockAndReset, withReset, RawModule}
 
 /** This black-boxes an Async Reset


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

While chisel3 now provides native AsyncReset support, some code bases may still be making use of the `AsyncResetReg` modules and helpers which wrap it. Although those helpers cast the resets internally as needed to generate `AsyncReset`, they are intolerant of themselves being driven by `AsyncReset` because they are currently `Chisel._` modules and expect only `Bool` resets.

Use the compatibility options that allow these to accept resets of any type.

It's probably worth deprecating some of these interfaces, but i have not done that in this PR.

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:   implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Enable `AsyncResetReg`, `AsyncResetRegVec` modules and helpers to be used within modules with `chisel3`  `AsyncReset`
