### PR TITLE
Bump hardfloat (revert DivSqrtRecF64 to use Module instead RawModule)

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "3f88b663c7324cf9a27f9e20b82382908bb4cc11",
+        "commit": "22ebeb54301ca85fa087180596d21fa56335fdbc",
         "name": "hardfloat",
         "source": "git@github.com:ucb-bar/berkeley-hardfloat.git"
     },


### PR DESCRIPTION
https://github.com/ucb-bar/berkeley-hardfloat/issues/44