### PR TITLE
Attach TLError LogicalTreeNodes to subsystem LogicalTreeNode

### DIFF
--- a/src/main/scala/devices/tilelink/DevNull.scala
+++ b/src/main/scala/devices/tilelink/DevNull.scala
@@ -25,7 +25,7 @@ case class DevNullParams(
   * They may discard writes, refuse to respond to requests, issue error responses,
   * or otherwise violate 'expected' memory behavior.
   */
-abstract class DevNullDevice(params: DevNullParams, minLatency: Int, beatBytes: Int, device: SimpleDevice)
+abstract class DevNullDevice(params: DevNullParams, minLatency: Int, beatBytes: Int, protected val device: SimpleDevice)
                             (implicit p: Parameters)
     extends LazyModule with HasClockDomainCrossing {
   val xfer = if (params.maxTransfer > 0) TransferSizes(1, params.maxTransfer) else TransferSizes.none

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -27,8 +27,7 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
       val interrupts = DiplomaticObjectModelAddressing.describeInterrupts(name, resourceBindings)
       Seq(OMErrorDevice(
         memoryRegions = memRegions,
-        interrupts = interrupts,
-        specifications = Nil
+        interrupts = interrupts
       ))
     }
   }

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -26,7 +26,10 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
       val memRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions(name, resourceBindings, None)
       val interrupts = DiplomaticObjectModelAddressing.describeInterrupts(name, resourceBindings)
       Seq(OMErrorDevice(
-        memoryRegions = memRegions,
+        memoryRegions = memRegions.map(_.copy(
+          name = "errordevice",
+          description = "Error Device"
+        )),
         interrupts = interrupts
       ))
     }

--- a/src/main/scala/devices/tilelink/Zero.scala
+++ b/src/main/scala/devices/tilelink/Zero.scala
@@ -36,7 +36,10 @@ class TLZero(address: AddressSet, beatBytes: Int = 4)(implicit p: Parameters)
       val memRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions(name, resourceBindings, None)
       val interrupts = DiplomaticObjectModelAddressing.describeInterrupts(name, resourceBindings)
       Seq(OMZeroDevice(
-        memoryRegions = memRegions,
+        memoryRegions = memRegions.map(_.copy(
+          name = "zerodevice",
+          description = "Zero Device"
+        )),
         interrupts = interrupts
       ))
     }

--- a/src/main/scala/devices/tilelink/Zero.scala
+++ b/src/main/scala/devices/tilelink/Zero.scala
@@ -7,6 +7,10 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink.TLMessages
 
+import freechips.rocketchip.diplomaticobjectmodel.{DiplomaticObjectModelAddressing, HasLogicalTreeNode}
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+import freechips.rocketchip.diplomaticobjectmodel.model.{OMZeroDevice, OMComponent}
+
 /** This /dev/null device accepts single beat gets/puts, as well as atomics.
   * Response data is always 0. Reequests to write data have no effect.
   */
@@ -22,7 +26,22 @@ class TLZero(address: AddressSet, beatBytes: Int = 4)(implicit p: Parameters)
       mayDenyPut = false),
     minLatency = 1,
     beatBytes = beatBytes,
-    device = new SimpleDevice("rom", Seq("ucbbar,cacheable-zero0"))) {
+    device = new SimpleDevice("rom", Seq("ucbbar,cacheable-zero0")))
+    with HasLogicalTreeNode
+{
+
+  lazy val logicalTreeNode: LogicalTreeNode = new LogicalTreeNode(() => Some(device)) {
+    def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil) = {
+      val Description(name, mapping) = device.describe(resourceBindings)
+      val memRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions(name, resourceBindings, None)
+      val interrupts = DiplomaticObjectModelAddressing.describeInterrupts(name, resourceBindings)
+      Seq(OMZeroDevice(
+        memoryRegions = memRegions,
+        interrupts = interrupts
+      ))
+    }
+  }
+
   lazy val module = new LazyModuleImp(this) {
     val (in, edge) = node.in(0)
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMErrorDevice.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMErrorDevice.scala
@@ -1,0 +1,11 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.diplomaticobjectmodel.model
+
+
+case class OMErrorDevice(
+  memoryRegions: Seq[OMMemoryRegion],
+  interrupts: Seq[OMInterrupt],
+  specifications: Seq[OMSpecification],
+  _types: Seq[String] = Seq("OMErrorDevice", "OMDevice", "OMComponent", "OMCompoundType")
+) extends OMDevice

--- a/src/main/scala/diplomaticobjectmodel/model/OMZeroDevice.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMZeroDevice.scala
@@ -3,8 +3,8 @@
 package freechips.rocketchip.diplomaticobjectmodel.model
 
 
-case class OMErrorDevice(
+case class OMZeroDevice(
   memoryRegions: Seq[OMMemoryRegion],
   interrupts: Seq[OMInterrupt],
-  _types: Seq[String] = Seq("OMErrorDevice", "OMDevice", "OMComponent", "OMCompoundType")
+  _types: Seq[String] = Seq("OMZeroDevice", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMDevice

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -143,8 +143,13 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem
     mbus.builtInDevices,
     cbus.builtInDevices
   )
-  for (builtIn <- builtInDevices; error <- builtIn.errorOpt) {
-    LogicalModuleTree.add(logicalTreeNode, error.logicalTreeNode)
+  builtInDevices.foreach { builtIn => 
+    builtIn.errorOpt.foreach { error => 
+      LogicalModuleTree.add(logicalTreeNode, error.logicalTreeNode)
+     }
+    builtIn.zeroOpt.foreach { zero => 
+      LogicalModuleTree.add(logicalTreeNode, zero.logicalTreeNode)
+    }
   }
 }
 

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -134,20 +134,17 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem
     }
   }
 
-  lazy val logicalTreeNode = {
-    val subsystemLogicalTreeNode = new SubsystemLogicalTreeNode()
-    val builtInDevices = Seq(
-      pbus.builtInDevices,
-      fbus.builtInDevices,
-      mbus.builtInDevices,
-      cbus.builtInDevices
-    )
-    for (builtIn <- builtInDevices) {
-      builtIn.errorOpt.foreach { error =>
-        LogicalModuleTree.add(subsystemLogicalTreeNode, error.logicalTreeNode)
-      }
-    }
-    subsystemLogicalTreeNode
+  lazy val logicalTreeNode = new SubsystemLogicalTreeNode()
+
+  private val builtInDevices = Seq(
+    sbus.builtInDevices,
+    pbus.builtInDevices,
+    fbus.builtInDevices,
+    mbus.builtInDevices,
+    cbus.builtInDevices
+  )
+  for (builtIn <- builtInDevices; error <- builtIn.errorOpt) {
+    LogicalModuleTree.add(logicalTreeNode, error.logicalTreeNode)
   }
 }
 

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -81,7 +81,7 @@ case object ResetAsynchronousFull extends SubsystemResetScheme
 case object SubsystemResetSchemeKey extends Field[SubsystemResetScheme](ResetSynchronous)
 
 /** Base Subsystem class with no peripheral devices or ports added */
-abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem 
+abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem
     with Attachable {
 
   override val module: BaseSubsystemModuleImp[BaseSubsystem]
@@ -136,18 +136,20 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem
 
   lazy val logicalTreeNode = new SubsystemLogicalTreeNode()
 
-  private val builtInDevices = Seq(
-    sbus.builtInDevices,
-    pbus.builtInDevices,
-    fbus.builtInDevices,
-    mbus.builtInDevices,
-    cbus.builtInDevices
+  private val buses = Seq(
+    sbus,
+    pbus,
+    fbus,
+    mbus,
+    cbus
   )
-  builtInDevices.foreach { builtIn => 
-    builtIn.errorOpt.foreach { error => 
+
+  buses.foreach { bus =>
+    val builtIn = bus.builtInDevices
+    builtIn.errorOpt.foreach { error =>
       LogicalModuleTree.add(logicalTreeNode, error.logicalTreeNode)
-     }
-    builtIn.zeroOpt.foreach { zero => 
+    }
+    builtIn.zeroOpt.foreach { zero =>
       LogicalModuleTree.add(logicalTreeNode, zero.logicalTreeNode)
     }
   }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -134,7 +134,21 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem
     }
   }
 
-  lazy val logicalTreeNode = new SubsystemLogicalTreeNode()
+  lazy val logicalTreeNode = {
+    val subsystemLogicalTreeNode = new SubsystemLogicalTreeNode()
+    val builtInDevices = Seq(
+      pbus.builtInDevices,
+      fbus.builtInDevices,
+      mbus.builtInDevices,
+      cbus.builtInDevices
+    )
+    for (builtIn <- builtInDevices) {
+      builtIn.errorOpt.foreach { error =>
+        LogicalModuleTree.add(subsystemLogicalTreeNode, error.logicalTreeNode)
+      }
+    }
+    subsystemLogicalTreeNode
+  }
 }
 
 

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -20,5 +20,5 @@ class FrontBus(params: FrontBusParams)(implicit p: Parameters)
     with CanHaveBuiltInDevices
     with CanAttachTLMasters
     with HasTLXbarPhy {
-  val builtInDevices = attachBuiltInDevices(params)
+  val builtInDevices: BuiltInDevices = BuiltInDevices.attach(params, outwardNode)
 }

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -20,5 +20,5 @@ class FrontBus(params: FrontBusParams)(implicit p: Parameters)
     with CanHaveBuiltInDevices
     with CanAttachTLMasters
     with HasTLXbarPhy {
-  attachBuiltInDevices(params)
+  val builtInDevices = attachBuiltInDevices(params)
 }

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -59,7 +59,7 @@ class MemoryBus(params: MemoryBusParams)(implicit p: Parameters)
     if (params.replicatorMask == 0) xbar.node else { xbar.node :=* RegionReplicator(params.replicatorMask) }
   def outwardNode: TLOutwardNode = ProbePicker() :*= xbar.node
   def busView: TLEdge = xbar.node.edges.in.head
-  attachBuiltInDevices(params)
+  val builtInDevices = attachBuiltInDevices(params)
 
   def toDRAMController[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -59,7 +59,7 @@ class MemoryBus(params: MemoryBusParams)(implicit p: Parameters)
     if (params.replicatorMask == 0) xbar.node else { xbar.node :=* RegionReplicator(params.replicatorMask) }
   def outwardNode: TLOutwardNode = ProbePicker() :*= xbar.node
   def busView: TLEdge = xbar.node.edges.in.head
-  val builtInDevices = attachBuiltInDevices(params)
+  val builtInDevices: BuiltInDevices = BuiltInDevices.attach(params, outwardNode)
 
   def toDRAMController[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -51,7 +51,7 @@ class PeripheryBus(params: PeripheryBusParams, name: String)(implicit p: Paramet
   def outwardNode: TLOutwardNode = node
   def busView: TLEdge = fixer.node.edges.in.head
 
-  val builtInDevices = attachBuiltInDevices(params)
+  val builtInDevices: BuiltInDevices = BuiltInDevices.attach(params, outwardNode)
 
   def toTile
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -51,7 +51,7 @@ class PeripheryBus(params: PeripheryBusParams, name: String)(implicit p: Paramet
   def outwardNode: TLOutwardNode = node
   def busView: TLEdge = fixer.node.edges.in.head
 
-  attachBuiltInDevices(params)
+  val builtInDevices = attachBuiltInDevices(params)
 
   def toTile
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -29,7 +29,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
   def outwardNode: TLOutwardNode = system_bus_xbar.node
   def busView: TLEdge = system_bus_xbar.node.edges.in.head
 
-  val builtInDevices = attachBuiltInDevices(params)
+  val builtInDevices: BuiltInDevices = BuiltInDevices.attach(params, outwardNode)
 
   def fromTile
       (name: Option[String], buffer: BufferParams = BufferParams.none, cork: Option[Boolean] = None)

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -29,7 +29,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
   def outwardNode: TLOutwardNode = system_bus_xbar.node
   def busView: TLEdge = system_bus_xbar.node.edges.in.head
 
-  attachBuiltInDevices(params)
+  val builtInDevices = attachBuiltInDevices(params)
 
   def fromTile
       (name: Option[String], buffer: BufferParams = BufferParams.none, cork: Option[Boolean] = None)


### PR DESCRIPTION
This is my attempt at adding `OMErrorDevice` to the object model. It seems to work based on visual inspection of the resulting objectModel.json. Looking for feedback on whether this is the best way of plumbing and attaching the logicalTreeNodes.
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
includes https://github.com/chipsalliance/rocket-chip/pull/2343

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification
- factor out `CanHaveBuiltInDevices.attachBuiltInDevices` into `attach` helper method in `BuiltInDevices` companion object
- `CanHaveBuiltInDevices` has abstract field `def builtInDevices: BuiltInDevices`
- `TLError` extends `HasLogicalTreeNode`
- `TLZero` extends `HasLogicalTreeNode`
- argument `device` of  `DevNullDevice` is a `protected val`

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Add Object Model for TLError Device.
