### PR TITLE
Add Finder to diplomacy

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -118,9 +118,25 @@ abstract class LazyModule()(implicit val p: Parameters)
     children.foreach( _.childrenIterator(iterfunc) )
   }
 
+  def childrenFinder(filter: LazyModule => Boolean): LazyModule = {
+    val found = scala.collection.mutable.ListBuffer[LazyModule]()
+    childrenIterator(lm => if (filter(lm)) found += lm)
+    require(found.nonEmpty, s"no LazyModule found")
+    require(found.size == 1, s"constraint of filter is too loose, found ${found.size} LazyModules")
+    found.head
+  }
+
   def nodeIterator(iterfunc: (BaseNode) => Unit): Unit = {
     nodes.foreach(iterfunc)
     childrenIterator(_.nodes.foreach(iterfunc))
+  }
+
+  def nodeFinder(filter: BaseNode => Boolean): BaseNode = {
+    val found = scala.collection.mutable.ListBuffer[BaseNode]()
+    nodeIterator(node => if (filter(node)) found += node)
+    require(found.nonEmpty, s"no BaseNode found")
+    require(found.size == 1, s"constraint of filter is too loose, found ${found.size} LazyModules")
+    found.head
   }
 
   def getChildren = children


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
Since some `LazyModule` are instantiated by `Parameter`, which are not accessible by outer `LazyModule`, we cannot annotate these modules.
This PR implemented a `LazyModule` and `BaseNode` finder to find a specific element in the diplomatic modules.
When found required module, we can use `asInstanceOf` to cast it to the type it should be and annotate the contents.
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->