### PR TITLE
coreMonitorBundle.wren separate into wrenx/wrenf for integer/float

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -877,7 +877,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   coreMonitorBundle.timer := csr.io.time(31,0)
   coreMonitorBundle.valid := csr.io.trace(0).valid && !csr.io.trace(0).exception
   coreMonitorBundle.pc := csr.io.trace(0).iaddr(vaddrBitsExtended-1, 0).sextTo(xLen)
-  coreMonitorBundle.wren := wb_wen && !wb_set_sboard
+  coreMonitorBundle.wrenx := wb_wen && !wb_set_sboard
+  coreMonitorBundle.wrenf := false.B
   coreMonitorBundle.wrdst := wb_waddr
   coreMonitorBundle.wrdata := rf_wdata
   coreMonitorBundle.rd0src := wb_reg_inst(19,15)
@@ -920,8 +921,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
          io.hartid, coreMonitorBundle.timer, coreMonitorBundle.valid,
          coreMonitorBundle.pc,
          Mux(wb_ctrl.wxd || wb_ctrl.wfd, coreMonitorBundle.wrdst, 0.U),
-         Mux(coreMonitorBundle.wren, coreMonitorBundle.wrdata, 0.U),
-         coreMonitorBundle.wren,
+         Mux(coreMonitorBundle.wrenx, coreMonitorBundle.wrdata, 0.U),
+         coreMonitorBundle.wrenx,
          Mux(wb_ctrl.rxs1 || wb_ctrl.rfs1, coreMonitorBundle.rd0src, 0.U),
          Mux(wb_ctrl.rxs1 || wb_ctrl.rfs1, coreMonitorBundle.rd0val, 0.U),
          Mux(wb_ctrl.rxs2 || wb_ctrl.rfs2, coreMonitorBundle.rd1src, 0.U),

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -16,7 +16,10 @@ class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
   val pc = UInt(width = xLen.W)
   val wrdst = UInt(width = 5.W)
   val wrdata = UInt(width = xLen.W)
-  val wren = Bool()
+  val wrenx = Bool()
+  val wrenf = Bool()
+  @deprecated("replace wren with wrenx or wrenf to specify integer or floating point","")
+  def wren: Bool = wrenx || wrenf
   val rd0src = UInt(width = 5.W)
   val rd0val = UInt(width = xLen.W)
   val rd1src = UInt(width = 5.W)


### PR DESCRIPTION
**Related issue**: follow-on to #2409
**Type of change**: feature request
**Impact**: API modification
**Development Phase**: implementation

**Release Notes**
coreMonitorBundle remove `wren` and instead have `wrenx` for integer regfile writes and `wrenf` for floating point regfile writes.
Any users of `coreMonitorBundle.wren` will get a compile error and should change to `wrenx` for the same behavior.