### PR TITLE
A Pair of Phase-Ordering Fixes

### DIFF
--- a/src/main/scala/stage/phases/AddDefaultTests.scala
+++ b/src/main/scala/stage/phases/AddDefaultTests.scala
@@ -7,7 +7,7 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3.stage.phases.Elaborate
 import firrtl.AnnotationSeq
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{Phase, PreservesAll, Unserializable}
 import firrtl.options.Viewer.view
 import freechips.rocketchip.stage.RocketChipOptions
 import freechips.rocketchip.subsystem.RocketTilesKey
@@ -19,7 +19,7 @@ import freechips.rocketchip.system.DefaultTestSuites._
 import scala.collection.mutable
 
 /** Annotation that contains a list of [[RocketTestSuite]]s to run */
-case class RocketTestSuiteAnnotation(tests: Seq[RocketTestSuite]) extends NoTargetAnnotation
+case class RocketTestSuiteAnnotation(tests: Seq[RocketTestSuite]) extends NoTargetAnnotation with Unserializable
 
 /** Generates [[RocketTestSuiteAnnotation]] depending on whether the top-module project is part of
  *  [[freechips.rocketchip.system]] or not (e.g. for unit tests).

--- a/src/main/scala/stage/phases/TransformAnnotations.scala
+++ b/src/main/scala/stage/phases/TransformAnnotations.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.stage.phases
 
 import chisel3.stage.ChiselOutputFileAnnotation
-import chisel3.stage.phases.Emitter
 import firrtl.AnnotationSeq
 import firrtl.options.Viewer.view
 import firrtl.options.{Phase, PreservesAll}
@@ -14,7 +13,7 @@ import freechips.rocketchip.util.HasRocketChipStageUtils
 class TransformAnnotations extends Phase with PreservesAll[Phase] with HasRocketChipStageUtils {
 
   override val prerequisites = Seq(classOf[Checks])
-  override val dependents = Seq(classOf[Emitter])
+  override val dependents = Seq(classOf[chisel3.stage.phases.AddImplicitOutputFile])
 
   override def transform(annotations: AnnotationSeq): AnnotationSeq = {
     /** Construct output file annotation for emission */


### PR DESCRIPTION
While bumping Rocket Chip in Chipyard i ran into a couple of order issues with the initial Stage / Phase implementation. There many ways they can be fixed, but this is what i did: 

1) The dependency manager can schedule `TransformAnnotations` behind chisel's `AddImplicitOutputFile` phase, which leads the down stream phases to use the instance of the annotation provided by `AddImplicitOutputFile` and not `TransformAnnotations`. I added a dependency between the two phases to resolve this. 

2) The dependency manager can schedule `AddDefaultTestSuites` ahead of `GenerateFirrtlAnnos`, which leads to `RocketTestSuiteAnnotation`s being serialized when they cannot be. While there are myriad ways to fix this i've simply marked them as unserializable. 

**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
- [stage] Fix a bug where unserializable RocketTestSuiteAnnotations were being serialized
- [stage] Fix a bug where the desired output file name was being superseded  by another phase