### PR TITLE
pin Wit version to branch v0.12.0

### DIFF
--- a/ci-tests/wake_scala_compilation
+++ b/ci-tests/wake_scala_compilation
@@ -19,7 +19,7 @@ cd ..
 
 echo "Installing Wit"
 
-git clone https://github.com/sifive/wit.git
+git clone https://github.com/sifive/wit.git --branch v0.12.0
 export PATH=$PATH:$PWD/wit
 
 


### PR DESCRIPTION
**Related issue**: https://github.com/sifive/wit/pull/225
**Type of change**: fixes CI test wake compilation
**Impact**: API stabilization
**Development Phase**: implementation
**Release Notes**
pin Wit version to a specific branch
