### PR TITLE
Object model updates for AHB and AXI

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -51,7 +51,7 @@ case class AXI4_Lite(
 
 case class AHB_Lite(
   specification: Option[OMSpecification],
-  val _types: Seq[String] = Seq("AHB", "AMBA",  "OMProtocol")
+  val _types: Seq[String] = Seq("AHB_Lite", "AMBA",  "OMProtocol")
 ) extends AMBA
 
 case class AHB(

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -41,12 +41,12 @@ trait AMBA extends OMProtocol
 
 case class AXI4(
   specification: Option[OMSpecification],
-  _types: Seq[String] = Seq("AXI", "AMBA",  "OMProtocol")
+  _types: Seq[String] = Seq("AXI4", "AMBA",  "OMProtocol")
 ) extends AMBA
 
 case class AXI4_Lite(
   specification: Option[OMSpecification],
-  val _types: Seq[String] = Seq("AXI", "AMBA",  "OMProtocol")
+  val _types: Seq[String] = Seq("AXI4_Lite", "AMBA",  "OMProtocol")
 ) extends AMBA
 
 case class AHB_Lite(

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -41,17 +41,17 @@ trait AMBA extends OMProtocol
 
 case class AXI4(
   specification: Option[OMSpecification],
-  _types: Seq[String] = Seq("AXI4", "AMBA",  "OMProtocol")
+  _types: Seq[String] = Seq("AXI", "AMBA",  "OMProtocol")
 ) extends AMBA
 
 case class AXI4_Lite(
   specification: Option[OMSpecification],
-  val _types: Seq[String] = Seq("AXI4_Lite", "AMBA",  "OMProtocol")
+  val _types: Seq[String] = Seq("AXI", "AMBA",  "OMProtocol")
 ) extends AMBA
 
 case class AHB_Lite(
   specification: Option[OMSpecification],
-  val _types: Seq[String] = Seq("AHB_Lite", "AMBA",  "OMProtocol")
+  val _types: Seq[String] = Seq("AHB", "AMBA",  "OMProtocol")
 ) extends AMBA
 
 case class AHB(
@@ -125,15 +125,15 @@ case class SystemPort(
 
 object OMPortMaker {
   val protocolSpecifications = Map[ProtocolType, String](
-    AHBProtocol -> "AMBA 3 AHB-Lite Protocol",
-    AXI4Protocol -> "AMBA 3 AXI4-Lite Protocol",
-    APBProtocol -> "AMBA 3 APB Protocol",
+    AHBProtocol -> "AHB Protocol",
+    AXI4Protocol -> "AXI Protocol",
+    APBProtocol -> "APB Protocol",
     TLProtocol -> "TileLink specification"
   )
 
   val protocolSpecificationVersions = Map[ProtocolType, String](
-    AHBProtocol -> "1.0",
-    AXI4Protocol -> "1.0",
+    AHBProtocol -> "3",
+    AXI4Protocol -> "4",
     APBProtocol -> "1.0",
     TLProtocol -> "1.8"
   )

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -124,12 +124,17 @@ case class SystemPort(
   _types: Seq[String] = Seq("SystemPort", "OutboundPort", "OMPort", "OMDevice", "OMComponent", "OMCompoundType")) extends OutboundPort
 
 object OMPortMaker {
-  val protocolSpecifications = Map[ProtocolType, String](
-    AHBProtocol -> "AHB Protocol",
-    AXI4Protocol -> "AXI Protocol",
-    APBProtocol -> "APB Protocol",
-    TLProtocol -> "TileLink specification"
-  )
+  val protocolSpecifications: (ProtocolType, SubProtocolType) => String = {
+   case (AHBProtocol, AHBLiteSubProtocol) => "AHB Lite Protocol"
+   case (AHBProtocol, AHBFullSubProtocol) => "AHB Full Protocol"
+   case (AXI4Protocol, AXI4SubProtocol) => "AXI Protocol"
+   case (AXI4Protocol, AXI4LiteSubProtocol) => "AXI Lite Protocol"
+   case (APBProtocol, APBSubProtocol) => "APB Protocol"
+   case (TLProtocol, TL_UHSubProtocol) => "TileLink specification"
+   case (TLProtocol, TL_ULSubProtocol) => "TileLink specification"
+   case (TLProtocol, TL_CSubProtocol) => "TileLink specification"
+   case _ => "Invalid Protocol"
+  }
 
   val protocolSpecificationVersions = Map[ProtocolType, String](
     AHBProtocol -> "3",
@@ -138,7 +143,7 @@ object OMPortMaker {
     TLProtocol -> "1.8"
   )
 
-  def specVersion(protocol: ProtocolType, version: String): Option[OMSpecification] = Some(OMSpecification(protocolSpecifications(protocol), version))
+  def specVersion(protocol: ProtocolType, subProtocol: SubProtocolType, version: String): Option[OMSpecification] = Some(OMSpecification(protocolSpecifications(protocol, subProtocol), version))
 
   val portNames = Map[PortType, String](
     SystemPortType -> "System Port",
@@ -158,14 +163,14 @@ object OMPortMaker {
     val documentationName = portNames(portType)
 
     val omProtocol = (protocol, subProtocol) match {
-      case (AXI4Protocol, AXI4SubProtocol) => AXI4(specification = specVersion(protocol, version))
-      case (AXI4Protocol, AXI4LiteSubProtocol) => AXI4_Lite(specification = specVersion(protocol, version))
-      case (AHBProtocol, AHBLiteSubProtocol) => AHB_Lite(specification = specVersion(protocol, version))
-      case (AHBProtocol, AHBFullSubProtocol) => AHB(specification = specVersion(protocol, version))
-      case (APBProtocol, APBSubProtocol) => APB(specification = specVersion(protocol, version))
-      case (TLProtocol, TL_UHSubProtocol) => TL_UH(specification = specVersion(protocol, version))
-      case (TLProtocol, TL_ULSubProtocol) => TL_UL(specification = specVersion(protocol, version))
-      case (TLProtocol, TL_CSubProtocol) => TL_C(specification = specVersion(protocol, version))
+      case (AXI4Protocol, AXI4SubProtocol) => AXI4(specification = specVersion(protocol, subProtocol, version))
+      case (AXI4Protocol, AXI4LiteSubProtocol) => AXI4_Lite(specification = specVersion(protocol, subProtocol, version))
+      case (AHBProtocol, AHBLiteSubProtocol) => AHB_Lite(specification = specVersion(protocol, subProtocol, version))
+      case (AHBProtocol, AHBFullSubProtocol) => AHB(specification = specVersion(protocol, subProtocol, version))
+      case (APBProtocol, APBSubProtocol) => APB(specification = specVersion(protocol, subProtocol, version))
+      case (TLProtocol, TL_UHSubProtocol) => TL_UH(specification = specVersion(protocol, subProtocol, version))
+      case (TLProtocol, TL_ULSubProtocol) => TL_UL(specification = specVersion(protocol, subProtocol, version))
+      case (TLProtocol, TL_CSubProtocol) => TL_C(specification = specVersion(protocol, subProtocol, version))
       case _ => throw new IllegalArgumentException(s"protocol $protocol, subProtocol $subProtocol")
     }
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -130,9 +130,9 @@ object OMPortMaker {
    case (AXI4Protocol, AXI4SubProtocol) => "AXI Protocol"
    case (AXI4Protocol, AXI4LiteSubProtocol) => "AXI Lite Protocol"
    case (APBProtocol, APBSubProtocol) => "APB Protocol"
-   case (TLProtocol, TL_UHSubProtocol) => "TileLink specification"
-   case (TLProtocol, TL_ULSubProtocol) => "TileLink specification"
-   case (TLProtocol, TL_CSubProtocol) => "TileLink specification"
+   case (TLProtocol, TL_UHSubProtocol) => "TileLink Protocol"
+   case (TLProtocol, TL_ULSubProtocol) => "TileLink Protocol"
+   case (TLProtocol, TL_CSubProtocol) => "TileLink Protocol"
    case _ => "Invalid Protocol"
   }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
The PR aims at making the OM description of AHB and AXI ports clearer.
-->
An example representation of a port with AXI protocol:
```
      "signalNamePrefix" : "axi4_mem_port",
      "width" : 32,
      "protocol" : {
        "specification" : {
          "name" : "AXI Protocol",
          "version" : "4",
          "_types" : [ "OMSpecification" ]
        },
        "_types" : [ "AXI", "AMBA", "OMProtocol" ]
      },
```

An example representation of a port with AHB-Lite protocol:

```
      "signalNamePrefix" : "ahb_sys_port",
      "width" : 32,
      "protocol" : {
        "specification" : {
          "name" : "AHB Lite Protocol",
          "version" : "3",
          "_types" : [ "OMSpecification" ]
        },
        "_types" : [ "AHB", "AMBA", "OMProtocol" ]
      },
```