### PR TITLE
Diplomatic tilelink "v1" parameter fixes

### DIFF
--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -134,7 +134,7 @@ trait TLCommonTransferSizes {
 class TLSlaveParameters private(
   val nodePath:           Seq[BaseNode],
   val resources:          Seq[Resource],
-  setName:                String,
+  setName:                Option[String],
   val address:            Seq[AddressSet],
   val regionType:         RegionType.T,
   val executable:         Boolean,
@@ -195,7 +195,7 @@ class TLSlaveParameters private(
   require (regionType <= RegionType.UNCACHED || supportsAcquireB)  // tracked, cached -> acquire
   require (regionType != RegionType.UNCACHED || supportsGet) // uncached -> supportsGet
 
-  val name = if (setName != "") setName else nodePath.lastOption.map(_.lazyModule.name).getOrElse("disconnected")
+  val name = setName.orElse(nodePath.lastOption.map(_.lazyModule.name)).getOrElse("disconnected")
   val maxTransfer = List( // Largest supported transfer of all types
     supportsAcquireT.max,
     supportsAcquireB.max,
@@ -345,7 +345,7 @@ object TLSlaveParameters {
     fifoId:             Option[Int] = None) =
   {
     new TLSlaveParameters(
-      setName       = "",
+      setName       = None,
       address       = address,
       resources     = resources,
       regionType    = regionType,

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -99,7 +99,7 @@ case class TLSlaveToMasterTransferSizes(
   override def toString = {
     def str(x: TransferSizes, flag: String) = if (x.none) "" else flag
     def flags = Vector(
-      str(probe,      "T"),
+      str(probe,      "P"),
       str(arithmetic, "A"),
       str(logical,    "L"),
       str(get,        "G"),

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -261,7 +261,7 @@ class TLSlaveParameters private(
     fifoId:             Option[Int]     = fifoId) =
   {
     new TLSlaveParameters(
-      setName       = name,
+      setName       = setName,
       address       = address,
       resources     = resources,
       regionType    = regionType,


### PR DESCRIPTION
#2320 introduced a bug in `TLSlaveParameters.v1copy` that was then rolled out at large via #2353. The wrong `name` val was used in the copy constructor. Outcome of the bug is that many TLSlaves have been reporting their name as `"disconnected"`. However, in practice these names seem to only appear in e.g. diplomatic `require` failures that attempt to use the name of the failing slave in their error message. I don't believe any verilog emission was actually affected by this bug.

I fixed the bug in 8ab8246, but I think this bug could have been avoided by making `setName` an `Option` so that `name` and `setName` have different types. Handling it this way cleans up the `setName` code; there is a fundamental difference between setting/not-setting the name and choosing to name something `""`. I make this further change in f29b0c9. Since the API is private I think this is still a free action, thought it might impact #2365.