### PR TITLE
Revise Multichip routing

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -89,8 +89,8 @@ trait HasPeripheryDebug { this: BaseSubsystem =>
     }
 
     debug.dmInner.dmInner.sb2tlOpt.foreach { sb2tl  =>
-      locateTLBusWrapper(p(ExportDebug).masterWhere).asInstanceOf[CanAttachTLMasters].fromPort(Some("debug_sb")){
-        FlipRendering { implicit p => TLWidthWidget(1) := sb2tl.node }
+      locateTLBusWrapper(p(ExportDebug).masterWhere).coupleFrom("debug_sb") {
+        _ := TLWidthWidget(1) := sb2tl.node
       }
     }
     debug

--- a/src/main/scala/subsystem/BankedL2Params.scala
+++ b/src/main/scala/subsystem/BankedL2Params.scala
@@ -57,6 +57,7 @@ class CoherenceManagerWrapper(params: CoherenceManagerWrapperParams, context: Ha
   def busView: TLEdge = coherent_jbar.node.edges.out.head
   val inwardNode = tempIn :*= coherent_jbar.node
   val builtInDevices = BuiltInDevices.none
+  val prefixNode = None
 
   private def banked(node: TLOutwardNode): TLOutwardNode =
     if (params.nBanks == 0) node else { TLTempNode() :=* BankBinder(params.nBanks, params.blockBytes) :*= node }

--- a/src/main/scala/subsystem/BankedL2Params.scala
+++ b/src/main/scala/subsystem/BankedL2Params.scala
@@ -53,10 +53,9 @@ case class CoherenceManagerWrapperParams(
 class CoherenceManagerWrapper(params: CoherenceManagerWrapperParams, context: HasTileLinkLocations)(implicit p: Parameters) extends TLBusWrapper(params, params.name) {
   val (tempIn, tempOut, halt) = params.coherenceManager(context)
 
-  // TODO could remove temp if we could get access to .edges from InwardNodeHandle
-  val viewNode = TLIdentityNode()
-  def busView: TLEdge = viewNode.edges.out.head
-  val inwardNode = tempIn :*= viewNode
+  private val coherent_jbar = LazyModule(new TLJbar)
+  def busView: TLEdge = coherent_jbar.node.edges.out.head
+  val inwardNode = tempIn :*= coherent_jbar.node
   val builtInDevices = BuiltInDevices.none
 
   private def banked(node: TLOutwardNode): TLOutwardNode =

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -25,16 +25,14 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   case ControlBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
     blockBytes = site(CacheBlockBytes),
-    errorDevice = Some(DevNullParams(List(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096)),
-    replicatorMask = site(MultiChipMaskKey))
+    errorDevice = Some(DevNullParams(List(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096)))
   case PeripheryBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
     blockBytes = site(CacheBlockBytes),
     dtsFrequency = Some(100000000)) // Default to 100 MHz pbus clock
   case MemoryBusKey => MemoryBusParams(
     beatBytes = site(XLen)/8,
-    blockBytes = site(CacheBlockBytes),
-    replicatorMask = site(MultiChipMaskKey))
+    blockBytes = site(CacheBlockBytes))
   case FrontBusKey => FrontBusParams(
     beatBytes = site(XLen)/8,
     blockBytes = site(CacheBlockBytes))

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -30,4 +30,5 @@ class FrontBus(params: FrontBusParams, name: String = "front_bus")(implicit p: P
     extends TLBusWrapper(params, name)
     with HasTLXbarPhy {
   val builtInDevices: BuiltInDevices = BuiltInDevices.attach(params, outwardNode)
+  val prefixNode = None
 }

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -39,7 +39,9 @@ class MemoryBus(params: MemoryBusParams, name: String = "memory_bus")(implicit p
   val prefixNode = replicator.map(_.prefix)
 
   private val xbar = LazyModule(new TLXbar).suggestName(busName + "_xbar")
-  val inwardNode: TLInwardNode = replicator.map(xbar.node :*=* _.node).getOrElse(xbar.node)
+  val inwardNode: TLInwardNode =
+    replicator.map(xbar.node :*=* TLFIFOFixer(TLFIFOFixer.all) :*=* _.node)
+        .getOrElse(xbar.node :*=* TLFIFOFixer(TLFIFOFixer.all))
 
   val outwardNode: TLOutwardNode = ProbePicker() :*= xbar.node
   def busView: TLEdge = xbar.node.edges.in.head

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -13,14 +13,20 @@ import freechips.rocketchip.diplomaticobjectmodel.model._
 import freechips.rocketchip.tile._
 
 // TODO: how specific are these to RocketTiles?
-case class TileMasterPortParams(buffers: Int = 0, cork: Option[Boolean] = None)
-case class TileSlavePortParams(buffers: Int = 0, blockerCtrlAddr: Option[BigInt] = None)
+case class TileMasterPortParams(
+  buffers: Int = 0,
+  cork: Option[Boolean] = None,
+  where: TLBusWrapperLocation = SBUS)
+
+case class TileSlavePortParams(
+  buffers: Int = 0,
+  blockerCtrlAddr: Option[BigInt] = None,
+  where: TLBusWrapperLocation = CBUS)
 
 case class RocketCrossingParams(
-    crossingType: ClockCrossingType = SynchronousCrossing(),
-    master: TileMasterPortParams = TileMasterPortParams(),
-    slave: TileSlavePortParams = TileSlavePortParams()) {
-}
+  crossingType: ClockCrossingType = SynchronousCrossing(),
+  master: TileMasterPortParams = TileMasterPortParams(),
+  slave: TileSlavePortParams = TileSlavePortParams())
 
 case object RocketTilesKey extends Field[Seq[RocketTileParams]](Nil)
 case object RocketCrossingKey extends Field[Seq[RocketCrossingParams]](List(RocketCrossingParams()))

--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -93,7 +93,7 @@ class AddressAdjuster(mask: BigInt, adjustableRegion: Option[AddressSet] = Some(
   }
 
   // Now we create a custom node that joins the local and remote manager parameters, changing the PMAs of devices in the adjustable region
-  val node = TLJunctionNode(1, 2,
+  val node = TLJunctionNode(
     clientFn  = { cp => cp ++ cp },
     managerFn = { mp =>
       val remote = mp(0)

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -373,9 +373,9 @@ case class AddressAdjusterWrapperParams(
 class AddressAdjusterWrapper(params: AddressAdjusterWrapperParams, name: String)(implicit p: Parameters) extends TLBusWrapper(params, name) {
   private val address_adjuster = params.replication.map { r => LazyModule(new AddressAdjuster(r, params.forceLocal)) }
   private val viewNode = TLIdentityNode()
-  val inwardNode: TLInwardNode = address_adjuster.map(_.node :*=* TLFIFOFixer(params.policy)).getOrElse(viewNode)
-  def outwardNode: TLOutwardNode = address_adjuster.map(TLFIFOFixer(params.policy) :*=* _.node).getOrElse(viewNode)
-  def busView: TLEdge = address_adjuster.map(_.node).getOrElse(viewNode).edges.in.head
+  val inwardNode: TLInwardNode = address_adjuster.map(_.node :*=* TLFIFOFixer(params.policy) :*=* viewNode).getOrElse(viewNode)
+  def outwardNode: TLOutwardNode = address_adjuster.map(_.node).getOrElse(viewNode)
+  def busView: TLEdge = viewNode.edges.in.head
   val prefixNode = address_adjuster.map(_.prefix)
   val builtInDevices = BuiltInDevices.none
 }

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -355,7 +355,8 @@ case class AddressAdjusterWrapperParams(
   blockBytes: Int,
   beatBytes: Int,
   replication: Option[ReplicatedRegion],
-  forceLocal: Seq[AddressSet] = Nil
+  forceLocal: Seq[AddressSet] = Nil,
+  policy: TLFIFOFixer.Policy = TLFIFOFixer.allVolatile
 )
   extends HasTLBusParams
   with TLBusWrapperInstantiationLike
@@ -372,10 +373,9 @@ case class AddressAdjusterWrapperParams(
 class AddressAdjusterWrapper(params: AddressAdjusterWrapperParams, name: String)(implicit p: Parameters) extends TLBusWrapper(params, name) {
   private val address_adjuster = params.replication.map { r => LazyModule(new AddressAdjuster(r, params.forceLocal)) }
   private val viewNode = TLIdentityNode()
-  private val node = address_adjuster.map(_.node :=* TLFIFOFixer(TLFIFOFixer.allVolatile) :=* viewNode).getOrElse(viewNode)
-  val inwardNode: TLInwardNode = node
-  val outwardNode: TLOutwardNode = node
-  def busView: TLEdge = viewNode.edges.in.head
+  val inwardNode: TLInwardNode = address_adjuster.map(_.node :*=* TLFIFOFixer(params.policy)).getOrElse(viewNode)
+  def outwardNode: TLOutwardNode = address_adjuster.map(TLFIFOFixer(params.policy) :*=* _.node).getOrElse(viewNode)
+  def busView: TLEdge = address_adjuster.map(_.node).getOrElse(viewNode).edges.in.head
   val prefixNode = address_adjuster.map(_.prefix)
   val builtInDevices = BuiltInDevices.none
 }

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -62,6 +62,7 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
   def inwardNode: TLInwardNode
   def outwardNode: TLOutwardNode
   def busView: TLEdge
+  val prefixNode: Option[BundleBridgeSink[UInt]]
   def unifyManagers: List[TLManagerParameters] = ManagerUnification(busView.manager.managers)
   def crossOutHelper = this.crossOut(outwardNode)(ValName("bus_xing"))
   def crossInHelper = this.crossIn(inwardNode)(ValName("bus_xing"))
@@ -401,5 +402,6 @@ class TLJBarWrapper(params: TLJBarWrapperParams, name: String)(implicit p: Param
   val inwardNode: TLInwardNode = jbar.node
   val outwardNode: TLOutwardNode = jbar.node
   def busView: TLEdge = jbar.node.edges.in.head
+  val prefixNode = None
   val builtInDevices = BuiltInDevices.none
 }

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -355,7 +355,7 @@ case class AddressAdjusterWrapperParams(
   blockBytes: Int,
   beatBytes: Int,
   replication: Option[ReplicatedRegion],
-  forceLocal: Seq[AddressSet]
+  forceLocal: Seq[AddressSet] = Nil
 )
   extends HasTLBusParams
   with TLBusWrapperInstantiationLike

--- a/src/main/scala/tilelink/Jbar.scala
+++ b/src/main/scala/tilelink/Jbar.scala
@@ -6,11 +6,11 @@ import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 
-class TLJbar(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) extends LazyModule
+class TLJbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) extends LazyModule
 {
-  val node = TLJunctionNode(clientRatio, managerRatio,
+  val node : TLJunctionNode = TLJunctionNode(
     clientFn  = { seq =>
-      Seq.fill(managerRatio)(seq(0).v1copy(
+      Seq.fill(node.dRatio)(seq(0).v1copy(
         minLatency = seq.map(_.minLatency).min,
         clients = (TLXbar.mapInputIds(seq) zip seq) flatMap { case (range, port) =>
           port.clients map { client => client.v1copy(
@@ -21,7 +21,7 @@ class TLJbar(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLA
     },
     managerFn = { seq =>
       val fifoIdFactory = TLXbar.relabeler()
-      Seq.fill(clientRatio)(seq(0).v1copy(
+      Seq.fill(node.uRatio)(seq(0).v1copy(
         minLatency = seq.map(_.minLatency).min,
         endSinkId = TLXbar.mapOutputIds(seq).map(_.end).max,
         managers = seq.flatMap { port =>
@@ -43,8 +43,8 @@ class TLJbar(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLA
 
 object TLJbar
 {
-  def apply(clientRatio: Int, managerRatio: Int, policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) = {
-    val jbar = LazyModule(new TLJbar(clientRatio, managerRatio, policy))
+  def apply(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) = {
+    val jbar = LazyModule(new TLJbar(policy))
     jbar.node
   }
 }
@@ -53,7 +53,7 @@ object TLJbar
 import freechips.rocketchip.unittest._
 
 class TLJbarTestImp(nClients: Int, nManagers: Int, txns: Int)(implicit p: Parameters) extends LazyModule {
-  val jbar = LazyModule(new TLJbar(nClients, 1))
+  val jbar = LazyModule(new TLJbar)
 
   val fuzzers = Seq.fill(nClients) {
     val fuzzer = LazyModule(new TLFuzzer(txns))

--- a/src/main/scala/tilelink/Jbar.scala
+++ b/src/main/scala/tilelink/Jbar.scala
@@ -36,7 +36,6 @@ class TLJbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
     })
 
   lazy val module = new LazyModuleImp(this) {
-    println(s"JBar info: ${node.in.size}/${clientRatio} vs ${node.out.size}/${managerRatio}")
     node.inoutGrouped.foreach { case (in, out) => TLXbar.circuit(policy, in, out) }
   }
 }

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -44,12 +44,10 @@ case class TLAdapterNode(
   extends AdapterNode(TLImp)(clientFn, managerFn) with TLFormatNode
 
 case class TLJunctionNode(
-  clientRatio:  Int,
-  managerRatio: Int,
   clientFn:     Seq[TLMasterPortParameters] => Seq[TLMasterPortParameters],
   managerFn:    Seq[TLSlavePortParameters]  => Seq[TLSlavePortParameters])(
   implicit valName: ValName)
-  extends JunctionNode(TLImp)(clientRatio, managerRatio, clientFn, managerFn) with TLFormatNode
+  extends JunctionNode(TLImp)(clientFn, managerFn) with TLFormatNode
 
 case class TLIdentityNode()(implicit valName: ValName) extends IdentityNode(TLImp)() with TLFormatNode
 

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -1076,11 +1076,15 @@ object TLBundleParameters
 }
 
 case class TLEdgeParameters(
-  client:  TLClientPortParameters,
-  manager: TLManagerPortParameters,
+  master: TLMasterPortParameters,
+  slave:  TLSlavePortParameters,
   params:  Parameters,
   sourceInfo: SourceInfo) extends FormatEdge
 {
+  // legacy names:
+  def manager = slave
+  def client = master
+
   val maxTransfer = max(client.maxTransfer, manager.maxTransfer)
   val maxLgSize = log2Ceil(maxTransfer)
 

--- a/src/main/scala/tilelink/RegionReplication.scala
+++ b/src/main/scala/tilelink/RegionReplication.scala
@@ -6,46 +6,56 @@ import chisel3._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 
-case object MultiChipMaskKey extends Field[BigInt](0)
+/* Address inside the 'local' space are replicated to fill the 'remote' space.
+ */
+case class ReplicatedRegion(
+  local:  AddressSet,
+  region: AddressSet)
+{
+  require (region.contains(local))
+  val replicationMask = region.mask & ~local.mask
+  require ((local.base & replicationMask) == 0, s"Local region ${local} not aligned within ${region}")
+
+  def isLegalPrefix(prefix: UInt): Bool = ~(~prefix | replicationMask.U) === 0.U
+}
 
 trait HasRegionReplicatorParams {
-  val replicatorMask: BigInt
+  def replication: Option[ReplicatedRegion]
 }
 
 // Replicate all devices below this adapter that are inside replicationRegion to multiple addreses based on mask.
 // If a device was at 0x4000-0x4fff and mask=0x10000, it will now be at 0x04000-0x04fff and 0x14000-0x14fff.
-class RegionReplicator(mask: BigInt = 0, region: Option[AddressSet] = Some(AddressSet.everything))(implicit p: Parameters) extends LazyModule {
-  def ids = AddressSet.enumerateMask(mask)
-
+class RegionReplicator(val params: ReplicatedRegion)(implicit p: Parameters) extends LazyModule {
   val node = TLAdapterNode(
     clientFn  = { cp => cp },
     managerFn = { mp => mp.v1copy(managers = mp.managers.map { m =>
-      m.v1copy(address = m.address.flatMap { a =>
-        if (region.map(_.contains(a)).getOrElse(false)) { ids.map { id => AddressSet(a.base | id, a.mask) } }
-        else { Seq(a) }
+      m.v1copy(address = m.address.map { a =>
+        if (params.region.contains(a)) { a.widen(params.replicationMask) } else { a }
       })
     })}
   )
+
+  val prefix = BundleBridgeSink[UInt]()
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out <> in
 
-      val addr = in.a.bits.address
-      val contained = region.foldLeft(false.B)(_ || _.contains(addr))
-      out.a.bits.address := Mux(contained, ~(~addr | mask.U), addr)
+      // Which address within the mask routes to local devices?
+      val local_prefix = RegNext(prefix.bundle)
+      assert (params.isLegalPrefix(local_prefix))
 
-      // We can't support probes; we don't have the required information
-      edgeOut.manager.managers.foreach { m =>
-        require (m.regionType < RegionType.TRACKED, s"${m.name} has regionType ${m.regionType}, which requires Probe support a RegionReplicator cannot provide")
-      }
+      val a_addr = in.a.bits.address
+      val a_contained = params.region.contains(a_addr)
+      out.a.bits.address := Mux(a_contained, ~(~a_addr | params.replicationMask.U), a_addr)
+
+      val b_addr = out.b.bits.address
+      val b_contained = params.region.contains(b_addr)
+      in.b.bits.address := Mux(b_contained, b_addr | (local_prefix & params.replicationMask.U), b_addr)
+
+      val c_addr = in.c.bits.address
+      val c_contained = params.region.contains(c_addr)
+      out.c.bits.address := Mux(c_contained, ~(~c_addr | params.replicationMask.U), c_addr)
     }
-  }
-}
-
-object RegionReplicator {
-  def apply(mask: BigInt = 0, region: Option[AddressSet] = Some(AddressSet.everything))(implicit p: Parameters): TLNode = {
-    val replicator = LazyModule(new RegionReplicator(mask, region))
-    replicator.node
   }
 }


### PR DESCRIPTION
JunctionNodes now support configurable up/down connection ratio.
RegionReplicator and AddressAdjuster now takes a region+local AddressSet instead of a mask (MultiChipMaskKey was removed).
AddressAdjuster can now optionally leave off the 'remote' side of the connection.

**Type of change**: other enhancement
**Impact**: API modification
**Development Phase**: implementation

**Release Notes**
AddressAdjuster and RegionReplicator now work on prefixes (not chip id)