### PR TITLE
RocketTile: do not distort placement when hartid is not constant

### DIFF
--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -156,9 +156,9 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
   outer.traceSourceNode.bundle <> core.io.trace
   core.io.traceStall := outer.traceAuxSinkNode.bundle.stall
   outer.bpwatchSourceNode.bundle <> core.io.bpwatch
-  core.io.hartid := constants.hartid
-  outer.dcache.module.io.hartid := constants.hartid
-  outer.frontend.module.io.hartid := constants.hartid
+  core.io.hartid := RegNext(constants.hartid)
+  outer.dcache.module.io.hartid := RegNext(constants.hartid)
+  outer.frontend.module.io.hartid := RegNext(constants.hartid)
   outer.frontend.module.io.reset_vector := constants.reset_vector
 
   // Connect the core pipeline to other intra-tile modules


### PR DESCRIPTION
When hartid is not a constant, driving it to the I$ D$ and CSR file directly from a Tile IO distorts placement of the core. These registers alleviate that.

However, when the hartid IS a constant, these registers are unneeded. I believe chisel will eliminate the registers via constant propagation.

**Type of change**: other enhancement
**Impact**: no functional change
**Development Phase**: implementation

**Release Notes**
Pipeline tile hartid input.