### PR TITLE
Use static priority arbitration in PTW

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -102,7 +102,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   val s_ready :: s_req :: s_wait1 :: s_dummy1 :: s_wait2 :: s_wait3 :: s_dummy2 :: s_fragment_superpage :: Nil = Enum(UInt(), 8)
   val state = Reg(init=s_ready)
 
-  val arb = Module(new RRArbiter(Valid(new PTWReq), n))
+  val arb = Module(new Arbiter(Valid(new PTWReq), n))
   arb.io.in <> io.requestor.map(_.req)
   arb.io.out.ready := state === s_ready
 

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -88,7 +88,7 @@ trait HasLazyRoCCModule extends CanHavePTWModule
     val respArb = Module(new RRArbiter(new RoCCResponse()(outer.p), outer.roccs.size))
     val cmdRouter = Module(new RoccCommandRouter(outer.roccs.map(_.opcodes))(outer.p))
     outer.roccs.zipWithIndex.foreach { case (rocc, i) =>
-      ptwPorts ++= rocc.module.io.ptw
+      rocc.module.io.ptw ++=: ptwPorts
       rocc.module.io.cmd <> cmdRouter.io.out(i)
       val dcIF = Module(new SimpleHellaCacheIF()(outer.p))
       dcIF.io.requestor <> rocc.module.io.mem


### PR DESCRIPTION
Because of pipeline replays, round-robin arbitration isn't actually fair.
Using static prioritization is always OK, since RoCC instructions are
older than instructions using the D$, which are older than instructions
being fetched from the I$.
