### PR TITLE
Add definitions for ratified version of RISC-V Processor Trace spec

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -173,6 +173,7 @@ class TracedInstruction(implicit p: Parameters) extends CoreBundle {
 }
 
 class TraceAux extends Bundle {
+  val enable = Bool()
   val stall = Bool()
 }
 

--- a/src/main/scala/util/TraceCoreInterface.scala
+++ b/src/main/scala/util/TraceCoreInterface.scala
@@ -1,0 +1,51 @@
+// See LICENSE.Berkeley for license details.
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.ChiselEnum
+import freechips.rocketchip.tile._
+
+// Definitions for Trace core Interface defined in RISC-V Processor Trace Specification V1.0
+object TraceItype extends ChiselEnum {
+  val ITNothing   = Value(0.U)
+  val ITException = Value(1.U)
+  val ITInterrupt = Value(2.U)
+  val ITExcReturn = Value(3.U)
+  val ITBrNTaken  = Value(4.U)
+  val ITBrTaken   = Value(5.U)
+  val ITReserved6 = Value(6.U)
+  val ITReserved7 = Value(7.U)
+  val ITUnCall    = Value(8.U)
+  val ITInCall    = Value(9.U)
+  val ITUnTail    = Value(10.U)
+  val ITInTail    = Value(11.U)
+  val ITCoSwap    = Value(12.U)
+  val ITReturn    = Value(13.U)
+  val ITUnJump    = Value(14.U)
+  val ITInJump    = Value(15.U)
+}
+
+class TraceCoreParams (
+  val nGroups: Int = 1,
+  val iretireWidth: Int = 1,
+  val xlen: Int = 32,
+  val iaddrWidth: Int = 32
+)
+
+class TraceCoreGroup (val params: TraceCoreParams) extends Bundle {
+  val iretire = UInt(params.iretireWidth.W)
+  val iaddr = UInt(params.iaddrWidth.W)
+  val itype = TraceItype()
+  val ilastsize = UInt(1.W)
+}
+
+class TraceCoreInterface (val params: TraceCoreParams) extends Bundle {
+  val group = Vec(params.nGroups, new TraceCoreGroup(params))
+  val priv = UInt(4.W)
+  val tval = UInt(params.xlen.W)
+  val cause = UInt(params.xlen.W)
+}
+


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
[The RISC-V Processor Trace Specification](https://github.com/riscv/riscv-trace-spec/blob/master/riscv-trace-spec.pdf) has recently been ratified.  The definition of the core-to-trace encoder interface has been changed from the legacy definition currently implemented in rocket-chip.  This PR adds a second BundleBridge trace interface that conforms to the new version of the spec that will allow processors that conform to that spec to connect their trace ports to encoders.

The TraceAux bundle is for sideband signals that are useful but not in the spec.  Previously, there has been a `stall` request signal and this PR adds a new `enable` signal to TraceAux so a trace port client can enable the trace logic in a core only when it is being used (as a power saving).  In case there is more than one trace client, the `stall` and `enable` signals are a logical OR of these signals from all the clients.

Finally, the definition of the bpwatch bundle has been parameterized to allow an implementation to replace the default definition, if necessary, by overriding the `getBpwatchParams` function in BaseTile.
