### PR TITLE
Chisel compile warning: Chisel3 package import

### DIFF
--- a/src/main/scala/amba/apb/Monitor.scala
+++ b/src/main/scala/amba/apb/Monitor.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.amba.apb
 
 import chisel3._
-import chisel3.core.Reset
 import freechips.rocketchip.config.Parameters
 
 case class APBMonitorArgs(edge: APBEdgeParameters)

--- a/src/main/scala/amba/axi4/Monitor.scala
+++ b/src/main/scala/amba/axi4/Monitor.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.core.Reset
 import freechips.rocketchip.config.Parameters
 
 case class AXI4MonitorArgs(edge: AXI4EdgeParameters)


### PR DESCRIPTION
**Related issue**: follow-up to #2357
**Type of change**: paying off technical debt
**Impact**: no functional change
**Development Phase**: implementation

**Release Notes**
fix these Chisel compile warnings:
```
[warn] /rocket-chip/src/main/scala/amba/apb/Monitor.scala:17:67: type Reset in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]   def legalize(bundle: APBBundle, edge: APBEdgeParameters, reset: Reset): Unit
[warn]                                                                   ^
[warn] /rocket-chip/src/main/scala/amba/axi4/Monitor.scala:17:69: type Reset in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]   def legalize(bundle: AXI4Bundle, edge: AXI4EdgeParameters, reset: Reset): Unit
[warn]                                                                     ^
```