### PR TITLE
Updates to object model to include right protocol information

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -124,12 +124,16 @@ case class SystemPort(
   _types: Seq[String] = Seq("SystemPort", "OutboundPort", "OMPort", "OMDevice", "OMComponent", "OMCompoundType")) extends OutboundPort
 
 object OMPortMaker {
-  val protocolSpecifications = Map[ProtocolType, String](
-    AHBProtocol -> "AMBA 3 AHB-Lite Protocol",
-    AXI4Protocol -> "AMBA 3 AXI4-Lite Protocol",
-    APBProtocol -> "AMBA 3 APB Protocol",
-    TLProtocol -> "TileLink specification"
-  )
+  val protocolSpecifications = Map[(ProtocolType, SubProtocolType), String](
+   (AHBProtocol, AHBLiteSubProtocol)   -> "AHB Lite Protocol",
+   (AHBProtocol, AHBFullSubProtocol)   -> "AHB Full Protocol",
+   (AXI4Protocol, AXI4SubProtocol)     -> "AXI Protocol",
+   (AXI4Protocol, AXI4LiteSubProtocol) -> "AXI Lite Protocol",
+   (APBProtocol, APBSubProtocol)       -> "APB Protocol",
+   (TLProtocol, TL_UHSubProtocol)      -> "TileLink Protocol",
+   (TLProtocol, TL_ULSubProtocol)      -> "TileLink Protocol",
+   (TLProtocol, TL_CSubProtocol)       -> "TileLink Protocol"
+ )
 
   val protocolSpecificationVersions = Map[ProtocolType, String](
     AHBProtocol -> "1.0",

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -136,13 +136,13 @@ object OMPortMaker {
  )
 
   val protocolSpecificationVersions = Map[ProtocolType, String](
-    AHBProtocol -> "1.0",
-    AXI4Protocol -> "1.0",
+    AHBProtocol -> "3",
+    AXI4Protocol -> "4",
     APBProtocol -> "1.0",
     TLProtocol -> "1.8"
   )
 
-  def specVersion(protocol: ProtocolType, version: String): Option[OMSpecification] = Some(OMSpecification(protocolSpecifications(protocol), version))
+  def specVersion(protocol: ProtocolType, subProtocol: SubProtocolType, version: String): Option[OMSpecification] = Some(OMSpecification(protocolSpecifications(protocol, subProtocol), version))
 
   val portNames = Map[PortType, String](
     SystemPortType -> "System Port",
@@ -162,14 +162,14 @@ object OMPortMaker {
     val documentationName = portNames(portType)
 
     val omProtocol = (protocol, subProtocol) match {
-      case (AXI4Protocol, AXI4SubProtocol) => AXI4(specification = specVersion(protocol, version))
-      case (AXI4Protocol, AXI4LiteSubProtocol) => AXI4_Lite(specification = specVersion(protocol, version))
-      case (AHBProtocol, AHBLiteSubProtocol) => AHB_Lite(specification = specVersion(protocol, version))
-      case (AHBProtocol, AHBFullSubProtocol) => AHB(specification = specVersion(protocol, version))
-      case (APBProtocol, APBSubProtocol) => APB(specification = specVersion(protocol, version))
-      case (TLProtocol, TL_UHSubProtocol) => TL_UH(specification = specVersion(protocol, version))
-      case (TLProtocol, TL_ULSubProtocol) => TL_UL(specification = specVersion(protocol, version))
-      case (TLProtocol, TL_CSubProtocol) => TL_C(specification = specVersion(protocol, version))
+      case (AXI4Protocol, AXI4SubProtocol) => AXI4(specification = specVersion(protocol, subProtocol, version))
+      case (AXI4Protocol, AXI4LiteSubProtocol) => AXI4_Lite(specification = specVersion(protocol, subProtocol, version))
+      case (AHBProtocol, AHBLiteSubProtocol) => AHB_Lite(specification = specVersion(protocol, subProtocol, version))
+      case (AHBProtocol, AHBFullSubProtocol) => AHB(specification = specVersion(protocol, subProtocol, version))
+      case (APBProtocol, APBSubProtocol) => APB(specification = specVersion(protocol, subProtocol, version))
+      case (TLProtocol, TL_UHSubProtocol) => TL_UH(specification = specVersion(protocol, subProtocol, version))
+      case (TLProtocol, TL_ULSubProtocol) => TL_UL(specification = specVersion(protocol, subProtocol, version))
+      case (TLProtocol, TL_CSubProtocol) => TL_C(specification = specVersion(protocol, subProtocol, version))
       case _ => throw new IllegalArgumentException(s"protocol $protocol, subProtocol $subProtocol")
     }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--

-->
An example representation of a port with AXI protocol:

```
      "signalNamePrefix" : "axi4_mem_port",
      "width" : 32,
      "protocol" : {
        "specification" : {
          "name" : "AXI Protocol",
          "version" : "4",
          "_types" : [ "OMSpecification" ]
        },
        "_types" : [ "AXI", "AMBA", "OMProtocol" ]
      },
```
An example representation of a port with AHB-Lite protocol:

```
      "signalNamePrefix" : "ahb_sys_port",
      "width" : 32,
      "protocol" : {
        "specification" : {
          "name" : "AHB Lite Protocol",
          "version" : "3",
          "_types" : [ "OMSpecification" ]
        },
        "_types" : [ "AHB", "AMBA", "OMProtocol" ]
      },
```