### PR TITLE
Make the TLBroadcast and TLSourceShinker adapters pass through user bits

### DIFF
--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -16,13 +16,9 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
 
   val node = TLAdapterNode(
     clientFn  = { cp =>
-      cp.v1copy(
-        clients = Seq(TLMasterParameters.v1(
-          name     = "TLBroadcast",
-          sourceId = IdRange(0, 1 << log2Ceil(cp.endSourceId*4)))),
-        echoFields    = cp.echoFields,
-        requestFields = cp.requestFields,
-        responseKeys  = cp.responseKeys)
+      cp.v1copy(clients = Seq(TLMasterParameters.v1(
+        name     = "TLBroadcast",
+        sourceId = IdRange(0, 1 << log2Ceil(cp.endSourceId*4)))))
     },
     managerFn = { mp =>
       mp.v1copy(

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -18,7 +18,12 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
     sourceId = IdRange(0, maxInFlight))
   val node = TLAdapterNode(
     // We erase all client information since we crush the source Ids
-    clientFn  = { cp => TLMasterPortParameters.v1(clients = Seq(client.v1copy(requestFifo = cp.clients.exists(_.requestFifo)))) },
+    clientFn  = { cp => TLMasterPortParameters.v1(
+      clients = Seq(client.v1copy(requestFifo = cp.clients.exists(_.requestFifo))),
+      echoFields = cp.echoFields,
+      requestFields = cp.requestFields,
+      responseKeys = cp.responseKeys
+    )},
     managerFn = { mp => mp.v1copy(managers = mp.managers.map(m => m.v1copy(fifoId = if (maxInFlight==1) Some(0) else m.fifoId)))  })
 
   lazy val module = new LazyModuleImp(this) {


### PR DESCRIPTION
This change makes the `TLBroadcast` and `TLSourceShrinker` transparently pass through any user bits that are received from clients attached to them.