### PR TITLE
Drive AMBAProt bits from debug SBA

### DIFF
--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -4,6 +4,7 @@ package freechips.rocketchip.devices.debug.systembusaccess
 
 import chisel3._
 import chisel3.util._
+import freechips.rocketchip.amba._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
@@ -265,7 +266,9 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
 
   val cfg = p(DebugModuleKey).get
 
-  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1("debug")))))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(
+    clients = Seq(TLMasterParameters.v1("debug")),
+    requestFields = Seq(AMBAProtField()))))
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {
@@ -318,6 +321,16 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
     io.sbStateOut := sbState
     when(sbState === SBReadRequest.id.U) { tl.a.bits :=  gbits  }
     .otherwise                           { tl.a.bits := pfbits  }
+
+    tl.a.bits.user.lift(AMBAProt).foreach { x =>
+      x.bufferable := false.B
+      x.modifiable := false.B
+      x.readalloc  := false.B
+      x.writealloc := false.B
+      x.privileged := true.B
+      x.secure     := true.B
+      x.fetch      := false.B
+    }
 
     val respError = d.bits.denied || d.bits.corrupt
     io.respError := respError


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
AMBA adapters include PROT bits which indicate the characteristics of the transaction.  This PR adds drivers for these bits when the debug module initiates a transaction using SBA.

Privileged=1
Fetch=0
Secure=1
Modifiable=Bufferable=ReadAlloc=WriteAlloc=0
