### PR TITLE
Provide reset values for registers driving cease and wfi

### DIFF
--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -95,7 +95,7 @@ trait SourcesExternalNotifications { this: BaseTile =>
   def reportCease(could_cease: Option[Bool], quiescenceCycles: Int = 8) {
     def waitForQuiescence(cease: Bool): Bool = {
       // don't report cease until signal is stable for longer than any pipeline depth
-      val count = Reg(UInt(log2Ceil(quiescenceCycles + 1).W))
+      val count = RegInit(0.U(log2Ceil(quiescenceCycles + 1).W))
       val saturated = count >= quiescenceCycles.U
       when (!cease) { count := 0.U }
       when (cease && !saturated) { count := count + 1.U }
@@ -116,6 +116,6 @@ trait SourcesExternalNotifications { this: BaseTile =>
 
   def reportWFI(could_wfi: Option[Bool]) {
     val (wfi, _) = wfiNode.out(0)
-    wfi(0) := could_wfi.map(RegNext(_)).getOrElse(false.B)
+    wfi(0) := could_wfi.map(RegNext(_, init=false.B)).getOrElse(false.B)
   }
 }


### PR DESCRIPTION
Registers driving cease and wfi did not have reset values and could possibly be high for one cycle under reset.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
