### PR TITLE
.travis.yml: get rid of request for sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 git:
   submodules: false
 language: scala
-sudo: required
+sudo: false
 cache:
   apt: true
   directories:


### PR DESCRIPTION
Back at the end of 2017 apparently `sudo: required` gave you a bigger disk image, which we needed. But we're seeing a lot of Travis instability now so reverting this change to see if a) we still need that and b) whether it resolves some of the stability issues

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

For CI, don't request sudo (which gives a larger disk image) from Travis