### PR TITLE
Add support for emitting string-valued plusargs and plusargs with no default

### DIFF
--- a/src/main/scala/util/PlusArg.scala
+++ b/src/main/scala/util/PlusArg.scala
@@ -50,7 +50,7 @@ object PlusArg
     * pass.
     */
   def apply(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32): UInt = {
-    PlusArgArtefacts.append(name, Some(default), docstring, "INT")
+    PlusArgArtefacts.append(name, Some(default), docstring)
     Module(new plusarg_reader(name + "=%d", default, docstring, width)).io.out
   }
 
@@ -59,7 +59,7 @@ object PlusArg
     * Default 0 will never assert.
     */
   def timeout(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32)(count: UInt) {
-    PlusArgArtefacts.append(name, Some(default), docstring, "INT")
+    PlusArgArtefacts.append(name, Some(default), docstring)
     Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count := count
   }
 }
@@ -73,7 +73,7 @@ object PlusArgArtefacts {
     "Rocket Chip 2020.05"
   )
   def append(name: String, default: BigInt, docstring: String): Unit =
-    append(name, Some(default), docstring, "INT")
+    append(name, Some(default), docstring)
 
   /** Add a new PlusArg
     *
@@ -83,7 +83,7 @@ object PlusArgArtefacts {
     * @param docstring text to include in the help
     * @param doctype description of the Verilog type of the PlusArg value (e.g. STRING, INT)
     */
-  def append[A](name: String, default: Option[A], docstring: String, doctype: String): Unit =
+  def append[A](name: String, default: Option[A], docstring: String, doctype: String = "INT"): Unit =
     artefacts = artefacts ++ Map(name -> PlusArgContainer[A](default, docstring, doctype))
 
   /* From plus args, generate help text */

--- a/src/main/scala/util/PlusArg.scala
+++ b/src/main/scala/util/PlusArg.scala
@@ -50,7 +50,7 @@ object PlusArg
     * pass.
     */
   def apply(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32): UInt = {
-    PlusArgArtefacts.append(name, Some(default), docstring)
+    PlusArgArtefacts.append(name, Some(default), docstring, "INT")
     Module(new plusarg_reader(name + "=%d", default, docstring, width)).io.out
   }
 
@@ -59,7 +59,7 @@ object PlusArg
     * Default 0 will never assert.
     */
   def timeout(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32)(count: UInt) {
-    PlusArgArtefacts.append(name, Some(default), docstring)
+    PlusArgArtefacts.append(name, Some(default), docstring, "INT")
     Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count := count
   }
 }
@@ -73,7 +73,7 @@ object PlusArgArtefacts {
     "Rocket Chip 2020.05"
   )
   def append(name: String, default: BigInt, docstring: String): Unit =
-    append(name, Some(default), docstring)
+    append(name, Some(default), docstring, "INT")
 
   /** Add a new PlusArg
     *
@@ -83,7 +83,7 @@ object PlusArgArtefacts {
     * @param docstring text to include in the help
     * @param doctype description of the Verilog type of the PlusArg value (e.g. STRING, INT)
     */
-  def append[A](name: String, default: Option[A], docstring: String, doctype: String = "INT"): Unit =
+  def append[A](name: String, default: Option[A], docstring: String, doctype: String): Unit =
     artefacts = artefacts ++ Map(name -> PlusArgContainer[A](default, docstring, doctype))
 
   /* From plus args, generate help text */


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: API modification

**Development Phase**: implementation

I came across a case where I needed to add a plusarg in a BlackBoxed verilog module and found that I needed to use `PlusArgArtefacts.append` for verilator to correctly parse my plusarg. This worked fine, but to get the help text to make sense I needed to add some features. This does change the API for `PlusArgInfo`, but other function calls are backwards compatible.