### PR TITLE
Update Travis cache for Scala dependencies and SBT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ sudo: required
 cache:
   apt: true
   directories:
-    $HOME/.ivy2
+    $HOME/.cache/coursier
+    $HOME/.sbt
     regression/install
     emulator/verilator
 


### PR DESCRIPTION
As of SBT 1.3, the cache for dependencies changed. This updates it for dependencies as well as adds caching for SBT itself. Should save some time and help insulate CI against Maven Central being flakey.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
