### PR TITLE
cease glitch assertion should look at stable cease signal

### DIFF
--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -105,8 +105,8 @@ trait SourcesExternalNotifications { this: BaseTile =>
     cease(0) := could_cease.map{ c => 
       val cease = (waitForQuiescence(c))
       // Test-Only Code --
-      val prev_cease = RegNext(c, false.B)
-      assert(!(prev_cease & !c), "CEASE line can not glitch once raised") 
+      val prev_cease = RegNext(cease, false.B)
+      assert(!(prev_cease & !cease), "CEASE line can not glitch once raised") 
       cease
     }.getOrElse(false.B)
   }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
#2420 added an assertion to check for a glitchy cease, but the assertion was acting on the unstable cease signal and not the quiesced signal.

<!-- choose one -->
**Type of change**: bug report
<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
