### PR TITLE
Improve DecodeLogic runtime

### DIFF
--- a/src/main/scala/rocket/Decode.scala
+++ b/src/main/scala/rocket/Decode.scala
@@ -136,12 +136,18 @@ object Simplify
   def stringify(s: Seq[Term], bits: Int) = s.map(t => (0 until bits).map(i => if ((t.mask & (1 << i)) != 0) "x" else ((t.value >> i) & 1).toString).reduceLeft(_+_).reverse).reduceLeft(_+" + "+_)
 
   def apply(minterms: Seq[Term], dontcares: Seq[Term], bits: Int) = {
-    val prime = getPrimeImplicants(minterms ++ dontcares, bits)
-    minterms.foreach(t => assert(prime.exists(_.covers(t))))
-    val (eprime, prime2, uncovered) = getEssentialPrimeImplicants(prime, minterms)
-    val cover = eprime ++ getCover(prime2, uncovered, bits)
-    minterms.foreach(t => assert(cover.exists(_.covers(t)))) // sanity check
-    cover
+    if (dontcares.isEmpty) {
+      // As an elaboration performance optimization, don't be too clever if
+      // there are no don't-cares; synthesis can figure it out.
+      minterms
+    } else {
+      val prime = getPrimeImplicants(minterms ++ dontcares, bits)
+      minterms.foreach(t => assert(prime.exists(_.covers(t))))
+      val (eprime, prime2, uncovered) = getEssentialPrimeImplicants(prime, minterms)
+      val cover = eprime ++ getCover(prime2, uncovered, bits)
+      minterms.foreach(t => assert(cover.exists(_.covers(t)))) // sanity check
+      cover
+    }
   }
 }
 


### PR DESCRIPTION
For cases where none of the clauses (nor the default) is X, skip the
optimization problem altogether.

It turns out this is both a common and problematic case.  For a design I'm
working on, it reduced the runtime to about 10s from [whenver I Ctrl-C'd the
thing after several minutes].

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change