### PR TITLE
public events field of EventSet and eventSets field of SuperscalarEve…

### DIFF
--- a/src/main/scala/rocket/Events.scala
+++ b/src/main/scala/rocket/Events.scala
@@ -9,8 +9,11 @@ import freechips.rocketchip.util.property._
 
 class EventSet(gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bool)]) {
   def size = events.size
-  val hits = events.map(_._2()).asUInt
-  def check(mask: UInt) = gate(mask, hits)
+  val hits = Wire(Vec(size, Bool()))
+  def check(mask: UInt) = {
+    hits := events.map(_._2())
+    gate(mask, hits.asUInt)
+  }
   def dump() {
     for (((name, _), i) <- events.zipWithIndex)
       when (check(1.U << i)) { printf(s"Event $name\n") }

--- a/src/main/scala/rocket/Events.scala
+++ b/src/main/scala/rocket/Events.scala
@@ -7,9 +7,9 @@ import Chisel._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
 
-class EventSet(gate: (UInt, UInt) => Bool, events: Seq[(String, () => Bool)]) {
+class EventSet(gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bool)]) {
   def size = events.size
-  def hits = events.map(_._2()).asUInt
+  val hits = events.map(_._2()).asUInt
   def check(mask: UInt) = gate(mask, hits)
   def dump() {
     for (((name, _), i) <- events.zipWithIndex)
@@ -49,7 +49,7 @@ class EventSets(val eventSets: Seq[EventSet]) {
   private def eventSetIdBits = 8
 }
 
-class SuperscalarEventSets(eventSets: Seq[(Seq[EventSet], (UInt, UInt) => UInt)]) {
+class SuperscalarEventSets(val eventSets: Seq[(Seq[EventSet], (UInt, UInt) => UInt)]) {
   def evaluate(eventSel: UInt): UInt = {
     val (set, mask) = decode(eventSel)
     val sets = for ((sets, reducer) <- eventSets)


### PR DESCRIPTION
public events field of EventSet and eventSets field of SuperscalarEventSets
and apply hits of EventSet when EventSet is constructed,
so events in EventSet and SuperscalarEventSets could be monitor

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

** Purpose **
I am going to write a monitor for eventSets,
And I need to apply EventSet.hits whenever EventSet is instantiate because if I call EventSet.hits as a function in the monitor out of the scope it is instantiated, event lists in EventSet.events are not available.