### PR TITLE
Fragmenter: when extending denied, we must also extend corrupt

### DIFF
--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -228,7 +228,8 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
           // Take denied only from the first beat and hold that value
           val d_denied = out.d.bits.denied holdUnless dFirst
           when (dHasData) {
-            in.d.bits.denied := d_denied
+            in.d.bits.denied  := d_denied
+            in.d.bits.corrupt := d_denied || out.d.bits.corrupt
           }
         }
 


### PR DESCRIPTION
The TL spec requires denied messages with data to be also corrupt.

In cases where the Fragmenter extends the denied signal, it must also
ensure that corrupt is also raised.

**Type of change**: bug report
**Impact**: no functional change
**Development Phase**:  implementation
