### PR TITLE
AddressAdjuster patches

### DIFF
--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -258,8 +258,8 @@ class AddressAdjuster(
       parent.a.ready := Mux(a_local, local.a.ready, remote.a.ready) && !a_stall
       local .a.valid := parent.a.valid &&  a_local && !a_stall
       remote.a.valid := parent.a.valid && !a_local && !a_stall
-      local .a.bits  := parent.a.bits
-      remote.a.bits  := parent.a.bits
+      local .a.bits  :<= parent.a.bits
+      remote.a.bits  :<= parent.a.bits
 
       // Count beats
       val a_first = parentEdge.first(parent.a)
@@ -321,11 +321,11 @@ class AddressAdjuster(
       val local_d  = Wire(chiselTypeOf(parent.d)) // type-cast, because 'sink' width differs
       local.d.ready := local_d.ready
       local_d.valid := local.d.valid
-      local_d.bits  := local.d.bits
+      local_d.bits  :<= local.d.bits
       val remote_d = Wire(chiselTypeOf(parent.d))
       remote.d.ready := remote_d.ready
       remote_d.valid := remote.d.valid
-      remote_d.bits := remote.d.bits
+      remote_d.bits :<= remote.d.bits
       remote_d.bits.sink := remote.d.bits.sink +& sink_threshold
       TLArbiter.robin(parentEdge, parent.d, local_d, remote_d)
 
@@ -340,16 +340,16 @@ class AddressAdjuster(
         parent.c.ready := Mux(c_local, local.c.ready, remote.c.ready)
         local .c.valid := parent.c.valid &&  c_local
         remote.c.valid := parent.c.valid && !c_local
-        local .c.bits  := parent.c.bits
-        remote.c.bits  := parent.c.bits
+        local .c.bits  :<= parent.c.bits
+        remote.c.bits  :<= parent.c.bits
 
         // Route E by sink
         val e_local = parent.e.bits.sink < sink_threshold
         parent.e.ready := Mux(e_local, local.e.ready, remote.e.ready)
         local .e.valid := parent.e.valid &&  e_local
         remote.e.valid := parent.e.valid && !e_local
-        local .e.bits  := parent.e.bits
-        remote.e.bits  := parent.e.bits
+        local .e.bits  :<= parent.e.bits
+        remote.e.bits  :<= parent.e.bits
         remote.e.bits.sink := parent.e.bits.sink - sink_threshold
       }
     }

--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -28,8 +28,8 @@ class AddressAdjuster(
     region.flatMap { _.subtract(defaultRegion) }
   }
 
-  // forceLocal better only go one place (the low index)
-  forceLocal.foreach { as => require((as.max & mask) == 0) }
+  localBaseAddressDefault.foreach { x => require((x & ~mask) == 0, s"localBaseAddressDefault $localBaseAddressDefault was not aligned to region") }
+  forceLocal.foreach { as => require((as.max & mask) == 0, s"forceLocal $forceLocal must be contained within the lowest index region") }
 
   // Address Adjustment requires many things about the downstream devices, captured here as helper functions:
 

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -357,7 +357,9 @@ case class AddressAdjusterWrapperParams(
   beatBytes: Int,
   replication: Option[ReplicatedRegion],
   forceLocal: Seq[AddressSet] = Nil,
-  localBaseAddressDefault: Option[BigInt] = None
+  localBaseAddressDefault: Option[BigInt] = None,
+  policy: TLFIFOFixer.Policy = TLFIFOFixer.allVolatile,
+  ordered: Boolean = true
 )
   extends HasTLBusParams
   with TLBusWrapperInstantiationLike
@@ -372,9 +374,9 @@ case class AddressAdjusterWrapperParams(
 }
 
 class AddressAdjusterWrapper(params: AddressAdjusterWrapperParams, name: String)(implicit p: Parameters) extends TLBusWrapper(params, name) {
-  private val address_adjuster = params.replication.map { r => LazyModule(new AddressAdjuster(r, params.forceLocal, params.localBaseAddressDefault)) }
+  private val address_adjuster = params.replication.map { r => LazyModule(new AddressAdjuster(r, params.forceLocal, params.localBaseAddressDefault, params.ordered)) }
   private val viewNode = TLIdentityNode()
-  val inwardNode: TLInwardNode = address_adjuster.map(_.node :*=* viewNode).getOrElse(viewNode)
+  val inwardNode: TLInwardNode = address_adjuster.map(_.node :*=* TLFIFOFixer(params.policy) :*=* viewNode).getOrElse(viewNode)
   def outwardNode: TLOutwardNode = address_adjuster.map(_.node).getOrElse(viewNode)
   def busView: TLEdge = viewNode.edges.in.head
   val prefixNode = address_adjuster.map(_.prefix)

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -356,7 +356,8 @@ case class AddressAdjusterWrapperParams(
   blockBytes: Int,
   beatBytes: Int,
   replication: Option[ReplicatedRegion],
-  forceLocal: Seq[AddressSet] = Nil
+  forceLocal: Seq[AddressSet] = Nil,
+  localBaseAddressDefault: Option[BigInt] = None
 )
   extends HasTLBusParams
   with TLBusWrapperInstantiationLike
@@ -371,7 +372,7 @@ case class AddressAdjusterWrapperParams(
 }
 
 class AddressAdjusterWrapper(params: AddressAdjusterWrapperParams, name: String)(implicit p: Parameters) extends TLBusWrapper(params, name) {
-  private val address_adjuster = params.replication.map { r => LazyModule(new AddressAdjuster(r, params.forceLocal)) }
+  private val address_adjuster = params.replication.map { r => LazyModule(new AddressAdjuster(r, params.forceLocal, params.localBaseAddressDefault)) }
   private val viewNode = TLIdentityNode()
   val inwardNode: TLInwardNode = address_adjuster.map(_.node :*=* viewNode).getOrElse(viewNode)
   def outwardNode: TLOutwardNode = address_adjuster.map(_.node).getOrElse(viewNode)


### PR DESCRIPTION
Porting some old enhancements to the AddressAdjuster and one bugfix:
- Allow DTS to report a default relocation amount that isn't the 0th region
- Allow the two legs to have divergent user bits with :<=