### PR TITLE
Added brackets for tupled args

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -142,7 +142,7 @@ object OMPortMaker {
     TLProtocol -> "1.8"
   )
 
-  def specVersion(protocol: ProtocolType, subProtocol: SubProtocolType, version: String): Option[OMSpecification] = Some(OMSpecification(protocolSpecifications(protocol, subProtocol), version))
+  def specVersion(protocol: ProtocolType, subProtocol: SubProtocolType, version: String): Option[OMSpecification] = Some(OMSpecification(protocolSpecifications((protocol, subProtocol)), version))
 
   val portNames = Map[PortType, String](
     SystemPortType -> "System Port",

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -355,7 +355,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     when (s2_valid && s2_req.no_alloc) { any_no_alloc_in_flight := true }
     val s1_need_check = any_no_alloc_in_flight || s2_valid && s2_req.no_alloc
 
-    val concerns = (uncachedInFlight zip uncachedReqs) :+ (s2_valid && s2_req.no_alloc, s2_req)
+    val concerns = (uncachedInFlight zip uncachedReqs) :+ ((s2_valid && s2_req.no_alloc, s2_req))
     val s1_uncached_hits = concerns.map { c =>
       val concern_wmask = new StoreGen(c._2.size, c._2.addr, UInt(0), wordBytes).mask
       val addr_match = (c._2.addr ^ s1_paddr)(pgIdxBits+pgLevelBits-1, wordBytes.log2) === 0

--- a/src/main/scala/tile/BusErrorUnit.scala
+++ b/src/main/scala/tile/BusErrorUnit.scala
@@ -52,7 +52,7 @@ class BusErrorUnit[T <: BusErrors](t: => T, params: BusErrorUnitParams, logicalT
 
     val sources_and_desc = io.errors.toErrorList
     val sources = sources_and_desc.map(_.map(_._1))
-    val sources_enums = sources_and_desc.zipWithIndex.flatMap{case (s, i) => s.map {e => (BigInt(i) -> (e._2, e._3))}}
+    val sources_enums = sources_and_desc.zipWithIndex.flatMap{case (s, i) => s.map {e => (BigInt(i) -> ((e._2, e._3)))}}
 
     val causeWidth = log2Ceil(sources.lastIndexWhere(_.nonEmpty) + 1)
     val (cause, cause_desc) = DescribedReg(UInt(causeWidth.W),

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -306,7 +306,7 @@ trait HasFPUParameters {
           val isbox = isBox(x, t)
           prev.map(p => (isbox && p._1, p._2))
         }
-      prev :+ (true.B, t.unsafeConvert(x, outType))
+      prev :+ ((true.B, t.unsafeConvert(x, outType)))
     }
 
     val (oks, floats) = helper(x, maxType).unzip

--- a/src/main/scala/tilelink/Metadata.scala
+++ b/src/main/scala/tilelink/Metadata.scala
@@ -16,7 +16,7 @@ object ClientStates {
   def Trunk   = UInt(2, width)
   def Dirty   = UInt(3, width)
 
-  def hasReadPermission(state: UInt): Bool = state > Nothing
+  def hasReadPermission(state: UInt): Bool  = state > Nothing
   def hasWritePermission(state: UInt): Bool = state > Branch
 }
 
@@ -33,16 +33,17 @@ object MemoryOpCategories extends MemoryOpConstants {
 }
 
 /** Stores the client-side coherence information,
-  * such as permissions on the data and whether the data is dirty.
-  * Its API can be used to make TileLink messages in response to
-  * memory operations, cache control oeprations, or Probe messages.
-  */
+ * such as permissions on the data and whether the data is dirty.
+ * Its API can be used to make TileLink messages in response to
+ * memory operations, cache control oeprations, or Probe messages.
+ */
 class ClientMetadata extends Bundle {
+
   /** Actual state information stored in this bundle */
   val state = UInt(width = ClientStates.width)
 
   /** Metadata equality */
-  def ===(rhs: UInt): Bool = state === rhs
+  def ===(rhs: UInt): Bool           = state === rhs
   def ===(rhs: ClientMetadata): Bool = state === rhs.state
   def =/=(rhs: ClientMetadata): Bool = !this.===(rhs)
 
@@ -55,42 +56,52 @@ class ClientMetadata extends Bundle {
     import TLPermissions._
     import ClientStates._
     val c = categorize(cmd)
-    MuxTLookup(Cat(c, state), (Bool(false), UInt(0)), Seq(
-    //(effect, am now) -> (was a hit,   next)
-      Cat(rd, Dirty)   -> (Bool(true),  Dirty),
-      Cat(rd, Trunk)   -> (Bool(true),  Trunk),
-      Cat(rd, Branch)  -> (Bool(true),  Branch),
-      Cat(wi, Dirty)   -> (Bool(true),  Dirty),
-      Cat(wi, Trunk)   -> (Bool(true),  Trunk),
-      Cat(wr, Dirty)   -> (Bool(true),  Dirty),
-      Cat(wr, Trunk)   -> (Bool(true),  Dirty),
-    //(effect, am now) -> (was a miss,  param)
-      Cat(rd, Nothing) -> (Bool(false), NtoB),
-      Cat(wi, Branch)  -> (Bool(false), BtoT),
-      Cat(wi, Nothing) -> (Bool(false), NtoT),
-      Cat(wr, Branch)  -> (Bool(false), BtoT),
-      Cat(wr, Nothing) -> (Bool(false), NtoT)))
+    MuxTLookup(
+      Cat(c, state),
+      (Bool(false), UInt(0)),
+      Seq(
+        //(effect, am now) -> (was a hit,   next)
+        Cat(rd, Dirty)  -> ((Bool(true), Dirty)),
+        Cat(rd, Trunk)  -> ((Bool(true), Trunk)),
+        Cat(rd, Branch) -> ((Bool(true), Branch)),
+        Cat(wi, Dirty)  -> ((Bool(true), Dirty)),
+        Cat(wi, Trunk)  -> ((Bool(true), Trunk)),
+        Cat(wr, Dirty)  -> ((Bool(true), Dirty)),
+        Cat(wr, Trunk)  -> ((Bool(true), Dirty)),
+        //(effect, am now) -> (was a miss,  param)
+        Cat(rd, Nothing) -> ((Bool(false), NtoB)),
+        Cat(wi, Branch)  -> ((Bool(false), BtoT)),
+        Cat(wi, Nothing) -> ((Bool(false), NtoT)),
+        Cat(wr, Branch)  -> ((Bool(false), BtoT)),
+        Cat(wr, Nothing) -> ((Bool(false), NtoT))
+      )
+    )
   }
 
   /** Determine what state to go to after miss based on Grant param
-    * For now, doesn't depend on state (which may have been Probed).
-    */
+   * For now, doesn't depend on state (which may have been Probed).
+   */
   private def growFinisher(cmd: UInt, param: UInt): UInt = {
     import MemoryOpCategories._
     import TLPermissions._
     import ClientStates._
     val c = categorize(cmd)
     //assert(c === rd || param === toT, "Client was expecting trunk permissions.")
-    MuxLookup(Cat(c, param), Nothing, Seq(
-    //(effect param) -> (next)
-      Cat(rd, toB)   -> Branch,
-      Cat(rd, toT)   -> Trunk,
-      Cat(wi, toT)   -> Trunk,
-      Cat(wr, toT)   -> Dirty))
+    MuxLookup(
+      Cat(c, param),
+      Nothing,
+      Seq(
+        //(effect param) -> (next)
+        Cat(rd, toB) -> Branch,
+        Cat(rd, toT) -> Trunk,
+        Cat(wi, toT) -> Trunk,
+        Cat(wr, toT) -> Dirty
+      )
+    )
   }
 
   /** Does this cache have permissions on this block sufficient to perform op,
-    * and what to do next (Acquire message param or updated metadata). */
+   * and what to do next (Acquire message param or updated metadata). */
   def onAccess(cmd: UInt): (Bool, UInt, ClientMetadata) = {
     val r = growStarter(cmd)
     (r._1, r._2, ClientMetadata(r._2))
@@ -99,14 +110,14 @@ class ClientMetadata extends Bundle {
   /** Does a secondary miss on the block require another Acquire message */
   def onSecondaryAccess(first_cmd: UInt, second_cmd: UInt): (Bool, Bool, UInt, ClientMetadata, UInt) = {
     import MemoryOpCategories._
-    val r1 = growStarter(first_cmd)
-    val r2 = growStarter(second_cmd)
-    val needs_second_acq = isWriteIntent(second_cmd) && !isWriteIntent(first_cmd)
-    val hit_again = r1._1 && r2._1
-    val dirties = categorize(second_cmd) === wr
+    val r1                 = growStarter(first_cmd)
+    val r2                 = growStarter(second_cmd)
+    val needs_second_acq   = isWriteIntent(second_cmd) && !isWriteIntent(first_cmd)
+    val hit_again          = r1._1 && r2._1
+    val dirties            = categorize(second_cmd) === wr
     val biggest_grow_param = Mux(dirties, r2._2, r1._2)
-    val dirtiest_state = ClientMetadata(biggest_grow_param)
-    val dirtiest_cmd = Mux(dirties, second_cmd, first_cmd)
+    val dirtiest_state     = ClientMetadata(biggest_grow_param)
+    val dirtiest_cmd       = Mux(dirties, second_cmd, first_cmd)
     (needs_second_acq, hit_again, biggest_grow_param, dirtiest_state, dirtiest_cmd)
   }
 
@@ -117,30 +128,32 @@ class ClientMetadata extends Bundle {
   private def shrinkHelper(param: UInt): (Bool, UInt, UInt) = {
     import ClientStates._
     import TLPermissions._
-    MuxTLookup(Cat(param, state), (Bool(false), UInt(0), UInt(0)), Seq(
-    //(wanted, am now)  -> (hasDirtyData resp, next)
-      Cat(toT, Dirty)   -> (Bool(true),  TtoT, Trunk),
-      Cat(toT, Trunk)   -> (Bool(false), TtoT, Trunk),
-      Cat(toT, Branch)  -> (Bool(false), BtoB, Branch),
-      Cat(toT, Nothing) -> (Bool(false), NtoN, Nothing),
-      Cat(toB, Dirty)   -> (Bool(true),  TtoB, Branch),
-      Cat(toB, Trunk)   -> (Bool(false), TtoB, Branch),  // Policy: Don't notify on clean downgrade
-      Cat(toB, Branch)  -> (Bool(false), BtoB, Branch),
-      Cat(toB, Nothing) -> (Bool(false), NtoN, Nothing),
-      Cat(toN, Dirty)   -> (Bool(true),  TtoN, Nothing),
-      Cat(toN, Trunk)   -> (Bool(false), TtoN, Nothing), // Policy: Don't notify on clean downgrade
-      Cat(toN, Branch)  -> (Bool(false), BtoN, Nothing), // Policy: Don't notify on clean downgrade
-      Cat(toN, Nothing) -> (Bool(false), NtoN, Nothing)))
+    MuxTLookup(
+      Cat(param, state),
+      (Bool(false), UInt(0), UInt(0)),
+      Seq(
+        //(wanted, am now)  -> (hasDirtyData resp, next)
+        Cat(toT, Dirty)   -> ((Bool(true), TtoT, Trunk)),
+        Cat(toT, Trunk)   -> ((Bool(false), TtoT, Trunk)),
+        Cat(toT, Branch)  -> ((Bool(false), BtoB, Branch)),
+        Cat(toT, Nothing) -> ((Bool(false), NtoN, Nothing)),
+        Cat(toB, Dirty)   -> ((Bool(true), TtoB, Branch)),
+        Cat(toB, Trunk)   -> ((Bool(false), TtoB, Branch)), // Policy: Don't notify on clean downgrade
+        Cat(toB, Branch)  -> ((Bool(false), BtoB, Branch)),
+        Cat(toB, Nothing) -> ((Bool(false), NtoN, Nothing)),
+        Cat(toN, Dirty)   -> ((Bool(true), TtoN, Nothing)),
+        Cat(toN, Trunk)   -> ((Bool(false), TtoN, Nothing)), // Policy: Don't notify on clean downgrade
+        Cat(toN, Branch)  -> ((Bool(false), BtoN, Nothing)), // Policy: Don't notify on clean downgrade
+        Cat(toN, Nothing) -> ((Bool(false), NtoN, Nothing))
+      )
+    )
   }
 
   /** Translate cache control cmds into Probe param */
   private def cmdToPermCap(cmd: UInt): UInt = {
     import MemoryOpCategories._
     import TLPermissions._
-    MuxLookup(cmd, toN, Seq(
-      M_FLUSH   -> toN,
-      M_PRODUCE -> toB,
-      M_CLEAN   -> toT))
+    MuxLookup(cmd, toN, Seq(M_FLUSH -> toN, M_PRODUCE -> toB, M_CLEAN -> toT))
   }
 
   def onCacheControl(cmd: UInt): (Bool, UInt, ClientMetadata) = {
@@ -148,7 +161,7 @@ class ClientMetadata extends Bundle {
     (r._1, r._2, ClientMetadata(r._3))
   }
 
-  def onProbe(param: UInt): (Bool, UInt, ClientMetadata) = { 
+  def onProbe(param: UInt): (Bool, UInt, ClientMetadata) = {
     val r = shrinkHelper(param)
     (r._1, r._2, ClientMetadata(r._3))
   }


### PR DESCRIPTION
Added brackets to few places to avoid a compile error for the "-Yno-adapted-args" compiler setup