### PR TITLE
Use newer GitHub actions/cache for improved reliability.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,7 @@ jobs:
         # multiple paths to cache. This can be changed to a normal version
         # number (likely v2) once it is released. See
         # https://github.com/actions/cache/pull/212
-        uses: actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b
+        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
         with:
           path: |
             ./regression/install
@@ -78,7 +78,7 @@ jobs:
 
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-      - uses: actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b
+      - uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
         with:
           path: ./emulator/verilator
           key: verilator-${{ hashFiles('./verilator.hash') }}-v1
@@ -105,7 +105,7 @@ jobs:
       - name: Use SBT Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b
+        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
         with:
           path: |
             ~/.cache/coursier
@@ -130,7 +130,7 @@ jobs:
       - name: Use riscv-tools Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b
+        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
         with:
           path: |
             ./regression/install
@@ -140,7 +140,7 @@ jobs:
       - name: Use Verilator Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b
+        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
         with:
           path: ./emulator/verilator
           key: verilator-${{ hashFiles('./verilator.hash') }}-v1
@@ -148,7 +148,7 @@ jobs:
       - name: Use SBT Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@eb78578266b7cec649ab65b6f1534bd6040c838b
+        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
         with:
           path: |
             ~/.cache/coursier

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,7 @@ jobs:
         # multiple paths to cache. This can be changed to a normal version
         # number (likely v2) once it is released. See
         # https://github.com/actions/cache/pull/212
-        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
+        uses: actions/cache@9ab95382c899bf0953a0c6c1374373fc40456ffe
         with:
           path: |
             ./regression/install
@@ -78,7 +78,7 @@ jobs:
 
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-      - uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
+      - uses: actions/cache@9ab95382c899bf0953a0c6c1374373fc40456ffe
         with:
           path: ./emulator/verilator
           key: verilator-${{ hashFiles('./verilator.hash') }}-v1
@@ -105,7 +105,7 @@ jobs:
       - name: Use SBT Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
+        uses: actions/cache@9ab95382c899bf0953a0c6c1374373fc40456ffe
         with:
           path: |
             ~/.cache/coursier
@@ -130,7 +130,7 @@ jobs:
       - name: Use riscv-tools Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
+        uses: actions/cache@9ab95382c899bf0953a0c6c1374373fc40456ffe
         with:
           path: |
             ./regression/install
@@ -140,7 +140,7 @@ jobs:
       - name: Use Verilator Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
+        uses: actions/cache@9ab95382c899bf0953a0c6c1374373fc40456ffe
         with:
           path: ./emulator/verilator
           key: verilator-${{ hashFiles('./verilator.hash') }}-v1
@@ -148,7 +148,7 @@ jobs:
       - name: Use SBT Cache
         # TODO: Use v2 once it is released. See the first occurrance of
         # actions/cache in this file for more details.
-        uses: actions/cache@16a133d9a70d12a51f9a8e3a3b6261b91d589d79
+        uses: actions/cache@9ab95382c899bf0953a0c6c1374373fc40456ffe
         with:
           path: |
             ~/.cache/coursier


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Per https://github.com/actions/cache/issues/141#issuecomment-629342357, several of the recent commits have improved reliability:

- https://github.com/actions/cache/pull/306
- https://github.com/actions/cache/pull/300
- https://github.com/actions/cache/pull/305

This may help with the reliability of the GitHub Actions CI checks we have, since we've noticed some flakiness since they were first merged in #2465.