### PR TITLE
RocketChipStage shouldn't extend ChiselStage

### DIFF
--- a/src/main/scala/stage/phases/AddDefaultTests.scala
+++ b/src/main/scala/stage/phases/AddDefaultTests.scala
@@ -26,7 +26,7 @@ case class RocketTestSuiteAnnotation(tests: Seq[RocketTestSuite]) extends NoTarg
  */
 class AddDefaultTests extends Phase with PreservesAll[Phase] with HasRocketChipStageUtils {
 
-  override val prerequisites = Seq(Dependency[Checks], Dependency[Elaborate])
+  override val prerequisites = Seq(Dependency[freechips.rocketchip.system.RocketChiselStage])
   override val dependents = Seq(Dependency[GenerateTestSuiteMakefrags])
 
   def GenerateDefaultTestSuites(): List[RocketTestSuite] = {

--- a/src/main/scala/stage/phases/GenerateArtefacts.scala
+++ b/src/main/scala/stage/phases/GenerateArtefacts.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.util.{ElaborationArtefacts, HasRocketChipStageUtils}
 /** Writes [[ElaborationArtefacts]] into files */
 class GenerateArtefacts extends Phase with PreservesAll[Phase] with HasRocketChipStageUtils {
 
-  override val prerequisites = Seq(Dependency[Checks], Dependency[Elaborate])
+  override val prerequisites = Seq(Dependency[freechips.rocketchip.system.RocketChiselStage])
 
   override def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val targetDir = view[StageOptions](annotations).targetDir

--- a/src/main/scala/stage/phases/GenerateFirrtlAnnos.scala
+++ b/src/main/scala/stage/phases/GenerateFirrtlAnnos.scala
@@ -13,12 +13,7 @@ import freechips.rocketchip.util.HasRocketChipStageUtils
 /** Writes FIRRTL annotations into a file */
 class GenerateFirrtlAnnos extends Phase with PreservesAll[Phase] with HasRocketChipStageUtils {
 
-  override val prerequisites = Seq(
-    Dependency[Checks],
-    Dependency[Elaborate],
-    Dependency[Convert],
-    Dependency[MaybeAspectPhase]
-  )
+  override val prerequisites = Seq(Dependency[freechips.rocketchip.system.RocketChiselStage])
 
   override def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val targetDir = view[StageOptions](annotations).targetDir

--- a/src/main/scala/stage/phases/GenerateTestSuiteMakefrags.scala
+++ b/src/main/scala/stage/phases/GenerateTestSuiteMakefrags.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.util.HasRocketChipStageUtils
 /** Generates a make script to run tests in [[RocketTestSuiteAnnotation]]. */
 class GenerateTestSuiteMakefrags extends Phase with PreservesAll[Phase] with HasRocketChipStageUtils {
 
-  override val prerequisites = Seq(Dependency[Checks], Dependency[Elaborate])
+  override val prerequisites = Seq(Dependency[freechips.rocketchip.system.RocketChiselStage])
 
   override def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val targetDir = view[StageOptions](annotations).targetDir

--- a/src/main/scala/system/RocketChipStageGenerator.scala
+++ b/src/main/scala/system/RocketChipStageGenerator.scala
@@ -43,7 +43,6 @@ class RocketChipStage extends Stage with PreservesAll[Phase] {
 
   override def run(annotations: AnnotationSeq): AnnotationSeq = pm.transform(annotations)
 
-  // TODO: need a RunPhaseAnnotation to inject phases into ChiselStage
 }
 
 object Generator extends StageMain(new RocketChipStage)

--- a/src/main/scala/system/RocketChipStageGenerator.scala
+++ b/src/main/scala/system/RocketChipStageGenerator.scala
@@ -3,18 +3,16 @@
 package freechips.rocketchip.system
 
 import chisel3.stage.{ChiselCli, ChiselStage}
+import firrtl.AnnotationSeq
 import firrtl.options.PhaseManager.PhaseDependency
-import firrtl.options.{Dependency, Phase, PreservesAll, Shell, StageMain}
+import firrtl.options.{Dependency, Phase, PhaseManager, PreservesAll, Shell, Stage, StageMain}
 import firrtl.stage.FirrtlCli
 import freechips.rocketchip.stage.RocketChipCli
 
-class RocketChipStage extends ChiselStage with PreservesAll[Phase] {
+/** Modified ChiselStage that includes the GenerateROMs phase */
+private[freechips] final class RocketChiselStage extends ChiselStage {
 
-  override val shell = new Shell("rocket-chip") with RocketChipCli with ChiselCli with FirrtlCli
-  override val targets: Seq[PhaseDependency] = Seq(
-    Dependency[freechips.rocketchip.stage.phases.Checks],
-    Dependency[freechips.rocketchip.stage.phases.TransformAnnotations],
-    Dependency[freechips.rocketchip.stage.phases.PreElaboration],
+  override val targets = Seq(
     Dependency[chisel3.stage.phases.Checks],
     Dependency[chisel3.stage.phases.Elaborate],
     Dependency[freechips.rocketchip.stage.phases.GenerateROMs],
@@ -22,12 +20,28 @@ class RocketChipStage extends ChiselStage with PreservesAll[Phase] {
     Dependency[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
     Dependency[chisel3.stage.phases.MaybeAspectPhase],
     Dependency[chisel3.stage.phases.Emitter],
-    Dependency[chisel3.stage.phases.Convert],
+    Dependency[chisel3.stage.phases.Convert]
+  )
+
+}
+
+class RocketChipStage extends Stage with PreservesAll[Phase] {
+
+  override val shell = new Shell("rocket-chip") with RocketChipCli with ChiselCli with FirrtlCli
+  val targets: Seq[PhaseDependency] = Seq(
+    Dependency[freechips.rocketchip.stage.phases.Checks],
+    Dependency[freechips.rocketchip.stage.phases.TransformAnnotations],
+    Dependency[freechips.rocketchip.stage.phases.PreElaboration],
+    Dependency[RocketChiselStage],
     Dependency[freechips.rocketchip.stage.phases.GenerateFirrtlAnnos],
     Dependency[freechips.rocketchip.stage.phases.AddDefaultTests],
     Dependency[freechips.rocketchip.stage.phases.GenerateTestSuiteMakefrags],
-    Dependency[freechips.rocketchip.stage.phases.GenerateArtefacts],
+    Dependency[freechips.rocketchip.stage.phases.GenerateArtefacts]
   )
+
+  private val pm = new PhaseManager(targets)
+
+  override def run(annotations: AnnotationSeq): AnnotationSeq = pm.transform(annotations)
 
   // TODO: need a RunPhaseAnnotation to inject phases into ChiselStage
 }


### PR DESCRIPTION
Add a separate `RocketChiselStage` that adds appropriate modifications to `ChiselStage` that rocket chip needs (only modification is the addition of . Remove `ChiselStage` from `RocketChipStage`'s type hierarchy.

I only spot checked that this passes `DefaultConfig` and that the stack trace trimming didn't appear to break.

I think that this is a better approach than to rely on access to `ChiselStage.run` which is a method that should probably be made `protected`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Fixes #2467

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Remove emitVerilog, emitFirrtl, and emitChirrtl methods from RocketChipStage