### PR TITLE
Standardize IdMap and IdMapEntry

### DIFF
--- a/src/main/scala/amba/axi4/IdIndexer.scala
+++ b/src/main/scala/amba/axi4/IdIndexer.scala
@@ -37,6 +37,7 @@ class AXI4IdIndexer(idBits: Int)(implicit p: Parameters) extends LazyModule
             maxFlight = old.maxFlight.flatMap { o => m.maxFlight.map { n => o+n } })
         }
       }
+      names.foreach { n => if (n.isEmpty) n += "<unused>" }
       val bits = log2Ceil(mp.endId) - idBits
       val field = if (bits > 0) Seq(AXI4ExtraIdField(bits)) else Nil
       mp.copy(

--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -173,3 +173,21 @@ case class AXI4BufferParams(
   def copyOut(x: BufferParams) = this.copy(aw = x, ar = x, w = x)
   def copyInOut(x: BufferParams) = this.copyIn(x).copyOut(x)
 }
+
+/** Pretty printing of AXI4 source id maps */
+class AXI4IdMap(axi4: AXI4MasterPortParameters) extends IdMap[AXI4IdMapEntry] {
+  private val axi4Digits = String.valueOf(axi4.endId-1).length()
+  protected val fmt = s"\t[%${axi4Digits}d, %${axi4Digits}d) %s%s%s"
+  private val sorted = axi4.masters.sortBy(_.id)
+
+  val mapping: Seq[AXI4IdMapEntry] = sorted.map { case c =>
+    AXI4IdMapEntry(c.id, c.name)
+  }
+}
+
+case class AXI4IdMapEntry(axi4Id: IdRange, name: String) extends IdMapEntry {
+  val from = axi4Id
+  val to = axi4Id
+  val isCache = false
+  val requestFifo = false
+}

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -9,6 +9,15 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
+case class AXI4ToTLIdMapEntry(tlId: IdRange, axi4Id: IdRange, name: String)
+  extends IdMapEntry
+{
+  val from = axi4Id
+  val to = tlId
+  val isCache = false
+  val requestFifo = false
+}
+
 case class AXI4ToTLNode(wcorrupt: Boolean)(implicit valName: ValName) extends MixedAdapterNode(AXI4Imp, TLImp)(
   dFn = { case mp =>
     mp.masters.foreach { m => require (m.maxFlight.isDefined, "AXI4 must include a transaction maximum per ID to convert to TL") }

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -322,3 +322,23 @@ trait DirectedBuffers[T] {
   def copyOut(x: BufferParams): T
   def copyInOut(x: BufferParams): T
 }
+
+trait IdMapEntry {
+  val name: String
+  val from: IdRange
+  val to: IdRange
+  val isCache: Boolean
+  val requestFifo: Boolean
+  def pretty(fmt: String) =
+    if (from ne to) {
+      fmt.format(to.start, to.end, from.start, from.end, s""""$name"""", if (isCache) " [CACHE]" else "", if (requestFifo) " [FIFO]" else "")
+    } else {
+      fmt.format(from.start, from.end, s""""$name"""", if (isCache) " [CACHE]" else "", if (requestFifo) " [FIFO]" else "")
+    }
+}
+
+abstract class IdMap[T <: IdMapEntry] {
+  protected val fmt: String
+  val mapping: Seq[T]
+  def pretty: String = mapping.map(_.pretty(fmt)).mkString(",\n")
+}

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -324,13 +324,13 @@ trait DirectedBuffers[T] {
 }
 
 trait IdMapEntry {
-  val name: String
-  val from: IdRange
-  val to: IdRange
-  val isCache: Boolean
-  val requestFifo: Boolean
+  def name: String
+  def from: IdRange
+  def to: IdRange
+  def isCache: Boolean
+  def requestFifo: Boolean
   def pretty(fmt: String) =
-    if (from ne to) {
+    if (from ne to) { // if the subclass uses the same reference for both from and to, assume its format string has an arity of 5
       fmt.format(to.start, to.end, from.start, from.end, s""""$name"""", if (isCache) " [CACHE]" else "", if (requestFifo) " [FIFO]" else "")
     } else {
       fmt.format(from.start, from.end, s""""$name"""", if (isCache) " [CACHE]" else "", if (requestFifo) " [FIFO]" else "")

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -1168,23 +1168,19 @@ case class TLBufferParams(
 }
 
 /** Pretty printing of TL source id maps */
-class TLSourceIdMap(tl: TLClientPortParameters) {
+class TLSourceIdMap(tl: TLMasterPortParameters) extends IdMap[TLSourceIdMapEntry] {
   private val tlDigits = String.valueOf(tl.endSourceId-1).length()
-  private val fmt = s"\t[%${tlDigits}d, %${tlDigits}d) %s%s%s"
-  private val sorted = tl.clients.sortWith(TLToAXI4.sortByType)
+  protected val fmt = s"\t[%${tlDigits}d, %${tlDigits}d) %s%s%s"
+  private val sorted = tl.clients.sortBy(_.sourceId)
 
   val mapping: Seq[TLSourceIdMapEntry] = sorted.map { case c =>
     TLSourceIdMapEntry(c.sourceId, c.name, c.supportsProbe, c.requestFifo)
   }
-
-  def pretty: String = mapping.map(_.pretty(fmt)).mkString(",\n")
 }
 
-case class TLSourceIdMapEntry(tlId: IdRange, name: String, isCache: Boolean, requestFifo: Boolean) {
-  def pretty(fmt: String): String = fmt.format(
-    tlId.start,
-    tlId.end,
-    s""""$name"""",
-    if (isCache) " [CACHE]" else "",
-    if (requestFifo) " [FIFO]" else "")
+case class TLSourceIdMapEntry(tlId: IdRange, name: String, isCache: Boolean, requestFifo: Boolean)
+  extends IdMapEntry
+{
+  val from = tlId
+  val to = tlId
 }


### PR DESCRIPTION
Requests for information about the meaning and properties of certain ids used in diplomatic protocols to be stored in the Object Model necessitates having a common representation of id spaces across protocols. I refactored some common code related to displaying this information during elaboration such that an underlying abstract class and trait are now shared across the representations.

<!-- choose one -->
**Type of change**: refactoring

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation