### PR TITLE
RVV 0.9: Tighten fractional LMUL-SEW constraint

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -280,8 +280,7 @@ class VType(implicit p: Parameters) extends CoreBundle {
   def max_vsew = log2Ceil(eLen/8)
   def max_vlmul = (1 << vlmul_mag.getWidth) - 1
 
-  def lmul_ok: Bool = (!this.vlmul_sign || this.vlmul_mag =/= 0) &&
-    (this.vsew +& Cat(this.vlmul_sign, ~this.vlmul_mag) <= maxVLMax.log2)
+  def lmul_ok: Bool = Mux(this.vlmul_sign, this.vlmul_mag =/= 0 && ~this.vlmul_mag < max_vsew - this.vsew, true.B)
 
   def minVLMax: Int = ((maxVLMax / eLen) >> ((1 << vlmul_mag.getWidth) - 1)) max 1
 


### PR DESCRIPTION
The spec requires that implementations support fractional LMUL settings
for LMUL ≥ SEW/ELEN.  The old code enforced the looser constraint that
LMUL ≥ SEW/VLEN, so e.g. if VLEN were twice ELEN, we would support one
notch smaller LMUL for any given SEW.

Tightening the constraint will catch software bugs that rely on vtype
settings that aren't guaranteed to be supported across implemenetations.
The space of configurations that need to be verified is also reduced.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation
