### PR TITLE
Fix Travis CI Shell Options

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -277,7 +277,7 @@ ifdef SEED
 SEED_ARG = --seed $(SEED)
 endif
 
-JTAG_DTM_SIM_ARGS = +verbose +jtag_rbb_enable=1 $(SEED_ARG)
+JTAG_DTM_SIM_ARGS = +jtag_rbb_enable=1 $(SEED_ARG)
 
 stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
 	RISCV=$(RISCV) PATH="$(abspath $(RISCV)/bin:$(PATH))" $(GDBSERVER) \

--- a/regression/run-test-bucket
+++ b/regression/run-test-bucket
@@ -28,7 +28,9 @@ if [[ ${TRAVIS:-false} == true ]]; then
   . "${regression_dir}/travis_setup_env.bash"
   . "${regression_dir}/travis_jigger.bash"
   . "${regression_dir}/travis_wait.bash"
+  set +u
   travis_setup_env
+  set -u
 else
   # If not running on Travis CI, Stub out the travis_wait to be a no-op, since
   # it's unnecessary and it has some undesirable side effects such as hiding

--- a/regression/travis_wait.bash
+++ b/regression/travis_wait.bash
@@ -23,6 +23,7 @@
 # https://github.com/travis-ci/travis-build/blob/73a5393263e0b135f49aceeb40ef6f0d827b9b11/lib/travis/build/bash/travis_wait.bash
 
 travis_wait() {
+  set +e
   local timeout="${1}"
 
   if [[ "${timeout}" =~ ^[0-9]+$ ]]; then
@@ -56,5 +57,6 @@ travis_wait() {
   echo -e "\\n${ANSI_GREEN}Log:${ANSI_RESET}\\n"
   cat "${log_file}"
 
+  set -e
   return "${result}"
 }


### PR DESCRIPTION
This fixes two issues when using the new regression scripts on Travis infrastructure:

1. `travis_setup_env.bash` may have an undefined variable `TRAVIS_ENABLE_INFRA_DETECTION`. This script needs to continue past this and have unset variable checking disabled.
2. `travis_wait.bash` is written such that it needs to continue after the first failure to do useful things like print out the log of execution.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None.

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
None.
