### PR TITLE
Add 'openjdk/java/1.8.0' resource string to java invocations

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -121,7 +121,7 @@ global def runRocketChipGenerator options =
     def baseFileName = match options.getRocketChipGeneratorOptionsBaseFileName
       Some name = "--name", name, Nil
       None = Nil
-    which "java", "-cp", classpath, main,
+    "java", "-cp", classpath, main,
     "--target-dir", relTargetDir,
     "--top-module", topModule,
     "--configs", configs,
@@ -134,6 +134,7 @@ global def runRocketChipGenerator options =
 
   def generatorJob =
     makePlan cmdline inputs
+    | setPlanResources ("openjdk/java/1.8.0", Nil)
     | setPlanDirectory runDir
     | runJob
 


### PR DESCRIPTION
Add a resource string (via `setPlanResources`) for java invocations.

A wake runner can use this to resolve a shell `PATH` and `JAVA_HOME` to allow setting different installation locations for java.
If no wake runner is available, wake will fallback to the current default `PATH=/usr/bin:/bin`

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
