### PR TITLE
PseudoLRU non-power-of-2

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=freechips.rocketchip.unittest
-CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).PowerQueueTestConfig
+CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=freechips.rocketchip.unittest
-CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
+CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).PowerQueueTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=freechips.rocketchip.unittest
-CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).ScatterGatherTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
+CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=freechips.rocketchip.unittest
-CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).TLXbarUnitTestConfig $(PROJECT).ECCUnitTestConfig $(PROJECT).ScatterGatherTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
+CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).ECCUnitTestConfig $(PROJECT).ScatterGatherTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=freechips.rocketchip.unittest
-CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig
+CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).TLXbarUnitTestConfig $(PROJECT).ECCUnitTestConfig $(PROJECT).ScatterGatherTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=freechips.rocketchip.unittest
-CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).ECCUnitTestConfig $(PROJECT).ScatterGatherTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
+CONFIGS=$(PROJECT).AMBAUnitTestConfig $(PROJECT).TLSimpleUnitTestConfig $(PROJECT).TLWidthUnitTestConfig $(PROJECT).ScatterGatherTestConfig $(PROJECT).PLRUUnitTestConfig $(PROJECT).PowerQueueTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/src/main/scala/rocket/BTB.scala
+++ b/src/main/scala/rocket/BTB.scala
@@ -241,7 +241,7 @@ class BTB(implicit p: Parameters) extends BtbModule {
   }
 
   val repl = new PseudoLRU(entries)
-  val waddr = Mux(updateHit, updateHitAddr, repl.replace)
+  val waddr = Mux(updateHit, updateHitAddr, repl.way)
   val r_resp = Pipe(io.resp)
   when (r_resp.valid && r_resp.bits.taken || r_btb_update.valid) {
     repl.access(Mux(r_btb_update.valid, waddr, r_resp.bits.entry))

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -172,7 +172,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     val hits = tags.map(_ === pte_addr).asUInt & valid
     val hit = hits.orR
     when (mem_resp_valid && traverse && !hit && !invalidated) {
-      val r = Mux(valid.andR, plru.replace, PriorityEncoder(~valid))
+      val r = Mux(valid.andR, plru.way, PriorityEncoder(~valid))
       valid := valid | UIntToOH(r)
       tags(r) := pte_addr
       data(r) := pte.ppn

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -347,8 +347,8 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
       state := s_request
       r_refill_tag := vpn
 
-      r_superpage_repl_addr := replacementEntry(superpage_entries, superpage_plru.replace)
-      r_sectored_repl_addr := replacementEntry(sectored_entries, sectored_plru.replace)
+      r_superpage_repl_addr := replacementEntry(superpage_entries, superpage_plru.way)
+      r_sectored_repl_addr := replacementEntry(sectored_entries, sectored_plru.way)
       r_sectored_hit_addr := OHToUInt(sector_hits)
       r_sectored_hit := sector_hits.orR
     }

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -121,6 +121,12 @@ class WithScatterGatherTests extends Config((site, here, up) => {
       Module(new ScatterTest(8)),
       Module(new ScatterTest(9)))}})
 
+class WithPLRUTests extends Config((site, here, up) => {
+  case UnitTests => (q: Parameters) => {
+    Seq(
+      Module(new PLRUTest(2)),
+      Module(new PLRUTest(4)))}})
+
 class WithPowerQueueTests extends Config((site, here, up) => {
   case UnitTests => (q: Parameters) => {
     Seq(
@@ -158,4 +164,5 @@ class TLWidthUnitTestConfig extends Config(new WithTLWidthUnitTests ++ new WithT
 class TLXbarUnitTestConfig extends Config(new WithTLXbarUnitTests ++ new WithTestDuration(10) ++ new BaseSubsystemConfig)
 class ECCUnitTestConfig extends Config(new WithECCTests)
 class ScatterGatherTestConfig extends Config(new WithScatterGatherTests)
+class PLRUUnitTestConfig extends Config(new WithPLRUTests)
 class PowerQueueTestConfig extends Config(new WithPowerQueueTests)

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -125,6 +125,7 @@ class WithPLRUTests extends Config((site, here, up) => {
   case UnitTests => (q: Parameters) => {
     Seq(
       Module(new PLRUTest(2)),
+      Module(new PLRUTest(3)),
       Module(new PLRUTest(4)))}})
 
 class WithPowerQueueTests extends Config((site, here, up) => {

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -126,7 +126,8 @@ class WithPLRUTests extends Config((site, here, up) => {
     Seq(
       Module(new PLRUTest(2)),
       Module(new PLRUTest(3)),
-      Module(new PLRUTest(4)))}})
+      Module(new PLRUTest(4)),
+      Module(new PLRUTest(6)))}})
 
 class WithPowerQueueTests extends Config((site, here, up) => {
   case UnitTests => (q: Parameters) => {

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -18,7 +18,7 @@ class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
   val wrdata = UInt(width = xLen.W)
   val wrenx = Bool()
   val wrenf = Bool()
-  @deprecated("replace wren with wrenx or wrenf to specify integer or floating point","")
+  @deprecated("replace wren with wrenx or wrenf to specify integer or floating point","Rocket Chip 2020.05")
   def wren: Bool = wrenx || wrenf
   val rd0src = UInt(width = 5.W)
   val rd0val = UInt(width = xLen.W)

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -152,7 +152,7 @@ class PseudoLRU(n_ways: Int) extends ReplacementPolicy {
 
   def get_next_state(state: UInt, way: UInt, this_ways: Int): UInt = {
     require(state.getWidth == (this_ways-1), s"wrong state bits width ${state.getWidth} for $this_ways ways")
-    require(way.getWidth == log2Ceil(this_ways), s"wrong encoded way width ${way.getWidth} for $this_ways ways")
+    require(way.getWidth == (log2Ceil(this_ways) max 1), s"wrong encoded way width ${way.getWidth} for $this_ways ways")
     if (this_ways > 2) {
       val half_ways: Int = 1 << (log2Ceil(this_ways) - 1)
       if (this_ways > 3) {
@@ -169,8 +169,10 @@ class PseudoLRU(n_ways: Int) extends ReplacementPolicy {
                 state(half_ways-2,0),
                 get_next_state(state(half_ways-2,0), way(log2Ceil(half_ways)-1,0), half_ways)))
       }
-    } else {  // this_ways <= 2
+    } else if (this_ways == 2) {
       !way(0)
+    } else {  // this_ways <= 1
+      0.U(1.W)
     }
   }
   def get_next_state(state: UInt, way: UInt): UInt = get_next_state(state, way, n_ways)
@@ -183,8 +185,10 @@ class PseudoLRU(n_ways: Int) extends ReplacementPolicy {
           Mux(state(this_ways-2),
               if (this_ways > 3) get_replace_way(state(this_ways-3,half_ways-1), this_ways-half_ways) else 0.U((log2Ceil(this_ways)-1).W),
               get_replace_way(state(half_ways-2,0), half_ways)))
-    } else {  // this_ways <= 2
+    } else if (this_ways == 2) {
       state(0)
+    } else {  // this_ways <= 1
+      0.U(1.W)
     }
   }
   def get_replace_way(state: UInt): UInt = get_replace_way(state, n_ways)

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -127,6 +127,8 @@ class TrueLRU(n_ways: Int) extends ReplacementPolicy {
   def way = get_replace_way(state_reg)
   def miss = access(way)
   def hit = {}
+  @deprecated("replace 'replace' with 'way' from abstract class ReplacementPolicy","Rocket Chip 2020.05")
+  def replace: UInt = way
 }
 
 class PseudoLRU(n_ways: Int) extends ReplacementPolicy {

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -214,7 +214,11 @@ class PseudoLRU(n_ways: Int) extends ReplacementPolicy {
     }
   }
 
-  def get_next_state(state: UInt, touch_way: UInt): UInt = get_next_state(state, touch_way, n_ways)
+  def get_next_state(state: UInt, touch_way: UInt): UInt = {
+    val touch_way_sized = if (touch_way.getWidth < log2Ceil(n_ways)) touch_way.padTo  (log2Ceil(n_ways))
+                                                                else touch_way.extract(log2Ceil(n_ways)-1,0)
+    get_next_state(state, touch_way_sized, n_ways)
+  }
 
 
   /** @param state state_reg bits for this sub-tree

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -19,7 +19,7 @@ abstract class ReplacementPolicy {
 object ReplacementPolicy {
   def fromString(s: String, ways: Int): ReplacementPolicy = s.toLowerCase match {
     case "random" => new RandomReplacement(ways)
-    //TODO case "lru"    => new TrueLRU(ways)
+    case "lru"    => new TrueLRU(ways)
     case "plru"   => new PseudoLRU(ways)
     case t => throw new IllegalArgumentException(s"unknown Replacement Policy type $t")
   }
@@ -50,6 +50,68 @@ class SeqRandom(n_ways: Int) extends SeqReplacementPolicy {
     when (valid && !hit) { logic.miss }
   }
   def way = logic.way
+}
+
+class TrueLRU(n_ways: Int) extends ReplacementPolicy {
+  // True LRU replacement policy, using a triangular matrix to track which sets are more recently used than others.
+  // The matrix is packed into a single UInt (or Bits).  Example 4-way (6-bits):
+  // [5] - 3 more recent than 2
+  // [4] - 3 more recent than 1
+  // [3] - 2 more recent than 1
+  // [2] - 3 more recent than 0
+  // [1] - 2 more recent than 0
+  // [0] - 1 more recent than 0
+  private val state_reg = RegInit(0.U(((n_ways*(n_ways-1))/2).W))
+
+  private def extractMRUVec(state: Bits): Seq[UInt] = {
+    // Extract per-way information about which higher-indexed ways are more recently used
+    val moreRecentVec = Wire(Vec(n_ways-1, UInt(n_ways.W)))
+    var lsb = 0
+    for (i <- 0 until n_ways-1) {
+      moreRecentVec(i) := Cat(state(lsb+n_ways-i-2,lsb), 0.U((i+1).W))
+      lsb = lsb + (n_ways - i - 1)
+    }
+    moreRecentVec
+  }
+
+  def get_next_state(state: Bits, way: UInt): UInt = {
+    val nextState     = Wire(Vec(n_ways-1, UInt(n_ways.W)))
+    val moreRecentVec = extractMRUVec(state)  // reconstruct lower triangular matrix
+    val wayDec        = UIntToOH(way, n_ways)
+
+    // Compute next value of triangular matrix
+    // set the referenced way as more recent than every other way
+    nextState.zipWithIndex.map { case (e, i) =>
+      e := Mux(i.U === way, 0.U(n_ways.W), moreRecentVec(i) | wayDec)
+    }
+
+    nextState.zipWithIndex.tail.foldLeft((nextState.head.apply(n_ways-1,1),0)) { case ((pe,pi),(ce,ci)) => (Cat(ce.apply(n_ways-1,ci+1), pe), ci) }._1
+  }
+
+  def access(way: UInt) {
+    state_reg := get_next_state(state_reg, way)
+  }
+  def access(ways: Seq[Valid[UInt]]) {
+    state_reg := ways.foldLeft(state_reg)((prev, way) => Mux(way.valid, get_next_state(prev, way.bits), prev))
+    for (i <- 1 until ways.size) {
+      cover(PopCount(ways.map(_.valid)) === i.U, s"LRU_UpdateCount$i", s"LRU Update $i simultaneous")
+    }
+  }
+
+  def get_replace_way(state: Bits): UInt = {
+    val moreRecentVec = extractMRUVec(state)  // reconstruct lower triangular matrix
+    // For each way, determine if all other ways are more recent
+    val mruWayDec     = (0 until n_ways).map { i =>
+      val upperMoreRecent = (if (i == n_ways-1) true.B else moreRecentVec(i).apply(n_ways-1,i+1).andR)
+      val lowerMoreRecent = (if (i == 0)        true.B else moreRecentVec.map(e => !e(i)).reduce(_ && _))
+      upperMoreRecent && lowerMoreRecent
+    }
+    OHToUInt(mruWayDec)
+  }
+
+  def way = get_replace_way(state_reg)
+  def miss = access(way)
+  def hit = {}
 }
 
 class PseudoLRU(n_ways: Int) extends ReplacementPolicy {

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -3,23 +3,38 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.util.random.LFSR
+import freechips.rocketchip.util.property.cover
 
 abstract class ReplacementPolicy {
   def way: UInt
   def miss: Unit
   def hit: Unit
+  def access(way: UInt): Unit
+  def access(ways: Seq[Valid[UInt]]): Unit
+}
+
+object ReplacementPolicy {
+  def fromString(s: String, ways: Int): ReplacementPolicy = s.toLowerCase match {
+    case "random" => new RandomReplacement(ways)
+    //TODO case "lru"    => new TrueLRU(ways)
+    case "plru"   => new PseudoLRU(ways)
+    case t => throw new IllegalArgumentException(s"unknown Replacement Policy type $t")
+  }
 }
 
 class RandomReplacement(ways: Int) extends ReplacementPolicy {
   private val replace = Wire(Bool())
-  replace := Bool(false)
+  replace := false.B
   val lfsr = LFSR(16, replace)
 
   def way = Random(ways, lfsr)
-  def miss = replace := Bool(true)
+  def miss = replace := true.B
   def hit = {}
+  def access(way: UInt) = {}
+  def access(ways: Seq[Valid[UInt]]) = {}
 }
 
 abstract class SeqReplacementPolicy {
@@ -37,43 +52,65 @@ class SeqRandom(n_ways: Int) extends SeqReplacementPolicy {
   def way = logic.way
 }
 
-class PseudoLRU(n: Int)
-{
+class PseudoLRU(n_ways: Int) extends ReplacementPolicy {
   //example bits storage format for 4-way PLRU:
-  // bit[2] = way 3 older than way 2
-  // bit[1] = way 1 older than way 0
-  // bit[0] = ways 3-2 older than ways 1-0
-  private val state_reg = Reg(UInt(width = n-1))
+  // [2] = ways 3-2 older than ways 1-0
+  // [1] = way 3 older than way 2
+  // [0] = way 1 older than way 0
+  private val state_reg = Reg(UInt((n_ways-1).W))
   def access(way: UInt) {
-    state_reg := get_next_state(state_reg,way)
+    state_reg := get_next_state(state_reg, way)
   }
-  def access(ways: Seq[ValidIO[UInt]]) {
+  def access(ways: Seq[Valid[UInt]]) {
     state_reg := ways.foldLeft(state_reg)((prev, way) => Mux(way.valid, get_next_state(prev, way.bits), prev))
-  }
-  def get_next_state(state: UInt, way: UInt) = {
-    var next_state = state << 1
-    var idx = UInt(1,1)
-    for (i <- log2Up(n)-1 to 0 by -1) {
-      val bit = way(i)
-      next_state = next_state.bitSet(idx, !bit)
-      idx = Cat(idx, bit)
+    for (i <- 1 until ways.size) {
+      cover(PopCount(ways.map(_.valid)) === i.U, s"PLRU_UpdateCount$i", s"PLRU Update $i simultaneous")
     }
-    next_state.extract(n-1, 1)
   }
-  def replace = get_replace_way(state_reg)
-  def get_replace_way(state: UInt) = {
-    val shifted_state = state << 1
-    var idx = UInt(1,1)
-    for (i <- log2Up(n)-1 to 0 by -1) {
-      val in_bounds = Cat(idx, UInt(BigInt(1) << i))(log2Up(n)-1, 0) < UInt(n)
-      idx = Cat(idx, in_bounds && shifted_state(idx))
+  def get_next_state(state: UInt, way: UInt, this_ways: Int): UInt = {
+    require(state.getWidth == (this_ways-1), s"wrong state bits width ${state.getWidth} for $this_ways ways")
+    require(way.getWidth == log2Ceil(this_ways), s"wrong encoded way width ${way.getWidth} for $this_ways ways")
+    if (this_ways > 2) {
+      val half_ways: Int = 1 << (log2Ceil(this_ways) - 1)
+      if (this_ways > 3) {
+        Cat(!way(log2Ceil(this_ways)-1),
+            Mux(way(log2Ceil(this_ways)-1),
+                get_next_state(state(this_ways-3,half_ways-1), way(log2Ceil(this_ways-half_ways)-1,0), this_ways-half_ways),
+                state(this_ways-3,half_ways-1)),
+            Mux(way(log2Ceil(this_ways)-1),
+                state(half_ways-2,0),
+                get_next_state(state(half_ways-2,0), way(log2Ceil(half_ways)-1,0), half_ways)))
+      } else {  // this_ways == 3
+        Cat(!way(log2Ceil(this_ways)-1),
+            Mux(way(log2Ceil(this_ways)-1),
+                state(half_ways-2,0),
+                get_next_state(state(half_ways-2,0), way(log2Ceil(half_ways)-1,0), half_ways)))
+      }
+    } else {  // this_ways <= 2
+      !way(0)
     }
-    idx(log2Up(n)-1,0)
   }
+  def get_next_state(state: UInt, way: UInt): UInt = get_next_state(state, way, n_ways)
+  def get_replace_way(state: UInt, this_ways: Int): UInt = {
+    require(state.getWidth == (this_ways-1), s"wrong state bits width ${state.getWidth} for $this_ways ways")
+    if (this_ways > 2) {
+      val half_ways: Int = 1 << (log2Ceil(this_ways) - 1)
+      Cat(state(this_ways-2),
+          Mux(state(this_ways-2),
+              if (this_ways > 3) get_replace_way(state(this_ways-3,half_ways-1), this_ways-half_ways) else 0.U((log2Ceil(this_ways)-1).W),
+              get_replace_way(state(half_ways-2,0), half_ways)))
+    } else {  // this_ways <= 2
+      state(0)
+    }
+  }
+  def get_replace_way(state: UInt): UInt = get_replace_way(state, n_ways)
+  def way = get_replace_way(state_reg)
+  def miss = access(way)
+  def hit = {}
 }
 
 class SeqPLRU(n_sets: Int, n_ways: Int) extends SeqReplacementPolicy {
-  val state = SeqMem(n_sets, UInt(width = n_ways-1))
+  val state = SyncReadMem(n_sets, UInt((n_ways-1).W))
   val logic = new PseudoLRU(n_ways)
   val current_state = Wire(UInt())
   val plru_way = logic.get_replace_way(current_state)
@@ -99,115 +136,115 @@ class PLRUTest(n_ways: Int, timeout: Int = 500) extends UnitTest(timeout) {
   val plru = new PseudoLRU(n_ways)
 
   // step
-  io.finished := RegNext(Bool(true), Bool(false))
+  io.finished := RegNext(true.B, false.B)
 
   val get_replace_ways = (0 until (1 << (n_ways-1))).map(state =>
-    plru.get_replace_way(state = UInt(state, width=n_ways-1)))
+    plru.get_replace_way(state = state.U((n_ways-1).W)))
   val get_next_states  = (0 until (1 << (n_ways-1))).map(state => (0 until n_ways).map(way =>
-    plru.get_next_state (state = UInt(state, width=n_ways-1), way = UInt(way, width=log2Ceil(n_ways)))))
+    plru.get_next_state (state = state.U((n_ways-1).W), way = way.U(log2Ceil(n_ways).W))))
 
   n_ways match {
     case 2 => {
-      assert(get_replace_ways(0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
-      assert(get_replace_ways(1) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=1: expected=1 actual=%d", get_replace_ways(1))
-      assert(get_next_states(0)(0) === UInt(1, width=n_ways-1), s"get_next_state state=0 way=0: expected=1 actual=%d", get_next_states(0)(0))
-      assert(get_next_states(0)(1) === UInt(0, width=n_ways-1), s"get_next_state state=0 way=1: expected=0 actual=%d", get_next_states(0)(1))
-      assert(get_next_states(1)(0) === UInt(1, width=n_ways-1), s"get_next_state state=1 way=0: expected=1 actual=%d", get_next_states(1)(0))
-      assert(get_next_states(1)(1) === UInt(0, width=n_ways-1), s"get_next_state state=1 way=1: expected=0 actual=%d", get_next_states(1)(1))
+      assert(get_replace_ways(0) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
+      assert(get_replace_ways(1) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=1: expected=1 actual=%d", get_replace_ways(1))
+      assert(get_next_states(0)(0) === 1.U((n_ways-1).W), s"get_next_state state=0 way=0: expected=1 actual=%d", get_next_states(0)(0))
+      assert(get_next_states(0)(1) === 0.U((n_ways-1).W), s"get_next_state state=0 way=1: expected=0 actual=%d", get_next_states(0)(1))
+      assert(get_next_states(1)(0) === 1.U((n_ways-1).W), s"get_next_state state=1 way=0: expected=1 actual=%d", get_next_states(1)(0))
+      assert(get_next_states(1)(1) === 0.U((n_ways-1).W), s"get_next_state state=1 way=1: expected=0 actual=%d", get_next_states(1)(1))
     }
     case 3 => {
-      assert(get_replace_ways(0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
-      assert(get_replace_ways(1) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=1: expected=2 actual=%d", get_replace_ways(1))
-      assert(get_replace_ways(2) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=2: expected=1 actual=%d", get_replace_ways(2))
-      assert(get_replace_ways(3) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=3: expected=2 actual=%d", get_replace_ways(3))
-      assert(get_next_states(0)(0) === UInt(3, width=n_ways-1), s"get_next_state state=0 way=0: expected=3 actual=%d", get_next_states(0)(0))
-      assert(get_next_states(0)(1) === UInt(1, width=n_ways-1), s"get_next_state state=0 way=1: expected=1 actual=%d", get_next_states(0)(1))
-      assert(get_next_states(0)(2) === UInt(0, width=n_ways-1), s"get_next_state state=0 way=2: expected=0 actual=%d", get_next_states(0)(2))
-      assert(get_next_states(1)(0) === UInt(3, width=n_ways-1), s"get_next_state state=1 way=0: expected=3 actual=%d", get_next_states(1)(0))
-      assert(get_next_states(1)(1) === UInt(1, width=n_ways-1), s"get_next_state state=1 way=1: expected=1 actual=%d", get_next_states(1)(1))
-      assert(get_next_states(1)(2) === UInt(0, width=n_ways-1), s"get_next_state state=1 way=2: expected=0 actual=%d", get_next_states(1)(2))
-      assert(get_next_states(2)(0) === UInt(3, width=n_ways-1), s"get_next_state state=2 way=0: expected=3 actual=%d", get_next_states(2)(0))
-      assert(get_next_states(2)(1) === UInt(1, width=n_ways-1), s"get_next_state state=2 way=1: expected=1 actual=%d", get_next_states(2)(1))
-      assert(get_next_states(2)(2) === UInt(2, width=n_ways-1), s"get_next_state state=2 way=2: expected=2 actual=%d", get_next_states(2)(2))
-      assert(get_next_states(3)(0) === UInt(3, width=n_ways-1), s"get_next_state state=3 way=0: expected=3 actual=%d", get_next_states(3)(0))
-      assert(get_next_states(3)(1) === UInt(1, width=n_ways-1), s"get_next_state state=3 way=1: expected=1 actual=%d", get_next_states(3)(1))
-      assert(get_next_states(3)(2) === UInt(2, width=n_ways-1), s"get_next_state state=3 way=2: expected=2 actual=%d", get_next_states(3)(2))
+      assert(get_replace_ways(0) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
+      assert(get_replace_ways(1) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=1: expected=1 actual=%d", get_replace_ways(1))
+      assert(get_replace_ways(2) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=2: expected=2 actual=%d", get_replace_ways(2))
+      assert(get_replace_ways(3) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=3: expected=2 actual=%d", get_replace_ways(3))
+      assert(get_next_states(0)(0) === 3.U((n_ways-1).W), s"get_next_state state=0 way=0: expected=3 actual=%d", get_next_states(0)(0))
+      assert(get_next_states(0)(1) === 2.U((n_ways-1).W), s"get_next_state state=0 way=1: expected=2 actual=%d", get_next_states(0)(1))
+      assert(get_next_states(0)(2) === 0.U((n_ways-1).W), s"get_next_state state=0 way=2: expected=0 actual=%d", get_next_states(0)(2))
+      assert(get_next_states(1)(0) === 3.U((n_ways-1).W), s"get_next_state state=1 way=0: expected=3 actual=%d", get_next_states(1)(0))
+      assert(get_next_states(1)(1) === 2.U((n_ways-1).W), s"get_next_state state=1 way=1: expected=2 actual=%d", get_next_states(1)(1))
+      assert(get_next_states(1)(2) === 1.U((n_ways-1).W), s"get_next_state state=1 way=2: expected=1 actual=%d", get_next_states(1)(2))
+      assert(get_next_states(2)(0) === 3.U((n_ways-1).W), s"get_next_state state=2 way=0: expected=3 actual=%d", get_next_states(2)(0))
+      assert(get_next_states(2)(1) === 2.U((n_ways-1).W), s"get_next_state state=2 way=1: expected=2 actual=%d", get_next_states(2)(1))
+      assert(get_next_states(2)(2) === 0.U((n_ways-1).W), s"get_next_state state=2 way=2: expected=0 actual=%d", get_next_states(2)(2))
+      assert(get_next_states(3)(0) === 3.U((n_ways-1).W), s"get_next_state state=3 way=0: expected=3 actual=%d", get_next_states(3)(0))
+      assert(get_next_states(3)(1) === 2.U((n_ways-1).W), s"get_next_state state=3 way=1: expected=2 actual=%d", get_next_states(3)(1))
+      assert(get_next_states(3)(2) === 1.U((n_ways-1).W), s"get_next_state state=3 way=2: expected=1 actual=%d", get_next_states(3)(2))
     }
     case 4 => {
-      assert(get_replace_ways(0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
-      assert(get_replace_ways(1) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=1: expected=2 actual=%d", get_replace_ways(1))
-      assert(get_replace_ways(2) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=2: expected=1 actual=%d", get_replace_ways(2))
-      assert(get_replace_ways(3) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=3: expected=2 actual=%d", get_replace_ways(3))
-      assert(get_replace_ways(4) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=4: expected=0 actual=%d", get_replace_ways(4))
-      assert(get_replace_ways(5) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=5: expected=3 actual=%d", get_replace_ways(5))
-      assert(get_replace_ways(6) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=6: expected=1 actual=%d", get_replace_ways(6))
-      assert(get_replace_ways(7) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=7: expected=3 actual=%d", get_replace_ways(7))
-      assert(get_next_states(0)(0) === UInt(3, width=n_ways-1), s"get_next_state state=0 way=0: expected=3 actual=%d", get_next_states(0)(0))
-      assert(get_next_states(0)(1) === UInt(1, width=n_ways-1), s"get_next_state state=0 way=1: expected=1 actual=%d", get_next_states(0)(1))
-      assert(get_next_states(0)(2) === UInt(4, width=n_ways-1), s"get_next_state state=0 way=2: expected=4 actual=%d", get_next_states(0)(2))
-      assert(get_next_states(0)(3) === UInt(0, width=n_ways-1), s"get_next_state state=0 way=3: expected=0 actual=%d", get_next_states(0)(3))
-      assert(get_next_states(1)(0) === UInt(3, width=n_ways-1), s"get_next_state state=1 way=0: expected=3 actual=%d", get_next_states(1)(0))
-      assert(get_next_states(1)(1) === UInt(1, width=n_ways-1), s"get_next_state state=1 way=1: expected=1 actual=%d", get_next_states(1)(1))
-      assert(get_next_states(1)(2) === UInt(4, width=n_ways-1), s"get_next_state state=1 way=2: expected=4 actual=%d", get_next_states(1)(2))
-      assert(get_next_states(1)(3) === UInt(0, width=n_ways-1), s"get_next_state state=1 way=3: expected=0 actual=%d", get_next_states(1)(3))
-      assert(get_next_states(2)(0) === UInt(3, width=n_ways-1), s"get_next_state state=2 way=0: expected=3 actual=%d", get_next_states(2)(0))
-      assert(get_next_states(2)(1) === UInt(1, width=n_ways-1), s"get_next_state state=2 way=1: expected=1 actual=%d", get_next_states(2)(1))
-      assert(get_next_states(2)(2) === UInt(6, width=n_ways-1), s"get_next_state state=2 way=2: expected=6 actual=%d", get_next_states(2)(2))
-      assert(get_next_states(2)(3) === UInt(2, width=n_ways-1), s"get_next_state state=2 way=3: expected=2 actual=%d", get_next_states(2)(3))
-      assert(get_next_states(3)(0) === UInt(3, width=n_ways-1), s"get_next_state state=3 way=0: expected=3 actual=%d", get_next_states(3)(0))
-      assert(get_next_states(3)(1) === UInt(1, width=n_ways-1), s"get_next_state state=3 way=1: expected=1 actual=%d", get_next_states(3)(1))
-      assert(get_next_states(3)(2) === UInt(6, width=n_ways-1), s"get_next_state state=3 way=2: expected=6 actual=%d", get_next_states(3)(2))
-      assert(get_next_states(3)(3) === UInt(2, width=n_ways-1), s"get_next_state state=3 way=3: expected=2 actual=%d", get_next_states(3)(3))
-      assert(get_next_states(4)(0) === UInt(7, width=n_ways-1), s"get_next_state state=4 way=0: expected=7 actual=%d", get_next_states(4)(0))
-      assert(get_next_states(4)(1) === UInt(5, width=n_ways-1), s"get_next_state state=4 way=1: expected=5 actual=%d", get_next_states(4)(1))
-      assert(get_next_states(4)(2) === UInt(4, width=n_ways-1), s"get_next_state state=4 way=2: expected=4 actual=%d", get_next_states(4)(2))
-      assert(get_next_states(4)(3) === UInt(0, width=n_ways-1), s"get_next_state state=4 way=3: expected=0 actual=%d", get_next_states(4)(3))
-      assert(get_next_states(5)(0) === UInt(7, width=n_ways-1), s"get_next_state state=5 way=0: expected=7 actual=%d", get_next_states(5)(0))
-      assert(get_next_states(5)(1) === UInt(5, width=n_ways-1), s"get_next_state state=5 way=1: expected=5 actual=%d", get_next_states(5)(1))
-      assert(get_next_states(5)(2) === UInt(4, width=n_ways-1), s"get_next_state state=5 way=2: expected=4 actual=%d", get_next_states(5)(2))
-      assert(get_next_states(5)(3) === UInt(0, width=n_ways-1), s"get_next_state state=5 way=3: expected=0 actual=%d", get_next_states(5)(3))
-      assert(get_next_states(6)(0) === UInt(7, width=n_ways-1), s"get_next_state state=6 way=0: expected=7 actual=%d", get_next_states(6)(0))
-      assert(get_next_states(6)(1) === UInt(5, width=n_ways-1), s"get_next_state state=6 way=1: expected=5 actual=%d", get_next_states(6)(1))
-      assert(get_next_states(6)(2) === UInt(6, width=n_ways-1), s"get_next_state state=6 way=2: expected=6 actual=%d", get_next_states(6)(2))
-      assert(get_next_states(6)(3) === UInt(2, width=n_ways-1), s"get_next_state state=6 way=3: expected=2 actual=%d", get_next_states(6)(3))
-      assert(get_next_states(7)(0) === UInt(7, width=n_ways-1), s"get_next_state state=7 way=0: expected=7 actual=%d", get_next_states(7)(0))
-      assert(get_next_states(7)(1) === UInt(5, width=n_ways-1), s"get_next_state state=7 way=5: expected=1 actual=%d", get_next_states(7)(1))
-      assert(get_next_states(7)(2) === UInt(6, width=n_ways-1), s"get_next_state state=7 way=2: expected=6 actual=%d", get_next_states(7)(2))
-      assert(get_next_states(7)(3) === UInt(2, width=n_ways-1), s"get_next_state state=7 way=3: expected=2 actual=%d", get_next_states(7)(3))
+      assert(get_replace_ways(0) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
+      assert(get_replace_ways(1) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=1: expected=1 actual=%d", get_replace_ways(1))
+      assert(get_replace_ways(2) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=2: expected=0 actual=%d", get_replace_ways(2))
+      assert(get_replace_ways(3) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=3: expected=1 actual=%d", get_replace_ways(3))
+      assert(get_replace_ways(4) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=4: expected=2 actual=%d", get_replace_ways(4))
+      assert(get_replace_ways(5) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=5: expected=2 actual=%d", get_replace_ways(5))
+      assert(get_replace_ways(6) === 3.U(log2Ceil(n_ways).W), s"get_replace_way state=6: expected=3 actual=%d", get_replace_ways(6))
+      assert(get_replace_ways(7) === 3.U(log2Ceil(n_ways).W), s"get_replace_way state=7: expected=3 actual=%d", get_replace_ways(7))
+      assert(get_next_states(0)(0) === 5.U((n_ways-1).W), s"get_next_state state=0 way=0: expected=5 actual=%d", get_next_states(0)(0))
+      assert(get_next_states(0)(1) === 4.U((n_ways-1).W), s"get_next_state state=0 way=1: expected=4 actual=%d", get_next_states(0)(1))
+      assert(get_next_states(0)(2) === 2.U((n_ways-1).W), s"get_next_state state=0 way=2: expected=2 actual=%d", get_next_states(0)(2))
+      assert(get_next_states(0)(3) === 0.U((n_ways-1).W), s"get_next_state state=0 way=3: expected=0 actual=%d", get_next_states(0)(3))
+      assert(get_next_states(1)(0) === 5.U((n_ways-1).W), s"get_next_state state=1 way=0: expected=5 actual=%d", get_next_states(1)(0))
+      assert(get_next_states(1)(1) === 4.U((n_ways-1).W), s"get_next_state state=1 way=1: expected=4 actual=%d", get_next_states(1)(1))
+      assert(get_next_states(1)(2) === 3.U((n_ways-1).W), s"get_next_state state=1 way=2: expected=3 actual=%d", get_next_states(1)(2))
+      assert(get_next_states(1)(3) === 1.U((n_ways-1).W), s"get_next_state state=1 way=3: expected=1 actual=%d", get_next_states(1)(3))
+      assert(get_next_states(2)(0) === 7.U((n_ways-1).W), s"get_next_state state=2 way=0: expected=7 actual=%d", get_next_states(2)(0))
+      assert(get_next_states(2)(1) === 6.U((n_ways-1).W), s"get_next_state state=2 way=1: expected=6 actual=%d", get_next_states(2)(1))
+      assert(get_next_states(2)(2) === 2.U((n_ways-1).W), s"get_next_state state=2 way=2: expected=2 actual=%d", get_next_states(2)(2))
+      assert(get_next_states(2)(3) === 0.U((n_ways-1).W), s"get_next_state state=2 way=3: expected=0 actual=%d", get_next_states(2)(3))
+      assert(get_next_states(3)(0) === 7.U((n_ways-1).W), s"get_next_state state=3 way=0: expected=7 actual=%d", get_next_states(3)(0))
+      assert(get_next_states(3)(1) === 6.U((n_ways-1).W), s"get_next_state state=3 way=1: expected=6 actual=%d", get_next_states(3)(1))
+      assert(get_next_states(3)(2) === 3.U((n_ways-1).W), s"get_next_state state=3 way=2: expected=3 actual=%d", get_next_states(3)(2))
+      assert(get_next_states(3)(3) === 1.U((n_ways-1).W), s"get_next_state state=3 way=3: expected=1 actual=%d", get_next_states(3)(3))
+      assert(get_next_states(4)(0) === 5.U((n_ways-1).W), s"get_next_state state=4 way=0: expected=5 actual=%d", get_next_states(4)(0))
+      assert(get_next_states(4)(1) === 4.U((n_ways-1).W), s"get_next_state state=4 way=1: expected=4 actual=%d", get_next_states(4)(1))
+      assert(get_next_states(4)(2) === 2.U((n_ways-1).W), s"get_next_state state=4 way=2: expected=2 actual=%d", get_next_states(4)(2))
+      assert(get_next_states(4)(3) === 0.U((n_ways-1).W), s"get_next_state state=4 way=3: expected=0 actual=%d", get_next_states(4)(3))
+      assert(get_next_states(5)(0) === 5.U((n_ways-1).W), s"get_next_state state=5 way=0: expected=5 actual=%d", get_next_states(5)(0))
+      assert(get_next_states(5)(1) === 4.U((n_ways-1).W), s"get_next_state state=5 way=1: expected=4 actual=%d", get_next_states(5)(1))
+      assert(get_next_states(5)(2) === 3.U((n_ways-1).W), s"get_next_state state=5 way=2: expected=3 actual=%d", get_next_states(5)(2))
+      assert(get_next_states(5)(3) === 1.U((n_ways-1).W), s"get_next_state state=5 way=3: expected=1 actual=%d", get_next_states(5)(3))
+      assert(get_next_states(6)(0) === 7.U((n_ways-1).W), s"get_next_state state=6 way=0: expected=7 actual=%d", get_next_states(6)(0))
+      assert(get_next_states(6)(1) === 6.U((n_ways-1).W), s"get_next_state state=6 way=1: expected=6 actual=%d", get_next_states(6)(1))
+      assert(get_next_states(6)(2) === 2.U((n_ways-1).W), s"get_next_state state=6 way=2: expected=2 actual=%d", get_next_states(6)(2))
+      assert(get_next_states(6)(3) === 0.U((n_ways-1).W), s"get_next_state state=6 way=3: expected=0 actual=%d", get_next_states(6)(3))
+      assert(get_next_states(7)(0) === 7.U((n_ways-1).W), s"get_next_state state=7 way=0: expected=7 actual=%d", get_next_states(7)(0))
+      assert(get_next_states(7)(1) === 6.U((n_ways-1).W), s"get_next_state state=7 way=5: expected=6 actual=%d", get_next_states(7)(1))
+      assert(get_next_states(7)(2) === 3.U((n_ways-1).W), s"get_next_state state=7 way=2: expected=3 actual=%d", get_next_states(7)(2))
+      assert(get_next_states(7)(3) === 1.U((n_ways-1).W), s"get_next_state state=7 way=3: expected=1 actual=%d", get_next_states(7)(3))
     }
     case 6 => {
-      assert(get_replace_ways( 0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=00: expected=0 actual=%d", get_replace_ways( 0))
-      assert(get_replace_ways( 1) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=01: expected=4 actual=%d", get_replace_ways( 1))
-      assert(get_replace_ways( 2) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=02: expected=2 actual=%d", get_replace_ways( 2))
-      assert(get_replace_ways( 3) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=03: expected=4 actual=%d", get_replace_ways( 3))
-      assert(get_replace_ways( 4) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=04: expected=0 actual=%d", get_replace_ways( 4))
-      assert(get_replace_ways( 5) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=05: expected=4 actual=%d", get_replace_ways( 5))
-      assert(get_replace_ways( 6) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=06: expected=2 actual=%d", get_replace_ways( 6))
-      assert(get_replace_ways( 7) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=07: expected=4 actual=%d", get_replace_ways( 7))
-      assert(get_replace_ways( 8) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=08: expected=1 actual=%d", get_replace_ways( 8))
-      assert(get_replace_ways( 9) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=09: expected=4 actual=%d", get_replace_ways( 9))
-      assert(get_replace_ways(10) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=10: expected=2 actual=%d", get_replace_ways(10))
-      assert(get_replace_ways(11) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=11: expected=4 actual=%d", get_replace_ways(11))
-      assert(get_replace_ways(12) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=12: expected=1 actual=%d", get_replace_ways(12))
-      assert(get_replace_ways(13) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=13: expected=4 actual=%d", get_replace_ways(13))
-      //assert(get_replace_ways(14) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=14: expected=3 actual=%d", get_replace_ways(14))
-      assert(get_replace_ways(15) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=15: expected=4 actual=%d", get_replace_ways(15))
-      assert(get_replace_ways(16) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=16: expected=0 actual=%d", get_replace_ways(16))
-      assert(get_replace_ways(17) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=17: expected=5 actual=%d", get_replace_ways(17))
-      //assert(get_replace_ways(18) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=18: expected=2 actual=%d", get_replace_ways(18))
-      //assert(get_replace_ways(19) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=19: expected=5 actual=%d", get_replace_ways(19))
-      //assert(get_replace_ways(20) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=20: expected=0 actual=%d", get_replace_ways(20))
-      //assert(get_replace_ways(21) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=21: expected=5 actual=%d", get_replace_ways(21))
-      //assert(get_replace_ways(22) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=22: expected=2 actual=%d", get_replace_ways(22))
-      //assert(get_replace_ways(23) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=23: expected=5 actual=%d", get_replace_ways(23))
-      //assert(get_replace_ways(24) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=24: expected=1 actual=%d", get_replace_ways(24))
-      //assert(get_replace_ways(25) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=25: expected=5 actual=%d", get_replace_ways(25))
-      //assert(get_replace_ways(26) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=26: expected=2 actual=%d", get_replace_ways(26))
-      //assert(get_replace_ways(27) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=27: expected=5 actual=%d", get_replace_ways(27))
-      //assert(get_replace_ways(28) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=28: expected=1 actual=%d", get_replace_ways(28))
-      //assert(get_replace_ways(29) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=29: expected=5 actual=%d", get_replace_ways(29))
-      //assert(get_replace_ways(30) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=30: expected=3 actual=%d", get_replace_ways(30))
-      //assert(get_replace_ways(31) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=31: expected=5 actual=%d", get_replace_ways(31))
+      assert(get_replace_ways( 0) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=00: expected=0 actual=%d", get_replace_ways( 0))
+      assert(get_replace_ways( 1) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=01: expected=1 actual=%d", get_replace_ways( 1))
+      assert(get_replace_ways( 2) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=02: expected=0 actual=%d", get_replace_ways( 2))
+      assert(get_replace_ways( 3) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=03: expected=1 actual=%d", get_replace_ways( 3))
+      assert(get_replace_ways( 4) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=04: expected=2 actual=%d", get_replace_ways( 4))
+      assert(get_replace_ways( 5) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=05: expected=2 actual=%d", get_replace_ways( 5))
+      assert(get_replace_ways( 6) === 3.U(log2Ceil(n_ways).W), s"get_replace_way state=06: expected=3 actual=%d", get_replace_ways( 6))
+      assert(get_replace_ways( 7) === 3.U(log2Ceil(n_ways).W), s"get_replace_way state=07: expected=3 actual=%d", get_replace_ways( 7))
+      assert(get_replace_ways( 8) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=08: expected=0 actual=%d", get_replace_ways( 8))
+      assert(get_replace_ways( 9) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=09: expected=1 actual=%d", get_replace_ways( 9))
+      assert(get_replace_ways(10) === 0.U(log2Ceil(n_ways).W), s"get_replace_way state=10: expected=0 actual=%d", get_replace_ways(10))
+      assert(get_replace_ways(11) === 1.U(log2Ceil(n_ways).W), s"get_replace_way state=11: expected=1 actual=%d", get_replace_ways(11))
+      assert(get_replace_ways(12) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=12: expected=2 actual=%d", get_replace_ways(12))
+      assert(get_replace_ways(13) === 2.U(log2Ceil(n_ways).W), s"get_replace_way state=13: expected=2 actual=%d", get_replace_ways(13))
+      assert(get_replace_ways(14) === 3.U(log2Ceil(n_ways).W), s"get_replace_way state=14: expected=3 actual=%d", get_replace_ways(14))
+      assert(get_replace_ways(15) === 3.U(log2Ceil(n_ways).W), s"get_replace_way state=15: expected=3 actual=%d", get_replace_ways(15))
+      assert(get_replace_ways(16) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=16: expected=4 actual=%d", get_replace_ways(16))
+      assert(get_replace_ways(17) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=17: expected=4 actual=%d", get_replace_ways(17))
+      assert(get_replace_ways(18) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=18: expected=4 actual=%d", get_replace_ways(18))
+      assert(get_replace_ways(19) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=19: expected=4 actual=%d", get_replace_ways(19))
+      assert(get_replace_ways(20) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=20: expected=4 actual=%d", get_replace_ways(20))
+      assert(get_replace_ways(21) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=21: expected=4 actual=%d", get_replace_ways(21))
+      assert(get_replace_ways(22) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=22: expected=4 actual=%d", get_replace_ways(22))
+      assert(get_replace_ways(23) === 4.U(log2Ceil(n_ways).W), s"get_replace_way state=23: expected=4 actual=%d", get_replace_ways(23))
+      assert(get_replace_ways(24) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=24: expected=5 actual=%d", get_replace_ways(24))
+      assert(get_replace_ways(25) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=25: expected=5 actual=%d", get_replace_ways(25))
+      assert(get_replace_ways(26) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=26: expected=5 actual=%d", get_replace_ways(26))
+      assert(get_replace_ways(27) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=27: expected=5 actual=%d", get_replace_ways(27))
+      assert(get_replace_ways(28) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=28: expected=5 actual=%d", get_replace_ways(28))
+      assert(get_replace_ways(29) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=29: expected=5 actual=%d", get_replace_ways(29))
+      assert(get_replace_ways(30) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=30: expected=5 actual=%d", get_replace_ways(30))
+      assert(get_replace_ways(31) === 5.U(log2Ceil(n_ways).W), s"get_replace_way state=31: expected=5 actual=%d", get_replace_ways(31))
     }
     case _ => throw new IllegalArgumentException(s"no test pattern found for n_ways=$n_ways")
   }

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -39,6 +39,10 @@ class SeqRandom(n_ways: Int) extends SeqReplacementPolicy {
 
 class PseudoLRU(n: Int)
 {
+  //example bits storage format for 4-way PLRU:
+  // bit[2] = way 3 older than way 2
+  // bit[1] = way 1 older than way 0
+  // bit[0] = ways 3-2 older than ways 1-0
   private val state_reg = Reg(UInt(width = n-1))
   def access(way: UInt) {
     state_reg := get_next_state(state_reg,way)
@@ -86,4 +90,73 @@ class SeqPLRU(n_sets: Int, n_ways: Int) extends SeqReplacementPolicy {
   }
 
   def way = plru_way
+}
+
+/** Synthesizeable unit tests */
+import freechips.rocketchip.unittest._
+
+class PLRUTest(n_ways: Int, timeout: Int = 500) extends UnitTest(timeout) {
+  val plru = new PseudoLRU(n_ways)
+
+  // step
+  io.finished := RegNext(true.B, Bool(false))
+
+  val get_replace_ways = (0 until (1 << (n_ways-1))).map(state =>
+    plru.get_replace_way(state = UInt(state, width=n_ways-1)))
+  val get_next_states  = (0 until (1 << (n_ways-1))).map(state => (0 until n_ways).map(way =>
+    plru.get_next_state (state = UInt(state, width=n_ways-1), way = UInt(way, width=log2Ceil(n_ways)))))
+
+  n_ways match {
+    case 2 => {
+      assert(get_replace_ways(0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
+      assert(get_replace_ways(1) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=1: expected=1 actual=%d", get_replace_ways(1))
+      assert(get_next_states(0)(0) === UInt(1, width=n_ways-1), s"get_next_state state=0 way=0: expected=1 actual=%d", get_next_states(0)(0))
+      assert(get_next_states(0)(1) === UInt(0, width=n_ways-1), s"get_next_state state=0 way=1: expected=0 actual=%d", get_next_states(0)(1))
+      assert(get_next_states(1)(0) === UInt(1, width=n_ways-1), s"get_next_state state=1 way=0: expected=1 actual=%d", get_next_states(1)(0))
+      assert(get_next_states(1)(1) === UInt(0, width=n_ways-1), s"get_next_state state=1 way=1: expected=0 actual=%d", get_next_states(1)(1))
+    }
+    case 4 => {
+      assert(get_replace_ways(0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
+      assert(get_replace_ways(1) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=1: expected=2 actual=%d", get_replace_ways(1))
+      assert(get_replace_ways(2) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=2: expected=1 actual=%d", get_replace_ways(2))
+      assert(get_replace_ways(3) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=3: expected=2 actual=%d", get_replace_ways(3))
+      assert(get_replace_ways(4) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=4: expected=0 actual=%d", get_replace_ways(4))
+      assert(get_replace_ways(5) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=5: expected=3 actual=%d", get_replace_ways(5))
+      assert(get_replace_ways(6) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=6: expected=1 actual=%d", get_replace_ways(6))
+      assert(get_replace_ways(7) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=7: expected=3 actual=%d", get_replace_ways(7))
+      assert(get_next_states(0)(0) === UInt(3, width=n_ways-1), s"get_next_state state=0 way=0: expected=3 actual=%d", get_next_states(0)(0))
+      assert(get_next_states(0)(1) === UInt(1, width=n_ways-1), s"get_next_state state=0 way=1: expected=1 actual=%d", get_next_states(0)(1))
+      assert(get_next_states(0)(2) === UInt(4, width=n_ways-1), s"get_next_state state=0 way=2: expected=4 actual=%d", get_next_states(0)(2))
+      assert(get_next_states(0)(3) === UInt(0, width=n_ways-1), s"get_next_state state=0 way=3: expected=0 actual=%d", get_next_states(0)(3))
+      assert(get_next_states(1)(0) === UInt(3, width=n_ways-1), s"get_next_state state=1 way=0: expected=3 actual=%d", get_next_states(1)(0))
+      assert(get_next_states(1)(1) === UInt(1, width=n_ways-1), s"get_next_state state=1 way=1: expected=1 actual=%d", get_next_states(1)(1))
+      assert(get_next_states(1)(2) === UInt(4, width=n_ways-1), s"get_next_state state=1 way=2: expected=4 actual=%d", get_next_states(1)(2))
+      assert(get_next_states(1)(3) === UInt(0, width=n_ways-1), s"get_next_state state=1 way=3: expected=0 actual=%d", get_next_states(1)(3))
+      assert(get_next_states(2)(0) === UInt(3, width=n_ways-1), s"get_next_state state=2 way=0: expected=3 actual=%d", get_next_states(2)(0))
+      assert(get_next_states(2)(1) === UInt(1, width=n_ways-1), s"get_next_state state=2 way=1: expected=1 actual=%d", get_next_states(2)(1))
+      assert(get_next_states(2)(2) === UInt(6, width=n_ways-1), s"get_next_state state=2 way=2: expected=6 actual=%d", get_next_states(2)(2))
+      assert(get_next_states(2)(3) === UInt(2, width=n_ways-1), s"get_next_state state=2 way=3: expected=2 actual=%d", get_next_states(2)(3))
+      assert(get_next_states(3)(0) === UInt(3, width=n_ways-1), s"get_next_state state=3 way=0: expected=3 actual=%d", get_next_states(3)(0))
+      assert(get_next_states(3)(1) === UInt(1, width=n_ways-1), s"get_next_state state=3 way=1: expected=1 actual=%d", get_next_states(3)(1))
+      assert(get_next_states(3)(2) === UInt(6, width=n_ways-1), s"get_next_state state=3 way=2: expected=6 actual=%d", get_next_states(3)(2))
+      assert(get_next_states(3)(3) === UInt(2, width=n_ways-1), s"get_next_state state=3 way=3: expected=2 actual=%d", get_next_states(3)(3))
+      assert(get_next_states(4)(0) === UInt(7, width=n_ways-1), s"get_next_state state=4 way=0: expected=7 actual=%d", get_next_states(4)(0))
+      assert(get_next_states(4)(1) === UInt(5, width=n_ways-1), s"get_next_state state=4 way=1: expected=5 actual=%d", get_next_states(4)(1))
+      assert(get_next_states(4)(2) === UInt(4, width=n_ways-1), s"get_next_state state=4 way=2: expected=4 actual=%d", get_next_states(4)(2))
+      assert(get_next_states(4)(3) === UInt(0, width=n_ways-1), s"get_next_state state=4 way=3: expected=0 actual=%d", get_next_states(4)(3))
+      assert(get_next_states(5)(0) === UInt(7, width=n_ways-1), s"get_next_state state=5 way=0: expected=7 actual=%d", get_next_states(5)(0))
+      assert(get_next_states(5)(1) === UInt(5, width=n_ways-1), s"get_next_state state=5 way=1: expected=5 actual=%d", get_next_states(5)(1))
+      assert(get_next_states(5)(2) === UInt(4, width=n_ways-1), s"get_next_state state=5 way=2: expected=4 actual=%d", get_next_states(5)(2))
+      assert(get_next_states(5)(3) === UInt(0, width=n_ways-1), s"get_next_state state=5 way=3: expected=0 actual=%d", get_next_states(5)(3))
+      assert(get_next_states(6)(0) === UInt(7, width=n_ways-1), s"get_next_state state=6 way=0: expected=7 actual=%d", get_next_states(6)(0))
+      assert(get_next_states(6)(1) === UInt(5, width=n_ways-1), s"get_next_state state=6 way=1: expected=5 actual=%d", get_next_states(6)(1))
+      assert(get_next_states(6)(2) === UInt(6, width=n_ways-1), s"get_next_state state=6 way=2: expected=6 actual=%d", get_next_states(6)(2))
+      assert(get_next_states(6)(3) === UInt(2, width=n_ways-1), s"get_next_state state=6 way=3: expected=2 actual=%d", get_next_states(6)(3))
+      assert(get_next_states(7)(0) === UInt(7, width=n_ways-1), s"get_next_state state=7 way=0: expected=7 actual=%d", get_next_states(7)(0))
+      assert(get_next_states(7)(1) === UInt(5, width=n_ways-1), s"get_next_state state=7 way=5: expected=1 actual=%d", get_next_states(7)(1))
+      assert(get_next_states(7)(2) === UInt(6, width=n_ways-1), s"get_next_state state=7 way=2: expected=6 actual=%d", get_next_states(7)(2))
+      assert(get_next_states(7)(3) === UInt(2, width=n_ways-1), s"get_next_state state=7 way=3: expected=2 actual=%d", get_next_states(7)(3))
+    }
+    case _ => throw new IllegalArgumentException(s"no test pattern found for n_ways=$n_ways")
+  }
 }

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -115,6 +115,24 @@ class PLRUTest(n_ways: Int, timeout: Int = 500) extends UnitTest(timeout) {
       assert(get_next_states(1)(0) === UInt(1, width=n_ways-1), s"get_next_state state=1 way=0: expected=1 actual=%d", get_next_states(1)(0))
       assert(get_next_states(1)(1) === UInt(0, width=n_ways-1), s"get_next_state state=1 way=1: expected=0 actual=%d", get_next_states(1)(1))
     }
+    case 3 => {
+      assert(get_replace_ways(0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
+      assert(get_replace_ways(1) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=1: expected=2 actual=%d", get_replace_ways(1))
+      assert(get_replace_ways(2) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=2: expected=1 actual=%d", get_replace_ways(2))
+      assert(get_replace_ways(3) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=3: expected=2 actual=%d", get_replace_ways(3))
+      assert(get_next_states(0)(0) === UInt(3, width=n_ways-1), s"get_next_state state=0 way=0: expected=3 actual=%d", get_next_states(0)(0))
+      assert(get_next_states(0)(1) === UInt(1, width=n_ways-1), s"get_next_state state=0 way=1: expected=1 actual=%d", get_next_states(0)(1))
+      assert(get_next_states(0)(2) === UInt(0, width=n_ways-1), s"get_next_state state=0 way=2: expected=0 actual=%d", get_next_states(0)(2))
+      assert(get_next_states(1)(0) === UInt(3, width=n_ways-1), s"get_next_state state=1 way=0: expected=3 actual=%d", get_next_states(1)(0))
+      assert(get_next_states(1)(1) === UInt(1, width=n_ways-1), s"get_next_state state=1 way=1: expected=1 actual=%d", get_next_states(1)(1))
+      assert(get_next_states(1)(2) === UInt(0, width=n_ways-1), s"get_next_state state=1 way=2: expected=0 actual=%d", get_next_states(1)(2))
+      assert(get_next_states(2)(0) === UInt(3, width=n_ways-1), s"get_next_state state=2 way=0: expected=3 actual=%d", get_next_states(2)(0))
+      assert(get_next_states(2)(1) === UInt(1, width=n_ways-1), s"get_next_state state=2 way=1: expected=1 actual=%d", get_next_states(2)(1))
+      assert(get_next_states(2)(2) === UInt(2, width=n_ways-1), s"get_next_state state=2 way=2: expected=2 actual=%d", get_next_states(2)(2))
+      assert(get_next_states(3)(0) === UInt(3, width=n_ways-1), s"get_next_state state=3 way=0: expected=3 actual=%d", get_next_states(3)(0))
+      assert(get_next_states(3)(1) === UInt(1, width=n_ways-1), s"get_next_state state=3 way=1: expected=1 actual=%d", get_next_states(3)(1))
+      assert(get_next_states(3)(2) === UInt(2, width=n_ways-1), s"get_next_state state=3 way=2: expected=2 actual=%d", get_next_states(3)(2))
+    }
     case 4 => {
       assert(get_replace_ways(0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=0: expected=0 actual=%d", get_replace_ways(0))
       assert(get_replace_ways(1) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=1: expected=2 actual=%d", get_replace_ways(1))

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -99,7 +99,7 @@ class PLRUTest(n_ways: Int, timeout: Int = 500) extends UnitTest(timeout) {
   val plru = new PseudoLRU(n_ways)
 
   // step
-  io.finished := RegNext(true.B, Bool(false))
+  io.finished := RegNext(Bool(true), Bool(false))
 
   val get_replace_ways = (0 until (1 << (n_ways-1))).map(state =>
     plru.get_replace_way(state = UInt(state, width=n_ways-1)))
@@ -190,24 +190,24 @@ class PLRUTest(n_ways: Int, timeout: Int = 500) extends UnitTest(timeout) {
       assert(get_replace_ways(11) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=11: expected=4 actual=%d", get_replace_ways(11))
       assert(get_replace_ways(12) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=12: expected=1 actual=%d", get_replace_ways(12))
       assert(get_replace_ways(13) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=13: expected=4 actual=%d", get_replace_ways(13))
-      assert(get_replace_ways(14) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=14: expected=2 actual=%d", get_replace_ways(14))//3
+      //assert(get_replace_ways(14) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=14: expected=3 actual=%d", get_replace_ways(14))
       assert(get_replace_ways(15) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=15: expected=4 actual=%d", get_replace_ways(15))
       assert(get_replace_ways(16) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=16: expected=0 actual=%d", get_replace_ways(16))
-      assert(get_replace_ways(17) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=17: expected=4 actual=%d", get_replace_ways(17))//5
-      assert(get_replace_ways(18) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=18: expected=3 actual=%d", get_replace_ways(18))//2
-      assert(get_replace_ways(19) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=19: expected=4 actual=%d", get_replace_ways(19))//5
-      assert(get_replace_ways(20) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=20: expected=0 actual=%d", get_replace_ways(20))
-      assert(get_replace_ways(21) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=21: expected=4 actual=%d", get_replace_ways(21))
-      assert(get_replace_ways(22) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=22: expected=3 actual=%d", get_replace_ways(22))//2
-      assert(get_replace_ways(23) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=23: expected=4 actual=%d", get_replace_ways(23))//5
-      assert(get_replace_ways(24) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=24: expected=1 actual=%d", get_replace_ways(24))
-      assert(get_replace_ways(25) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=25: expected=4 actual=%d", get_replace_ways(25))//5
-      assert(get_replace_ways(26) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=26: expected=3 actual=%d", get_replace_ways(26))//2
-      assert(get_replace_ways(27) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=27: expected=4 actual=%d", get_replace_ways(27))//5
-      assert(get_replace_ways(28) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=28: expected=1 actual=%d", get_replace_ways(28))
-      assert(get_replace_ways(29) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=29: expected=4 actual=%d", get_replace_ways(29))//5
-      assert(get_replace_ways(30) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=30: expected=3 actual=%d", get_replace_ways(30))//2
-      assert(get_replace_ways(31) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=31: expected=4 actual=%d", get_replace_ways(31))//5
+      assert(get_replace_ways(17) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=17: expected=5 actual=%d", get_replace_ways(17))
+      //assert(get_replace_ways(18) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=18: expected=2 actual=%d", get_replace_ways(18))
+      //assert(get_replace_ways(19) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=19: expected=5 actual=%d", get_replace_ways(19))
+      //assert(get_replace_ways(20) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=20: expected=0 actual=%d", get_replace_ways(20))
+      //assert(get_replace_ways(21) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=21: expected=5 actual=%d", get_replace_ways(21))
+      //assert(get_replace_ways(22) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=22: expected=2 actual=%d", get_replace_ways(22))
+      //assert(get_replace_ways(23) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=23: expected=5 actual=%d", get_replace_ways(23))
+      //assert(get_replace_ways(24) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=24: expected=1 actual=%d", get_replace_ways(24))
+      //assert(get_replace_ways(25) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=25: expected=5 actual=%d", get_replace_ways(25))
+      //assert(get_replace_ways(26) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=26: expected=2 actual=%d", get_replace_ways(26))
+      //assert(get_replace_ways(27) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=27: expected=5 actual=%d", get_replace_ways(27))
+      //assert(get_replace_ways(28) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=28: expected=1 actual=%d", get_replace_ways(28))
+      //assert(get_replace_ways(29) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=29: expected=5 actual=%d", get_replace_ways(29))
+      //assert(get_replace_ways(30) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=30: expected=3 actual=%d", get_replace_ways(30))
+      //assert(get_replace_ways(31) === UInt(5, width=log2Ceil(n_ways)), s"get_replace_way state=31: expected=5 actual=%d", get_replace_ways(31))
     }
     case _ => throw new IllegalArgumentException(s"no test pattern found for n_ways=$n_ways")
   }

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -175,6 +175,40 @@ class PLRUTest(n_ways: Int, timeout: Int = 500) extends UnitTest(timeout) {
       assert(get_next_states(7)(2) === UInt(6, width=n_ways-1), s"get_next_state state=7 way=2: expected=6 actual=%d", get_next_states(7)(2))
       assert(get_next_states(7)(3) === UInt(2, width=n_ways-1), s"get_next_state state=7 way=3: expected=2 actual=%d", get_next_states(7)(3))
     }
+    case 6 => {
+      assert(get_replace_ways( 0) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=00: expected=0 actual=%d", get_replace_ways( 0))
+      assert(get_replace_ways( 1) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=01: expected=4 actual=%d", get_replace_ways( 1))
+      assert(get_replace_ways( 2) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=02: expected=2 actual=%d", get_replace_ways( 2))
+      assert(get_replace_ways( 3) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=03: expected=4 actual=%d", get_replace_ways( 3))
+      assert(get_replace_ways( 4) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=04: expected=0 actual=%d", get_replace_ways( 4))
+      assert(get_replace_ways( 5) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=05: expected=4 actual=%d", get_replace_ways( 5))
+      assert(get_replace_ways( 6) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=06: expected=2 actual=%d", get_replace_ways( 6))
+      assert(get_replace_ways( 7) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=07: expected=4 actual=%d", get_replace_ways( 7))
+      assert(get_replace_ways( 8) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=08: expected=1 actual=%d", get_replace_ways( 8))
+      assert(get_replace_ways( 9) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=09: expected=4 actual=%d", get_replace_ways( 9))
+      assert(get_replace_ways(10) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=10: expected=2 actual=%d", get_replace_ways(10))
+      assert(get_replace_ways(11) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=11: expected=4 actual=%d", get_replace_ways(11))
+      assert(get_replace_ways(12) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=12: expected=1 actual=%d", get_replace_ways(12))
+      assert(get_replace_ways(13) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=13: expected=4 actual=%d", get_replace_ways(13))
+      assert(get_replace_ways(14) === UInt(2, width=log2Ceil(n_ways)), s"get_replace_way state=14: expected=2 actual=%d", get_replace_ways(14))//3
+      assert(get_replace_ways(15) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=15: expected=4 actual=%d", get_replace_ways(15))
+      assert(get_replace_ways(16) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=16: expected=0 actual=%d", get_replace_ways(16))
+      assert(get_replace_ways(17) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=17: expected=4 actual=%d", get_replace_ways(17))//5
+      assert(get_replace_ways(18) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=18: expected=3 actual=%d", get_replace_ways(18))//2
+      assert(get_replace_ways(19) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=19: expected=4 actual=%d", get_replace_ways(19))//5
+      assert(get_replace_ways(20) === UInt(0, width=log2Ceil(n_ways)), s"get_replace_way state=20: expected=0 actual=%d", get_replace_ways(20))
+      assert(get_replace_ways(21) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=21: expected=4 actual=%d", get_replace_ways(21))
+      assert(get_replace_ways(22) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=22: expected=3 actual=%d", get_replace_ways(22))//2
+      assert(get_replace_ways(23) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=23: expected=4 actual=%d", get_replace_ways(23))//5
+      assert(get_replace_ways(24) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=24: expected=1 actual=%d", get_replace_ways(24))
+      assert(get_replace_ways(25) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=25: expected=4 actual=%d", get_replace_ways(25))//5
+      assert(get_replace_ways(26) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=26: expected=3 actual=%d", get_replace_ways(26))//2
+      assert(get_replace_ways(27) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=27: expected=4 actual=%d", get_replace_ways(27))//5
+      assert(get_replace_ways(28) === UInt(1, width=log2Ceil(n_ways)), s"get_replace_way state=28: expected=1 actual=%d", get_replace_ways(28))
+      assert(get_replace_ways(29) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=29: expected=4 actual=%d", get_replace_ways(29))//5
+      assert(get_replace_ways(30) === UInt(3, width=log2Ceil(n_ways)), s"get_replace_way state=30: expected=3 actual=%d", get_replace_ways(30))//2
+      assert(get_replace_ways(31) === UInt(4, width=log2Ceil(n_ways)), s"get_replace_way state=31: expected=4 actual=%d", get_replace_ways(31))//5
+    }
     case _ => throw new IllegalArgumentException(s"no test pattern found for n_ways=$n_ways")
   }
 }


### PR DESCRIPTION
**Related issue**: 
**Type of change**: performance enhancement
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation

**Release Notes**
- Formerly, the PseudoLRU algorithm would not replace all entries in a non-power-of-2 ways cache (or TLB).  For example, PLRU with 6 ways results in way 5 (the sixth way) never being replaced unless it is otherwise invalidated.  However, the way index is always "in bounds", so this is purely a performance bug, not a functional bug.
- The new PseudoLRU algorithm is more verbose Chisel code, with extra if-statements to recursively descend an un-balanced binary tree.
- I wrote tests to exercise the old and the new PLRU behavior.  @hcook do I need to do anything else to include these in CI regressions?
- While I was at it, I upgraded Replacement.scala to Chisel3.
- I also added TrueLRU as an option for a replacement policy, based on code we had outside Rocket-chip.
- Lastly, I exposed some more internals of the ReplacementPolicy classes as public function defs to use outside Rocket-chip.