### PR TITLE
OMMemoryMap: register map can only go to 1 memory region

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -144,12 +144,15 @@ object DiplomaticObjectModelAddressing {
   }
 
   def getOMMemoryRegions(name: String, resourceBindings: ResourceBindings, omRegMap: Option[OMRegisterMap] = None): Seq[OMMemoryRegion]= {
-    resourceBindings.map.collect {
+    val result = resourceBindings.map.collect {
       case (x: String, seq: Seq[Binding]) if (DiplomacyUtils.regFilter(x) || DiplomacyUtils.rangeFilter(x)) =>
         seq.map {
           case Binding(device: Option[Device], value: ResourceValue) => omMemoryRegion(name, DiplomacyUtils.regName(x).getOrElse(""), value, omRegMap)
         }
     }.flatten.toSeq
+    require(omRegMap.isEmpty || (result.size == 1),
+      s"If Register Map is specified, there must be exactly one Memory Region, not ${result.size}")
+    result
   }
 
   def getOMPortMemoryRegions(name: String, resourceBindings: ResourceBindings, omRegMap: Option[OMRegisterMap] = None): Seq[OMMemoryRegion]= {


### PR DESCRIPTION
 OM Memory Map: prohibit passing a register map if there is not exactly 1 matching memory region

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Add requirement to ensure that `getOMMemoryRegions` is called correctly
