### PR TITLE
BundleBridge enhancements

### DIFF
--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -43,6 +43,7 @@ case class BundleBridgeSink[T <: Data](genOpt: Option[() => T] = None)
   def bundle: T = in(0)._1
 
   def makeIO()(implicit valName: ValName): T = makeIOs()(valName).head
+  def makeIO(name: String): T = makeIOs()(ValName(name)).head
 }
 
 case class BundleBridgeSource[T <: Data](genOpt: Option[() => T] = None)(implicit valName: ValName) extends SourceNode(new BundleBridgeImp[T])(Seq(BundleBridgeParams(genOpt)))
@@ -50,6 +51,7 @@ case class BundleBridgeSource[T <: Data](genOpt: Option[() => T] = None)(implici
   def bundle: T = out(0)._1
 
   def makeIO()(implicit valName: ValName): T = makeIOs()(valName).head
+  def makeIO(name: String): T = makeIOs()(ValName(name)).head
 
   private var doneSink = false
   def makeSink()(implicit p: Parameters) = {

--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -78,6 +78,9 @@ class BundleBridgeNexus[T <: Data](
 
     val broadcast: T = inputFn(inputs)
     val outputs: Seq[T] = outputFn(broadcast, node.out.size)
+    node.out.map(_._1).foreach { o => require(DataMirror.checkTypeEquivalence(o, outputs.head),
+      s"BundleBridgeNexus requires all outputs have equivalent Chisel Data types, but got\n$o\nvs\n${outputs.head}")
+    }
     require(outputs.size == node.out.size,
       s"BundleBridgeNexus outputFn must generate one output wire per edgeOut, but got ${outputs.size} vs ${node.out.size}")
 

--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -93,7 +93,7 @@ class BundleBridgeNexus[T <: Data](
     val inputs: Seq[T] = defaultWireOpt.toList ++ node.in.map(_._1)
     require(inputs.size >= 1, "BundleBridgeNexus requires at least one input or default.")
     inputs.foreach { i => require(DataMirror.checkTypeEquivalence(i, inputs.head),
-      s"BundleBridgeNexus requires all inputs have equivalent Chisel Data types, but got\n$i\nvs\n${inputs.head}")
+      s"${node.context} requires all inputs have equivalent Chisel Data types, but got\n$i\nvs\n${inputs.head}")
     }
     def getElements(x: Data): Seq[Element] = x match {
       case e: Element => Seq(e)
@@ -102,7 +102,7 @@ class BundleBridgeNexus[T <: Data](
     inputs.flatMap(getElements).foreach { elt => DataMirror.directionOf(elt) match {
       case ActualDirection.Output => ()
       case ActualDirection.Unspecified => ()
-      case _ => require(false, "BundleBridgeNexus can only be used with Output-directed Bundles")
+      case _ => require(false, s"${node.context} can only be used with Output-directed Bundles")
     } }
 
     val broadcast: T = inputFn(inputs)
@@ -111,7 +111,7 @@ class BundleBridgeNexus[T <: Data](
       s"BundleBridgeNexus requires all outputs have equivalent Chisel Data types, but got\n$o\nvs\n${outputs.head}")
     }
     require(outputs.size == node.out.size,
-      s"BundleBridgeNexus outputFn must generate one output wire per edgeOut, but got ${outputs.size} vs ${node.out.size}")
+      s"${node.context} outputFn must generate one output wire per edgeOut, but got ${outputs.size} vs ${node.out.size}")
 
     node.out.zip(outputs).foreach { case ((out, _), bcast) => out := bcast }
   }

--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -91,15 +91,21 @@ object BundleBridgeNexus {
     if (registered) RegNext(seq.head) else seq.head
   }
 
+  def orReduction[T <: Data](registered: Boolean)(seq: Seq[T]): T = {
+    val x = seq.reduce((a,b) => (a.asUInt | b.asUInt).asTypeOf(seq.head))
+    if (registered) RegNext(x) else x
+  }
+
   def fillN[T <: Data](registered: Boolean)(x: T, n: Int): Seq[T] = Seq.fill(n) {
     if (registered) RegNext(x) else x
   }
 
   def apply[T <: Data](
-    inputFn: Seq[T] => T = requireOne[T](false) _,
+    inputFn: Seq[T] => T = orReduction[T](false) _,
     outputFn: (T, Int) => Seq[T] = fillN[T](false) _,
+    default: Option[() => T] = None
   )(implicit p: Parameters, valName: ValName): BundleBridgeNexusNode[T] = {
-    val broadcast = LazyModule(new BundleBridgeNexus[T](inputFn, outputFn))
+    val broadcast = LazyModule(new BundleBridgeNexus[T](inputFn, outputFn, default))
     broadcast.node
   }
 }
@@ -115,4 +121,3 @@ object BundleBroadcast {
       outputFn = BundleBridgeNexus.fillN[T](registered) _)
   }
 }
-

--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -114,10 +114,11 @@ object BundleBroadcast {
   def apply[T <: Data](
     name: Option[String] = None,
     registered: Boolean = false
-  )(implicit p: Parameters): BundleBridgeNexusNode[T] = {
-    implicit val valName = ValName(name.getOrElse("broadcast"))
+  )(implicit p: Parameters, valName: ValName): BundleBridgeNexusNode[T] = {
+    val finalName = name.map(ValName(_)).getOrElse(valName)
     BundleBridgeNexus.apply[T](
       inputFn = BundleBridgeNexus.requireOne[T](registered) _,
-      outputFn = BundleBridgeNexus.fillN[T](registered) _)
+      outputFn = BundleBridgeNexus.fillN[T](registered) _)(
+      p, finalName)
   }
 }

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -66,7 +66,7 @@ package object diplomacy
 
   implicit def noCrossing(value: NoCrossing.type): ClockCrossingType = SynchronousCrossing(BufferParams.none)
 
-  type BundleBridgeInwardNode[T <: Data] = InwardNodeHandle[BundleBridgeParams[T], BundleBridgeNull, BundleBridgeParams[T], T]
-  type BundleBridgeOutwardNode[T <: Data] = OutwardNodeHandle[BundleBridgeParams[T], BundleBridgeNull, BundleBridgeParams[T], T]
-  type BundleBridgeNode[T <: Data] = NodeHandle[BundleBridgeParams[T], BundleBridgeNull, BundleBridgeParams[T], T, BundleBridgeParams[T], BundleBridgeNull, BundleBridgeParams[T], T]
+  type BundleBridgeInwardNode[T <: Data] = InwardNodeHandle[BundleBridgeParams[T], BundleBridgeParams[T], BundleBridgeEdgeParams[T], T]
+  type BundleBridgeOutwardNode[T <: Data] = OutwardNodeHandle[BundleBridgeParams[T], BundleBridgeParams[T], BundleBridgeEdgeParams[T], T]
+  type BundleBridgeNode[T <: Data] = NodeHandle[BundleBridgeParams[T], BundleBridgeParams[T], BundleBridgeEdgeParams[T], T, BundleBridgeParams[T], BundleBridgeParams[T], BundleBridgeEdgeParams[T], T]
 }

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -89,7 +89,7 @@ class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
   }
 
   val hartPrefixes = hartPrefixNode.map { hpn => Seq.fill(tiles.size) {
-   val hps = BundleBridgeSink[UInt]
+   val hps = BundleBridgeSink[UInt]()
    hps := hpn
    hps
   } }.getOrElse(Nil)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -178,14 +178,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   traceNode := traceSourceNode
 
   // Trace sideband signals into core
-  val traceAuxNode = BundleBridgeNexus[TraceAux](
-    inputFn = (seq: Seq[TraceAux]) => {
-      val aux = Wire(new TraceAux)
-      aux.stall := seq.map(_.stall).foldLeft(false.B)(_||_)
-      aux.enable := seq.map(_.enable).foldLeft(false.B)(_||_)
-      aux
-    }
-  )
+  val traceAuxNode = BundleBridgeNexus[TraceAux]()
   val traceAuxSinkNode = BundleBridgeSink[TraceAux]()
   val traceAuxDefaultNode = BundleBridgeSource(() => new TraceAux)
   traceAuxSinkNode := traceAuxNode := traceAuxDefaultNode


### PR DESCRIPTION
This PR adds two new capabilities to the diplomatic BundleBridge API.

`BundleBroadcast` is generalized into a `BundleBridgeNexus` that now can accept multiple inputs and a user-defined function for reducing the inputs into a single wire value that is to be broadcast, as well as a user-defined function for broadcasting that value.
- the confusingly named `BundleBridgeNexus` case class is renamed to `BundleBridgeNexusNode`
- `BundleBridgeNexus` is now the base class of the implementation of the reduction and broadcast wiring. It defaults to or-reducing its inputs and broadcasting identical copies of the reduction.
- `BundleBridgeNexus` can also be supplied a default wire value in cases where there are no input edges. This value is treated as an input by `inputFn`.
- aiding backwards compatibility,`BundleBridgeNexus.apply` produces a `BundleBridgeNexusNode`
- `BundleBroadcast.appy` is now just a factory of `BundleBridgeNexus` that supplies an `inputFn` that `require`s that only a single input edge be present
- `object BundleBridgeNexus` supplies some example input and output functions, including ones that insert timing closure registers on either input or output sides.

`BundleBridgeSink` is enhanced to also be able to optionally supply a `gen` function for producing bundles in the graph. If both source and sink supply gen functions, they must pass
`chisel3.DataMirror.checkTypeEquivalence`. If only sources or sinks supply a `gen` function, it is the one used. Neither supplying the function throws an exception. `BundleBridgeNexus` checks the type equivalence of all input and output edges.

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation