### PR TITLE
AddressSet.unify: fix reduction bug

### DIFF
--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -221,7 +221,7 @@ object AddressSet
 
   def unify(seq: Seq[AddressSet], bit: BigInt): Seq[AddressSet] = {
     // Pair terms up by ignoring 'bit'
-    seq.groupBy(x => x.copy(base = x.base & ~bit)).map { case (key, seq) =>
+    seq.distinct.groupBy(x => x.copy(base = x.base & ~bit)).map { case (key, seq) =>
       if (seq.size == 1) {
         seq.head // singleton -> unaffected
       } else {


### PR DESCRIPTION
If AddressSet.unify is ever passed a Seq with a duplicated AddressSet, it
will incorrectly widen that AddressSet.  This can happen even if you called
.distinct before calling AddressSet.unify, because unification can merge two
AddressSets into a new AddressSet which collides with a pre-existing
overlap/duplicate.

**Type of change**: bug report
**Impact**: no functional change
**Development Phase**: implementation

**Release Notes**
Fixed a very bad bug introduced in 63becef3ec369b569254378c5fc5b6be910b7874 on May 11.