### PR TITLE
Standardize Tile Instantiation and Attachment

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
@@ -36,7 +36,7 @@ object LogicalModuleTree {
 
   def rootLogicalTreeNode: LogicalTreeNode = {
     val roots = tree.collect { case (k, _) if !tree.exists(_._2.contains(k)) => k }
-    assert(roots.size == 1, "Logical Tree contains more than one root.")
+    require(roots.size == 1, s"Logical Tree contains more than one root:\n$roots")
     roots.head
   }
 

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -5,36 +5,56 @@ package freechips.rocketchip.groundtest
 
 import Chisel._
 import freechips.rocketchip.config.Config
+import freechips.rocketchip.devices.tilelink.{CLINTKey, PLICKey}
+import freechips.rocketchip.devices.debug.{DebugModuleKey}
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.system.BaseConfig
 import freechips.rocketchip.rocket.{DCacheParams}
-import freechips.rocketchip.tile.{MaxHartIdBits, XLen}
+import freechips.rocketchip.tile.{XLen}
 
 /** Actual testing target Configs */
 
-class TraceGenConfig extends Config(new WithTraceGen(List.fill(2){ DCacheParams(nSets = 16, nWays = 1) }) ++ new BaseConfig)
+class TraceGenConfig extends Config(
+  new WithTraceGen(List.fill(2){ DCacheParams(nSets = 16, nWays = 1) }) ++
+  new GroundTestBaseConfig
+)
 
-class TraceGenBufferlessConfig extends Config(new WithBufferlessBroadcastHub ++ new TraceGenConfig)
+class TraceGenBufferlessConfig extends Config(
+  new WithBufferlessBroadcastHub ++
+  new TraceGenConfig
+)
 
 /* Composable Configs to set individual parameters */
 
-class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192) extends Config((site, here, up) => {
-  case GroundTestTilesKey => params.map { dcp => TraceGenParams(
-    dcache = Some(dcp),
-    wordBits = site(XLen),
-    addrBits = 32,
-    addrBag = {
-      val nSets = dcp.nSets
-      val nWays = dcp.nWays
-      val blockOffset = site(SystemBusKey).blockOffset
-      val nBeats = site(SystemBusKey).blockBeats
-      List.tabulate(nWays) { i =>
-        Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
-      }.flatten
-    },
-    maxRequests = nReqs,
-    memStart = site(ExtMem).get.master.base,
-    numGens = params.size)
-  }
-  case MaxHartIdBits => log2Up(params.size)
+class GroundTestBaseConfig extends Config(
+  new BaseConfig().alter((site,here,up) => {
+    case DebugModuleKey => None
+    case CLINTKey => None
+    case PLICKey => None
+  })
+)
+
+class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192, idOffset: Int = 0) extends Config((site, here, up) => {
+  case TilesLocated(InSubsystem) => params.zipWithIndex.map { case (dcp, i) =>
+    TraceGenTileAttachParams(
+      tileParams = TraceGenParams(
+        hartId = i + idOffset,
+        dcache = Some(dcp),
+        wordBits = site(XLen),
+        addrBits = 32,
+        addrBag = {
+          val nSets = dcp.nSets
+          val nWays = dcp.nWays
+          val blockOffset = site(SystemBusKey).blockOffset
+          val nBeats = site(SystemBusKey).blockBeats
+          List.tabulate(nWays) { i =>
+            Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
+          }.flatten
+        },
+        maxRequests = nReqs,
+        memStart = site(ExtMem).get.master.base,
+        numGens = params.size),
+      crossingParams = RocketCrossingParams()
+    )
+  } ++ up(TilesLocated(InSubsystem), site)
 })

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -34,30 +34,38 @@ class GroundTestBaseConfig extends Config(
   })
 )
 
-class WithTraceGen(n: Int = 2, idOffset: Int = 0)(
+class WithTraceGen(
+  n: Int = 2,
+  overrideIdOffset: Option[Int] = None,
+  overrideMemOffset: Option[BigInt] = None)(
   params: Seq[DCacheParams] = List.fill(n){ DCacheParams(nSets = 16, nWays = 1) },
   nReqs: Int = 8192
 ) extends Config((site, here, up) => {
-  case TilesLocated(InSubsystem) => params.zipWithIndex.map { case (dcp, i) =>
-    TraceGenTileAttachParams(
-      tileParams = TraceGenParams(
-        hartId = i + idOffset,
-        dcache = Some(dcp),
-        wordBits = site(XLen),
-        addrBits = 32,
-        addrBag = {
-          val nSets = dcp.nSets
-          val nWays = dcp.nWays
-          val blockOffset = site(SystemBusKey).blockOffset
-          val nBeats = site(SystemBusKey).blockBeats
-          List.tabulate(nWays) { i =>
-            Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
-          }.flatten
-        },
-        maxRequests = nReqs,
-        memStart = site(ExtMem).get.master.base,
-        numGens = params.size),
-      crossingParams = RocketCrossingParams()
-    )
-  } ++ up(TilesLocated(InSubsystem), site)
+  case TilesLocated(InSubsystem) => {
+    val prev = up(TilesLocated(InSubsystem), site)
+    val idOffset = overrideIdOffset.getOrElse(prev.size)
+    val memOffset: BigInt = overrideMemOffset.orElse(site(ExtMem).map(_.master.base)).getOrElse(0x0L)
+    params.zipWithIndex.map { case (dcp, i) =>
+      TraceGenTileAttachParams(
+        tileParams = TraceGenParams(
+          hartId = i + idOffset,
+          dcache = Some(dcp),
+          wordBits = site(XLen),
+          addrBits = 32,
+          addrBag = {
+            val nSets = dcp.nSets
+            val nWays = dcp.nWays
+            val blockOffset = site(SystemBusKey).blockOffset
+            val nBeats = site(SystemBusKey).blockBeats
+            List.tabulate(nWays) { i =>
+              Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
+            }.flatten
+          },
+          maxRequests = nReqs,
+          memStart = memOffset,
+          numGens = params.size),
+        crossingParams = RocketCrossingParams()
+      )
+    } ++ prev
+  }
 })

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -15,7 +15,7 @@ import freechips.rocketchip.tile.{XLen}
 /** Actual testing target Configs */
 
 class TraceGenConfig extends Config(
-  new WithTraceGen(List.fill(2){ DCacheParams(nSets = 16, nWays = 1) }) ++
+  new WithTraceGen(2)() ++
   new GroundTestBaseConfig
 )
 
@@ -34,7 +34,10 @@ class GroundTestBaseConfig extends Config(
   })
 )
 
-class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192, idOffset: Int = 0) extends Config((site, here, up) => {
+class WithTraceGen(n: Int = 2, idOffset: Int = 0)(
+  params: Seq[DCacheParams] = List.fill(n){ DCacheParams(nSets = 16, nWays = 1) },
+  nReqs: Int = 8192
+) extends Config((site, here, up) => {
   case TilesLocated(InSubsystem) => params.zipWithIndex.map { case (dcp, i) =>
     TraceGenTileAttachParams(
       tileParams = TraceGenParams(

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -3,29 +3,23 @@
 package freechips.rocketchip.groundtest
 
 import Chisel._
-import freechips.rocketchip.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.model.OMInterrupt
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.tile._
+import chisel3.dontTouch
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.diplomacy.{AddressSet, LazyModule}
+import freechips.rocketchip.interrupts.{IntSinkNode, IntSinkPortSimple}
+import freechips.rocketchip.subsystem.{BaseSubsystem, BaseSubsystemModuleImp, HasTiles, CanHaveMasterAXI4MemPort}
+import freechips.rocketchip.tilelink.{TLRAM, TLFragmenter}
 
-import scala.math.max
-
-case object TileId extends Field[Int]
-
-class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
-    with CanHaveMasterAXI4MemPort {
-  val tileParams = p(GroundTestTilesKey)
-  val tiles = tileParams.zipWithIndex.map { case(c, i) => LazyModule(c.build(i, p)) }
-
-  tiles.map(_.masterNode).foreach { m =>
-    sbus.fromTile(None, buffer = BufferParams.default){ m }
-  }
-
+class GroundTestSubsystem(implicit p: Parameters)
+  extends BaseSubsystem
+  with HasTiles
+  with CanHaveMasterAXI4MemPort
+{
   val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), beatBytes=pbus.beatBytes))
   pbus.coupleTo("TestRAM") { testram.node := TLFragmenter(pbus) := _ }
+
+  // No cores to monitor
+  def coreMonitorBundles = Nil
 
   // No PLIC in ground test; so just sink the interrupts to nowhere
   IntSinkNode(IntSinkPortSimple()) :=* ibus.toPLIC
@@ -38,6 +32,6 @@ class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends
 
   outer.tiles.zipWithIndex.map { case(t, i) => t.module.constants.hartid := UInt(i) }
 
-  val status = DebugCombiner(outer.tiles.map(_.module.status))
-  success := status.finished
+  val status = dontTouch(DebugCombiner(outer.tiles.collect { case t: GroundTestTile => t.module.status }))
+  success := outer.tileCeaseSinkNode.in.head._1.asUInt.andR
 }

--- a/src/main/scala/groundtest/Status.scala
+++ b/src/main/scala/groundtest/Status.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.util.ValidMux
 
 class GroundTestStatus extends Bundle {
-  val finished = Bool(OUTPUT)
   val timeout = Valid(UInt(width = 4))
   val error = Valid(UInt(width = 4))
 }
@@ -14,10 +13,8 @@ class GroundTestStatus extends Bundle {
 object DebugCombiner {
   def apply(debugs: Seq[GroundTestStatus]): GroundTestStatus = {
     val out = Wire(new GroundTestStatus)
-    out.finished := debugs.map(_.finished).reduce(_ && _)
     out.timeout  := ValidMux(debugs.map(_.timeout))
     out.error    := ValidMux(debugs.map(_.error))
     out
   }
 }
-

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -17,8 +17,6 @@ trait GroundTestTileParams extends TileParams {
   val memStart: BigInt
   val maxRequests: Int
   val numGens: Int
-
-  def build(i: Int, p: Parameters): GroundTestTile
   
   val icache = Some(ICacheParams())
   val btb = None
@@ -28,18 +26,18 @@ trait GroundTestTileParams extends TileParams {
   val dataScratchpadBytes = 0
 }
 
-case object GroundTestTilesKey extends Field[Seq[GroundTestTileParams]]
-
-abstract class GroundTestTile private (params: GroundTestTileParams, x: ClockCrossingType, q: Parameters)
-    extends BaseTile(params, x, HartsWontDeduplicate(params), q)
+abstract class GroundTestTile(
+  params: GroundTestTileParams,
+  crossing: ClockCrossingType,
+  lookup: LookupByHartIdImpl,
+  q: Parameters
+) extends BaseTile(params, crossing, lookup, q)
+  with SinksExternalInterrupts
+  with SourcesExternalNotifications
 {
-  def this(params: GroundTestTileParams)(implicit p: Parameters) = this(params, SynchronousCrossing(), p)
-  val intInwardNode: IntInwardNode = IntIdentityNode()
+  val cpuDevice: SimpleDevice = new SimpleDevice("groundtest", Nil)
   val intOutwardNode: IntOutwardNode = IntIdentityNode()
   val slaveNode: TLInwardNode = TLIdentityNode()
-  val ceaseNode: IntOutwardNode = IntIdentityNode()
-  val haltNode: IntOutwardNode = IntIdentityNode()
-  val wfiNode: IntOutwardNode = IntIdentityNode()
 
   val dcacheOpt = params.dcache.map { dc => LazyModule(
     if (dc.nMSHRs == 0) new DCache(hartId, crossing)

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -67,7 +67,7 @@ case class TraceGenParams(
     numGens: Int,
     dcache: Option[DCacheParams] = Some(DCacheParams()),
     hartId: Int = 0
-) extends InstantiatableTileParams[TraceGenTile] with GroundTestTileParams
+) extends InstantiableTileParams[TraceGenTile] with GroundTestTileParams
 {
   def instantiate(crossing: TileCrossingParamsLike, lookup: LookupByHartIdImpl)(implicit p: Parameters): TraceGenTile = {
     new TraceGenTile(this, crossing, lookup)

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -77,8 +77,10 @@ class WithCoherentBusTopology extends Config((site, here, up) => {
       l2 = site(BankedL2Key)))
 })
 
-class WithNBigCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) => {
+class WithNBigCores(n: Int, overrideIdOffset: Option[Int] = None) extends Config((site, here, up) => {
   case RocketTilesKey => {
+    val prev = up(RocketTilesKey, site)
+    val idOffset = overrideIdOffset.getOrElse(prev.size)
     val big = RocketTileParams(
       core   = RocketCoreParams(mulDiv = Some(MulDivParams(
         mulUnroll = 8,
@@ -91,12 +93,14 @@ class WithNBigCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) =
       icache = Some(ICacheParams(
         rowBits = site(SystemBusKey).beatBits,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => big.copy(hartId = i + idOffset)) ++ up(RocketTilesKey, site)
+    List.tabulate(n)(i => big.copy(hartId = i + idOffset)) ++ prev
   }
 })
 
-class WithNMedCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) => {
+class WithNMedCores(n: Int, overrideIdOffset: Option[Int] = None) extends Config((site, here, up) => {
   case RocketTilesKey => {
+    val prev = up(RocketTilesKey, site)
+    val idOffset = overrideIdOffset.getOrElse(prev.size)
     val med = RocketTileParams(
       core = RocketCoreParams(fpu = None),
       btb = None,
@@ -113,12 +117,14 @@ class WithNMedCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) =
         nWays = 1,
         nTLBEntries = 4,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => med.copy(hartId = i + idOffset)) ++ up(RocketTilesKey, site)
+    List.tabulate(n)(i => med.copy(hartId = i + idOffset)) ++ prev
   }
 })
 
-class WithNSmallCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) => {
+class WithNSmallCores(n: Int, overrideIdOffset: Option[Int] = None) extends Config((site, here, up) => {
   case RocketTilesKey => {
+    val prev = up(RocketTilesKey, site)
+    val idOffset = overrideIdOffset.getOrElse(prev.size)
     val small = RocketTileParams(
       core = RocketCoreParams(useVM = false, fpu = None),
       btb = None,
@@ -135,7 +141,7 @@ class WithNSmallCores(n: Int, idOffset: Int = 0) extends Config((site, here, up)
         nWays = 1,
         nTLBEntries = 4,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => small.copy(hartId = i + idOffset)) ++ up(RocketTilesKey, site)
+    List.tabulate(n)(i => small.copy(hartId = i + idOffset)) ++ prev
   }
 })
 

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -17,7 +17,7 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   // Tile parameters
   case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
   case XLen => 64 // Applies to all cores
-  case MaxHartIdBits => log2Up(site(TilesLocated(InSubsystem)).map(_.tileParams.hartId).max)
+  case MaxHartIdBits => log2Up(site(TilesLocated(InSubsystem)).map(_.tileParams.hartId).max+1)
   // Interconnect parameters
   case SystemBusKey => SystemBusParams(
     beatBytes = site(XLen)/8,

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -77,7 +77,7 @@ class WithCoherentBusTopology extends Config((site, here, up) => {
       l2 = site(BankedL2Key)))
 })
 
-class WithNBigCores(n: Int) extends Config((site, here, up) => {
+class WithNBigCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) => {
   case RocketTilesKey => {
     val big = RocketTileParams(
       core   = RocketCoreParams(mulDiv = Some(MulDivParams(
@@ -91,11 +91,11 @@ class WithNBigCores(n: Int) extends Config((site, here, up) => {
       icache = Some(ICacheParams(
         rowBits = site(SystemBusKey).beatBits,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => big.copy(hartId = i))
+    List.tabulate(n)(i => big.copy(hartId = i + idOffset)) ++ up(RocketTilesKey, site)
   }
 })
 
-class WithNMedCores(n: Int) extends Config((site, here, up) => {
+class WithNMedCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) => {
   case RocketTilesKey => {
     val med = RocketTileParams(
       core = RocketCoreParams(fpu = None),
@@ -113,11 +113,11 @@ class WithNMedCores(n: Int) extends Config((site, here, up) => {
         nWays = 1,
         nTLBEntries = 4,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => med.copy(hartId = i))
+    List.tabulate(n)(i => med.copy(hartId = i + idOffset)) ++ up(RocketTilesKey, site)
   }
 })
 
-class WithNSmallCores(n: Int) extends Config((site, here, up) => {
+class WithNSmallCores(n: Int, idOffset: Int = 0) extends Config((site, here, up) => {
   case RocketTilesKey => {
     val small = RocketTileParams(
       core = RocketCoreParams(useVM = false, fpu = None),
@@ -135,7 +135,7 @@ class WithNSmallCores(n: Int) extends Config((site, here, up) => {
         nWays = 1,
         nTLBEntries = 4,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => small.copy(hartId = i))
+    List.tabulate(n)(i => small.copy(hartId = i + idOffset)) ++ up(RocketTilesKey, site)
   }
 })
 

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -17,7 +17,7 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   // Tile parameters
   case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
   case XLen => 64 // Applies to all cores
-  case MaxHartIdBits => log2Up(site(RocketTilesKey).size)
+  case MaxHartIdBits => log2Up(site(TilesLocated(InSubsystem)).map(_.tileParams.hartId).max)
   // Interconnect parameters
   case SystemBusKey => SystemBusParams(
     beatBytes = site(XLen)/8,

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -415,7 +415,7 @@ class WithScratchpadsOnly extends Config((site, here, up) => {
 
 /** Boilerplate code for translating between the old XTilesParamsKey/XTilesCrossingKey pattern and new TilesLocated pattern */
 object LegacyTileFieldHelper {
-  def apply[TPT <: InstantiatableTileParams[_], TCT <: TileCrossingParamsLike, TAP <: CanAttachTile](
+  def apply[TPT <: InstantiableTileParams[_], TCT <: TileCrossingParamsLike, TAP <: CanAttachTile](
     tileParams: Seq[TPT],
     tcp: Seq[TCT],
     apply: (TPT, TCT, LookupByHartIdImpl) => TAP): Seq[TAP] =

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -174,7 +174,7 @@ trait CanAttachTile {
     DisableMonitors { implicit p =>
       val controlBus = context.locateTLBusWrapper(crossingParams.slave.where)
       controlBus.coupleTo(tileParams.name.getOrElse("tile")) { bus =>
-        tile.crossSlavePort() :*= crossingParams.slave.injectNode(context) :*= bus
+        tile.crossSlavePort() :*= crossingParams.slave.injectNode(context) :*= TLWidthWidget(controlBus.beatBytes) :*= bus
       }
     }
   }

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.devices.tilelink.{BasicBusBlocker, BasicBusBlockerPa
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalModuleTree}
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tile.{BaseTile, LookupByHartIdImpl, TileParams, HasExternallyDrivenTileConstants, InstantiatableTileParams, PriorityMuxHartIdFromSeq}
+import freechips.rocketchip.tile.{BaseTile, LookupByHartIdImpl, TileParams, HasExternallyDrivenTileConstants, InstantiableTileParams, PriorityMuxHartIdFromSeq}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
@@ -147,7 +147,7 @@ trait DefaultTileContextType
 trait CanAttachTile {
   type TileType <: BaseTile
   type TileContextType <: DefaultTileContextType
-  def tileParams: InstantiatableTileParams[TileType]
+  def tileParams: InstantiableTileParams[TileType]
   def crossingParams: TileCrossingParamsLike
   def lookup: LookupByHartIdImpl
 

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -230,9 +230,9 @@ trait CanAttachTile {
     }
 
     // 5. Notifications of tile status are collected without needing to be clock-crossed
-    context.tileHaltXbarNode := tile.haltNode
-    context.tileWFIXbarNode := tile.wfiNode
-    context.tileCeaseXbarNode := tile.ceaseNode
+    context.tileHaltXbarNode :=* tile.haltNode
+    context.tileWFIXbarNode :=* tile.wfiNode
+    context.tileCeaseXbarNode :=* tile.ceaseNode
   }
 }
 

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -62,8 +62,8 @@ case class TileSlavePortParams(
       .map { bbbp =>
         val blocker = LazyModule(new BasicBusBlocker(bbbp))
         blockerBus.coupleTo("tile_slave_port_bus_blocker") { blocker.controlNode := TLFragmenter(blockerBus) := _ }
-        blocker.node
-      } .getOrElse { TLTempNode() }
+        blocker.node :*= TLBuffer(buffers)
+      } .getOrElse { TLBuffer(buffers) }
   }
 }
 

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -24,10 +24,7 @@ case class RocketTileAttachParams(
   tileParams: RocketTileParams,
   crossingParams: RocketCrossingParams,
   lookup: LookupByHartIdImpl
-) extends CanAttachTile {
-  type TileType = RocketTile
-  type TileContextType = DefaultTileContextType
-}
+) extends CanAttachTile { type TileType = RocketTile }
 
 case object RocketTilesKey extends Field[Seq[RocketTileParams]](Nil)
 case object RocketCrossingKey extends Field[Seq[RocketCrossingParams]](List(RocketCrossingParams()))

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -6,7 +6,7 @@ package freechips.rocketchip.system
 import Chisel._
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.groundtest.WithTraceGen
 
 class WithJtagDTMSystem extends freechips.rocketchip.subsystem.WithJtagDTM
 class WithDebugSBASystem extends freechips.rocketchip.subsystem.WithDebugSBA
@@ -38,6 +38,15 @@ class DualChannelDualBankConfig extends Config(
   new WithNBanks(4) ++ new DefaultConfig)
 
 class RoccExampleConfig extends Config(new WithRoccExample ++ new DefaultConfig)
+
+class HeterogeneousTileExampleConfig extends Config(
+  new WithTraceGen (n = 2, idOffset = 3)() ++
+  new WithNBigCores(n = 1, idOffset = 2) ++
+  new WithNMedCores(n = 1, idOffset = 1) ++
+  new WithNSmallCores(n = 1) ++
+  new WithCoherentBusTopology ++
+  new BaseConfig
+)
 
 class Edge128BitConfig extends Config(
   new WithEdgeDataBits(128) ++ new DefaultConfig)

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -40,9 +40,9 @@ class DualChannelDualBankConfig extends Config(
 class RoccExampleConfig extends Config(new WithRoccExample ++ new DefaultConfig)
 
 class HeterogeneousTileExampleConfig extends Config(
-  new WithTraceGen (n = 2, idOffset = 3)() ++
-  new WithNBigCores(n = 1, idOffset = 2) ++
-  new WithNMedCores(n = 1, idOffset = 1) ++
+  new WithTraceGen (n = 2, overrideMemOffset = Some(0x90000000L))() ++
+  new WithNBigCores(n = 1) ++
+  new WithNMedCores(n = 1) ++
   new WithNSmallCores(n = 1) ++
   new WithCoherentBusTopology ++
   new BaseConfig

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -32,6 +32,11 @@ trait TileParams {
   val name: Option[String]
 }
 
+abstract class InstantiatableTileParams[TileType <: BaseTile] extends TileParams {
+  def instantiate(crossing: TileCrossingParamsLike, lookup: LookupByHartIdImpl)
+                 (implicit p: Parameters): TileType
+}
+
 /** These parameters values are not computed based on diplomacy negotiation
   * and so are safe to use while diplomacy itself is running.
   */

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -7,6 +7,9 @@ import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomaticobjectmodel.{HasLogicalTreeNode}
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{GenericLogicalTreeNode, LogicalTreeNode}
+
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
@@ -148,6 +151,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
     extends LazyModule()(q)
     with CrossesToOnlyOneClockDomain
     with HasNonDiplomaticTileParameters
+    with HasLogicalTreeNode
 {
   // Public constructor alters Parameters to supply some legacy compatibility keys
   def this(tileParams: TileParams, crossing: ClockCrossingType, lookup: LookupByHartIdImpl, p: Parameters) = {
@@ -250,6 +254,8 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
 
   def crossIntIn(): IntInwardNode = crossIntIn(intInwardNode)
   def crossIntOut(): IntOutwardNode = crossIntOut(intOutwardNode)
+
+  val logicalTreeNode: LogicalTreeNode = new GenericLogicalTreeNode
 
   this.suggestName(tileParams.name)
 }

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -32,7 +32,7 @@ trait TileParams {
   val name: Option[String]
 }
 
-abstract class InstantiatableTileParams[TileType <: BaseTile] extends TileParams {
+abstract class InstantiableTileParams[TileType <: BaseTile] extends TileParams {
   def instantiate(crossing: TileCrossingParamsLike, lookup: LookupByHartIdImpl)
                  (implicit p: Parameters): TileType
 }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{DCacheLogicalTree
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.rocket._
-import freechips.rocketchip.subsystem.{SubsystemResetSchemeKey, ResetSynchronous, RocketCrossingParams, HartPrefixKey}
+import freechips.rocketchip.subsystem.{SubsystemResetSchemeKey, ResetSynchronous, HartPrefixKey, TileCrossingParamsLike}
 import freechips.rocketchip.util._
 
 case class RocketTileParams(
@@ -28,7 +28,7 @@ case class RocketTileParams(
     ) extends InstantiatableTileParams[RocketTile] {
   require(icache.isDefined)
   require(dcache.isDefined)
-   def instantiate(crossing: TileCrossingParamsLike, lookup: LookupByHartIdImpl)(implicit p: Parameters): RocketTile = {
+  def instantiate(crossing: TileCrossingParamsLike, lookup: LookupByHartIdImpl)(implicit p: Parameters): RocketTile = {
     new RocketTile(this, crossing, lookup)
   }
 }
@@ -46,7 +46,7 @@ class RocketTile private(
     with HasICacheFrontend
 {
   // Private constructor ensures altered LazyModule.p is used implicitly
-  def this(params: RocketTileParams, crossing: RocketCrossingParams, lookup: LookupByHartIdImpl)(implicit p: Parameters) =
+  def this(params: RocketTileParams, crossing: TileCrossingParamsLike, lookup: LookupByHartIdImpl)(implicit p: Parameters) =
     this(params, crossing.crossingType, lookup, p)
 
   val intOutwardNode = IntIdentityNode()

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -25,7 +25,7 @@ case class RocketTileParams(
     beuAddr: Option[BigInt] = None,
     blockerCtrlAddr: Option[BigInt] = None,
     boundaryBuffers: Boolean = false // if synthesized with hierarchical PnR, cut feed-throughs?
-    ) extends InstantiatableTileParams[RocketTile] {
+    ) extends InstantiableTileParams[RocketTile] {
   require(icache.isDefined)
   require(dcache.isDefined)
   def instantiate(crossing: TileCrossingParamsLike, lookup: LookupByHartIdImpl)(implicit p: Parameters): RocketTile = {

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -253,6 +253,12 @@ package object util {
     map.view.map({ case (k, vs) => k -> vs.toList }).toList
   }
 
+  def heterogeneousOrGlobalSetting[T](in: Seq[T], n: Int): Seq[T] = in.size match {
+    case 1 => List.fill(n)(in.head)
+    case x if x == n => in
+    case _ => throw new Exception(s"must provide exactly 1 or $n of some field, but got:\n$in")
+  }
+
 /** provides operators useful for working with bidirectional [[Bundle]]s
   * 
   * In terms of [[Flipped]] with a producer 'p' and 'consumer' c:


### PR DESCRIPTION
`HasTiles` is refactored to eagerly instantiate tiles of all types by pulling instances of `CanAttachTile` out of a new `Field` named `TilesLocated`.

This change has the following benefits:
- Any class `<: BaseTile` can be `Config`-urably instantiated inside a design without needing to mix in additional traits to the subsystem class hierarchy.
- Various subsystem user code that would like to operate over the `tiles` list (e.g. `nTiles`) does not have to jump through hoops to ensure that it doesn't get called before all tile-adding traits are mixed in, because those traits no longer exist.

In order to make a tile instantiate-able via the new field, you must supply a class like this one:
```
case class RocketTileAttachParams(
  tileParams: RocketTileParams,
  crossingParams: RocketCrossingParams,
  lookup: LookupByHartIdImpl
) extends CanAttachTile { type TileType = RocketTile }
```
where
- `tileParams` satisfies the new base class `InstantiableTileParams[TileType]` (you provide a function that instantiates an instance of your `TileType`)
- `crossingParams` satisfies `TileCrossingParamsLike`, for which you could just use the example `RocketCrossingParams`.

Backwards compatibility:
- Tiles can still be instantiated and attached manually via traits:
```
trait HasMyTiles extends HasTiles {
  val myTiles: Seq[MyTile] = p(MyTileField).map { ... }
  override val tiles = myTiles ++ super[HasTiles].tiles
```
- However, if you do so, be aware that you will have to also manually connect your tiles.
- The `Fields` `RocketTilesKey` and `RocketCrossingKey` are maintained for backwards compatibility and `LegacyTileFieldHelper` is applied to `TilesLocated` in `BaseConfig` to ensure that `Config` alterations that manipulate these fields continue to function
- `BaseTile` now `extends HasLogicalTreeNode`, but a `GenericLogicalTreeNode()` is supplied, which can be overridden.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
`val tiles` in `trait HasTiles` is now populated eagerly via the `TilesLocated` `Field`.
