### PR TITLE
SuperscalarEventSets check width

### DIFF
--- a/src/main/scala/rocket/Events.scala
+++ b/src/main/scala/rocket/Events.scala
@@ -28,14 +28,15 @@ class EventSet(gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bool)]
 class EventSets(val eventSets: Seq[EventSet]) {
   def maskEventSelector(eventSel: UInt): UInt = {
     // allow full associativity between counters and event sets (for now?)
-    val setMask = (BigInt(1) << log2Ceil(eventSets.size)) - 1
-    val maskMask = ((BigInt(1) << eventSets.map(_.size).max) - 1) << eventSetIdBits
+    val setMask = (BigInt(1) << eventSetIdBits) - 1
+    val maskMask = ((BigInt(1) << eventSets.map(_.size).max) - 1) << maxEventSetIdBits
     eventSel & (setMask | maskMask).U
   }
 
   private def decode(counter: UInt): (UInt, UInt) = {
-    require(eventSets.size <= (1 << eventSetIdBits))
-    (counter(log2Ceil(eventSets.size)-1, 0), counter >> eventSetIdBits)
+    require(eventSets.size <= (1 << maxEventSetIdBits))
+    require(eventSetIdBits > 0)
+    (counter(eventSetIdBits-1, 0), counter >> maxEventSetIdBits)
   }
 
   def evaluate(eventSel: UInt): Bool = {
@@ -49,14 +50,21 @@ class EventSets(val eventSets: Seq[EventSet]) {
 
   def cover() = eventSets.foreach { _ withCovers }
 
-  private def eventSetIdBits = 8
+  private def eventSetIdBits = log2Ceil(eventSets.size)
+  private def maxEventSetIdBits = 8
+
+  require(eventSetIdBits <= maxEventSetIdBits)
 }
 
 class SuperscalarEventSets(val eventSets: Seq[(Seq[EventSet], (UInt, UInt) => UInt)]) {
   def evaluate(eventSel: UInt): UInt = {
     val (set, mask) = decode(eventSel)
-    val sets = for ((sets, reducer) <- eventSets)
-      yield sets.map(_.check(mask)).reduce(reducer)
+    val sets = for ((sets, reducer) <- eventSets) yield {
+      sets.map { set =>
+        require(set.hits.getWidth <= mask.getWidth, s"too many events ${set.hits.getWidth} wider than mask ${mask.getWidth}")
+        set.check(mask)
+      }.reduce(reducer)
+    }
     val zeroPadded = sets.padTo(1 << eventSetIdBits, 0.U)
     zeroPadded(set)
   }
@@ -66,6 +74,7 @@ class SuperscalarEventSets(val eventSets: Seq[(Seq[EventSet], (UInt, UInt) => UI
   def cover() { eventSets.foreach(_._1.foreach(_.withCovers)) }
 
   private def decode(counter: UInt): (UInt, UInt) = {
+    require(eventSets.size <= (1 << maxEventSetIdBits))
     require(eventSetIdBits > 0)
     (counter(eventSetIdBits-1, 0), counter >> maxEventSetIdBits)
   }


### PR DESCRIPTION
**Related issue**: add the `require` from https://github.com/chipsalliance/rocket-chip/pull/2125 onto https://github.com/chipsalliance/rocket-chip/pull/2337

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
require that `SuperscalarEventSets` events fit within mask, same as regular `EventSets`