### PR TITLE
OptimizationBarrier: give the module an actual name. 

### DIFF
--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -228,15 +228,16 @@ package object util {
   }
 
   def OptimizationBarrier[T <: Data](in: T): T = {
-    val foo = Module(new Module {
+    val barrier = Module(new Module {
       val io = IO(new Bundle {
         val x = Input(in)
         val y = Output(in)
       })
       io.y := io.x
+      override def desiredName = "OptimizationBarrier"
     })
-    foo.io.x := in
-    foo.io.y
+    barrier.io.x := in
+    barrier.io.y
   }
 
   /** Similar to Seq.groupBy except this returns a Seq instead of a Map


### PR DESCRIPTION
Otherwise the module can end up being called package_Anon.v

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Previously, designs could end up with a module called `package_Anon*.v` which has now been renamed `OptimizationBarrier*.v` Note, there may be other things that end up called package_Anon.v that are not solved by this change.