### PR TITLE
Disallow writes to MSTATUS.XS

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -297,6 +297,7 @@ class CSRFile(
   val reset_mstatus = Wire(init=new MStatus().fromBits(0))
   reset_mstatus.mpp := PRV.M
   reset_mstatus.prv := PRV.M
+  reset_mstatus.xs := (if (usingRoCC) UInt(3) else UInt(0))
   val reg_mstatus = Reg(init=reset_mstatus)
 
   val new_prv = Wire(init = reg_mstatus.prv)
@@ -821,7 +822,6 @@ class CSRFile(
 
       if (usingSupervisor || usingFPU) reg_mstatus.fs := formFS(new_mstatus.fs)
       reg_mstatus.vs := formVS(new_mstatus.vs)
-      if (usingRoCC) reg_mstatus.xs := Fill(2, new_mstatus.xs.orR)
     }
     when (decoded_addr(CSRs.misa)) {
       val mask = UInt(isaStringToMask(isaMaskString), xLen)
@@ -894,7 +894,6 @@ class CSRFile(
           reg_mstatus.mxr := new_sstatus.mxr
           reg_mstatus.sum := new_sstatus.sum
         }
-        if (usingRoCC) reg_mstatus.xs := Fill(2, new_sstatus.xs.orR)
       }
       when (decoded_addr(CSRs.sip)) {
         val new_sip = new MIP().fromBits((read_mip & ~read_mideleg) | (wdata & read_mideleg))


### PR DESCRIPTION
The ISA specifies the XS field to be read-only. This PR modifies Rocket's CSR file to hardware XS to 3 (dirty) when RoCC is present, and 0 otherwise.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: mplementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
