### PR TITLE
Handle AddDefaultTests Corner Cases

### DIFF
--- a/src/test/scala/generatorTests/phases/AddDefaultTestsSpec.scala
+++ b/src/test/scala/generatorTests/phases/AddDefaultTestsSpec.scala
@@ -1,0 +1,60 @@
+// See LICENSE.SiFive for license details.
+
+package generatorTests.phases
+
+import freechips.rocketchip.config.Config
+import freechips.rocketchip.diplomacy.BigIntHexContext
+import freechips.rocketchip.stage.ConfigsAnnotation
+import freechips.rocketchip.stage.phases.AddDefaultTests
+import freechips.rocketchip.subsystem.ExtMem
+import freechips.rocketchip.system.DefaultConfig
+import freechips.rocketchip.tile.XLen
+
+import org.scalatest.{FlatSpec, Matchers}
+
+object AddDefaultTestsSpec {
+
+  /** A configuration that is not SV39 aligned */
+  class NotSV39AlignedConfig extends Config(
+    new Config(
+      (site, here, up) => {
+        case ExtMem => up(ExtMem, site).map(b => b.copy(master=b.master.copy(base = x"7000_0000")))
+      }
+    ) ++ new DefaultConfig)
+
+  /** A configuration that is RV128 */
+  class RV128Config extends Config(
+    new Config(
+      (site, here, up) => {
+        case XLen => 128
+      }
+    ) ++ new DefaultConfig)
+
+}
+
+class AddDefaultTestsSpec extends FlatSpec with Matchers {
+
+  import AddDefaultTestsSpec._
+
+  behavior of "freechips.rocketchip.stage.phases.AddDefaultTests"
+
+  it should "throw an IllegalArgumentException on an RV128 config" in {
+    val annotations = Seq(new ConfigsAnnotation(Seq((new RV128Config).getClass.getName)))
+    assertThrows[IllegalArgumentException] {
+      (new AddDefaultTests).GenerateSystemTestSuites(annotations)
+    }
+  }
+
+  it should "include '*-dirty' tests if the configuration is SV39 superpage aligned" in {
+    val annotations = Seq(new ConfigsAnnotation(Seq((new DefaultConfig).getClass.getName)))
+    val out = (new AddDefaultTests).GenerateSystemTestSuites(annotations)
+    out.toString should include ("dirty")
+  }
+
+  it should "not include '*-dirty' tests if the configuration isn't SV39 superpage aligned" in {
+    val annotations = Seq(new ConfigsAnnotation(Seq((new NotSV39AlignedConfig).getClass.getName)))
+    val out = (new AddDefaultTests).GenerateSystemTestSuites(annotations)
+    out.toString should not include ("dirty")
+  }
+
+}


### PR DESCRIPTION
This fixes two corner cases in the `AddDefaultTests` phase:

1. Any `XLen` which is not 32 or 64 will now throw an `IllegalArgumentException`. Previously, rv32 tests would be generated for any `XLen != 64`
2. The `rv(32|64)si-[pv]-dirty` test is now only included in the regression suite if the memory base address is aligned to an SV39 boundary.

For (2) this is a recent requirement of the `rv(32|64)si-[pv]-dirty` test introduced in https://github.com/riscv/riscv-tests/pull/255.

This PR includes tests of the behavior of (1) and (2).

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: bug report | other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Improve parametric test suite generation: error if not RV32/64, only emit `*-dirty` if legal