### PR TITLE
Add `sbt test` to regressions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bucket: [1, 2, 3, 4, 5, 6, 7]
+        bucket: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,3 +100,7 @@ jobs:
       name: check wake compilation
       script:
         - ci-tests/wake_scala_compilation
+    - <<: *test*
+      name: Scala tests
+      script:
+        - ./regression/run-test-bucket 8

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -334,3 +334,8 @@ emulator-jtag-dtm-tests-64 : $(EMULATOR_JTAG_DTM_64_TEST_STAMPS)
 # Targets for JTAG DTM full-chain simulation
 vsim-jtag-dtm-regression: vsim-jtag-dtm-tests-32 vsim-jtag-dtm-tests-64
 emulator-jtag-dtm-regression: emulator-jtag-dtm-tests-32 emulator-jtag-dtm-tests-64
+
+# Target to run Scalatest regressionsk 'sbt test'
+.PHONY: scalatest
+scalatest: stamps/other-submodules.stamp
+	(cd $(abspath $(TOP)) && $(SBT) test)

--- a/regression/run-test-bucket
+++ b/regression/run-test-bucket
@@ -91,6 +91,9 @@ case "${bucket_number}" in
   7)
     travis_wait 100 make emulator-ndebug -C regression SUITE=Miscellaneous JVM_MEMORY=3G
     ;;
+  8)
+    make scalatest -C regression SUITE=foo JVM_MEMORY=8G
+    ;;
 
   -h|--help)
     print_usage


### PR DESCRIPTION
This adds the few Scalatest tests to the regression suite of both Travis and GitHub Actions.

This is largely cargo cult-ed from existing tests, but I expect @richardxia can straighten me out.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.