### PR TITLE
TLBusWrapper: for internal wire name stability, genericize inner coupler port name

### DIFF
--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -76,10 +76,10 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
   }
 
   def coupleTo[T](name: String)(gen: TLOutwardNode => T): T =
-    to(name) { gen(outwardNode) }
+    to(name) { gen(TLNameNode("tl") :*=* outwardNode) }
 
   def coupleFrom[T](name: String)(gen: TLInwardNode => T): T =
-    from(name) { gen(inwardNode) }
+    from(name) { gen(inwardNode :*=* TLNameNode("tl")) }
 
   def crossToBus(bus: TLBusWrapper, xType: ClockCrossingType)(implicit asyncClockGroupNode: ClockGroupEphemeralNode): NoHandle = {
     bus.clockGroupNode := asyncMux(xType, asyncClockGroupNode, this.clockGroupNode)


### PR DESCRIPTION
Auto-generated signal names for diplomatically punched wires can contain the name of the node to which they are connected. While this behavior is informative in some cases, in other cases it represents a "leak" in terms of the contents of a child module becoming visible to a parent scope. One common case of this undesirable aspect of the behavior is the point at which `TLBusWrapper` "coupler scopes" are connected to the crossbar module within the BusWrapper. The child scope is usually productively named after the device it is connected to, and there is no added value in the specific adapters that happen to be used inside a particular coupler configuration being made apparent via the wire names internal to the wrapper, it's just another source of possible verilog diff mismatches across versions, or between configurations when e.g. a particular kind of clock crossing is inserted (or not).

Instead, we now just ensure that the signal name prefix for such connections is always `tl`. See examples below.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: change to some internal verilog signal names

<!-- choose one -->
**Development Phase**:  implementation

**Some Representative Verilog diffs**
```
<<< before >>> after
<   assign coupler_from_debug_sb_auto_widget_out_a_ready = subsystem_fbus_xbar_auto_in_0_a_ready; 
<   assign coupler_from_debug_sb_auto_widget_out_d_valid = subsystem_fbus_xbar_auto_in_0_d_valid; 
<   assign coupler_from_debug_sb_auto_widget_out_d_bits_opcode = subsystem_fbus_xbar_auto_in_0_d_bits_opcode; 
<   assign coupler_from_debug_sb_auto_widget_out_d_bits_param = subsystem_fbus_xbar_auto_in_0_d_bits_param; 
---
>   assign coupler_from_debug_sb_auto_tl_out_a_ready = subsystem_fbus_xbar_auto_in_0_a_ready; 
>   assign coupler_from_debug_sb_auto_tl_out_d_valid = subsystem_fbus_xbar_auto_in_0_d_valid; 
>   assign coupler_from_debug_sb_auto_tl_out_d_bits_opcode = subsystem_fbus_xbar_auto_in_0_d_bits_opcode; 
>   assign coupler_from_debug_sb_auto_tl_out_d_bits_param = subsystem_fbus_xbar_auto_in_0_d_bits_param; 
====
<   wire  coupler_to_debug_auto_fragmenter_in_a_ready; 
<   wire  coupler_to_debug_auto_fragmenter_in_a_valid; 
---
>   wire  coupler_to_debug_auto_tl_in_a_ready; 
>   wire  coupler_to_debug_auto_tl_in_a_valid; 
====
<   assign out_xbar_auto_out_1_d_bits_source = coupler_to_plic_auto_fragmenter_in_d_bits_source; 
<   assign out_xbar_auto_out_1_d_bits_data = coupler_to_plic_auto_fragmenter_in_d_bits_data; 
---
>   assign out_xbar_auto_out_1_d_bits_source = coupler_to_plic_auto_tl_in_d_bits_source; 
>   assign out_xbar_auto_out_1_d_bits_data = coupler_to_plic_auto_tl_in_d_bits_data; 
====
<   assign coupler_to_tile_auto_rsource_in_a_valid = out_xbar_auto_out_4_a_valid; 
<   assign coupler_to_tile_auto_rsource_in_a_bits_opcode = out_xbar_auto_out_4_a_bits_opcode; 
---
>   assign coupler_to_tile_auto_tl_in_a_valid = out_xbar_auto_out_4_a_valid; 
>   assign coupler_to_tile_auto_tl_in_a_bits_opcode = out_xbar_auto_out_4_a_bits_opcode; 
```