### PR TITLE
make scalatest rule depend on FIRRTL_JAR

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -337,5 +337,5 @@ emulator-jtag-dtm-regression: emulator-jtag-dtm-tests-32 emulator-jtag-dtm-tests
 
 # Target to run Scalatest regressionsk 'sbt test'
 .PHONY: scalatest
-scalatest: stamps/other-submodules.stamp
+scalatest: stamps/other-submodules.stamp $(FIRRTL_JAR)
 	(cd $(abspath $(TOP)) && $(SBT) test)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
sbt test depends on `FIRRTL_JAR` which puts the `firrtl-test.jar` files in the `test_lib` dir

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
