### PR TITLE
BundleBridge: preserve width; don't use RegNext

### DIFF
--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -122,18 +122,24 @@ class BundleBridgeNexus[T <: Data](
 }
 
 object BundleBridgeNexus {
+  def safeRegNext[T <: Data](x: T): T = {
+    val reg = Reg(chiselTypeOf(x))
+    reg := x
+    reg
+  }
+
   def requireOne[T <: Data](registered: Boolean)(seq: Seq[T]): T = {
     require(seq.size == 1, "BundleBroadcast default requires one input")
-    if (registered) RegNext(seq.head) else seq.head
+    if (registered) safeRegNext(seq.head) else seq.head
   }
 
   def orReduction[T <: Data](registered: Boolean)(seq: Seq[T]): T = {
     val x = seq.reduce((a,b) => (a.asUInt | b.asUInt).asTypeOf(seq.head))
-    if (registered) RegNext(x) else x
+    if (registered) safeRegNext(x) else x
   }
 
   def fillN[T <: Data](registered: Boolean)(x: T, n: Int): Seq[T] = Seq.fill(n) {
-    if (registered) RegNext(x) else x
+    if (registered) safeRegNext(x) else x
   }
 
   def apply[T <: Data](


### PR DESCRIPTION
RegNext erases the width of a UInt.
This leads to:

java.lang.IllegalArgumentException: requirement failed: hartPrefixNode.node (A nexus node with parent 'hartPrefixNode/topMod/topDesign/gen' at  (BundleBridge.scala:144:31)) requires all outputs have equivalent Chisel Data types, but got
UInt<10>(Wire in BundleBridgeNexus)
vs
UInt(Reg in BundleBridgeNexus)

Using safeRegNext, we can keep the useful requirement check and still have
BundleBridgeNexus work when registered=true with a UInt.

@jackkoenig FYI

**Type of change**: bug report
**Impact**: no functional change
**Development Phase**: implementation