### PR TITLE
public EventSet.gate so EventSet could be clone with tapped signals

### DIFF
--- a/src/main/scala/rocket/Events.scala
+++ b/src/main/scala/rocket/Events.scala
@@ -7,7 +7,7 @@ import Chisel._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
 
-class EventSet(gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bool)]) {
+class EventSet(val gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bool)]) {
   def size = events.size
   val hits = Wire(Vec(size, Bool()))
   def check(mask: UInt) = {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Let member `gate` of `EventSet` could be accessed so EventSet could be cloned by EventSet monitor
