### PR TITLE
Require RegFieldDesc names match a certain RegEx

### DIFF
--- a/src/main/scala/regmapper/RegFieldDesc.scala
+++ b/src/main/scala/regmapper/RegFieldDesc.scala
@@ -64,10 +64,20 @@ case class RegFieldDesc (
   // IP-XACT or similar outputs. 
   addressBlock: Option[AddressBlockInfo] = None
   // TODO: registerFiles
-)
+) {
+    require(RegFieldDesc.nameAcceptable(name),
+    s"RegFieldDesc.name of '$name' is not of the form '[A-Za-z_][A-Za-z0-9_]*'")
+}
 
 object RegFieldDesc {
   def reserved: RegFieldDesc = RegFieldDesc("reserved", "", access=RegFieldAccessType.R, reset=Some(0))
+
+  private val nameRegex: Regex = """[A-Za-z_][A-Za-z0-9_]*""".r
+
+  def nameAcceptable(name: String): Boolean = name match {
+    case RegFieldDesc.nameRegex(_*) => true
+    case _ => false
+  }
 }
 
 // Our descriptions are in terms of RegFields only, which is somewhat
@@ -78,6 +88,8 @@ object RegFieldDesc {
 
 object RegFieldGroup {
   def apply (name: String, desc: Option[String], regs: Seq[RegField], descFirstOnly: Boolean = true): Seq[RegField] = {
+    require(RegFieldDesc.nameAcceptable(name),
+      s"RegFieldDesc.group of '$name' is not of the form '[A-Za-z_][A-Za-z0-9_]*'")
     regs.zipWithIndex.map {case (r, i) =>
       val gDesc = if ((i > 0) & descFirstOnly) None else desc
       r.desc.map { d =>

--- a/src/main/scala/regmapper/RegFieldDesc.scala
+++ b/src/main/scala/regmapper/RegFieldDesc.scala
@@ -2,6 +2,8 @@
 
 package freechips.rocketchip.regmapper
 
+import scala.util.matching.Regex
+
 // This information is not used internally by the regmap(...) function.
 // However, the author of a RegField may be the best person to provide this
 // information which is likely to be needed by downstream SW and Documentation
@@ -80,7 +82,7 @@ object RegFieldDesc {
 
   // This Regex is considerably more limited than the IP-XACT standard,
   // ours is designed for simplicity and consistency in register naming.
-  private val nameRegex: Regex = """[A-Za-z_][A-Za-z0-9_]*""".r
+  val nameRegex: Regex = """[A-Za-z_][A-Za-z0-9_]*""".r
 
   def nameAcceptable(name: String): Boolean = name match {
     case RegFieldDesc.nameRegex(_*) => true

--- a/src/main/scala/regmapper/RegFieldDesc.scala
+++ b/src/main/scala/regmapper/RegFieldDesc.scala
@@ -80,9 +80,9 @@ case class RegFieldDesc (
 object RegFieldDesc {
   def reserved: RegFieldDesc = RegFieldDesc("reserved", "", access=RegFieldAccessType.R, reset=Some(0))
 
-  // This Regex is considerably more limited than the IP-XACT standard,
-  // ours is designed for simplicity and consistency in register naming.
-  val nameRegex: Regex = """[A-Za-z_][A-Za-z0-9_]*""".r
+  // This Regex is more limited than the IP-XACT standard,
+  // which allows some unicode characters as well.
+  val nameRegex: Regex = """^[_:A-Za-z][-._:A-Za-z0-9]*$""".r
 
   def nameAcceptable(name: String): Boolean = name match {
     case RegFieldDesc.nameRegex(_*) => true

--- a/src/main/scala/regmapper/RegFieldDesc.scala
+++ b/src/main/scala/regmapper/RegFieldDesc.scala
@@ -65,13 +65,21 @@ case class RegFieldDesc (
   addressBlock: Option[AddressBlockInfo] = None
   // TODO: registerFiles
 ) {
-    require(RegFieldDesc.nameAcceptable(name),
-    s"RegFieldDesc.name of '$name' is not of the form '[A-Za-z_][A-Za-z0-9_]*'")
+  require(RegFieldDesc.nameAcceptable(name),
+    s"RegFieldDesc.name of '$name' is not of the form '${RegFieldDesc.nameRegex.toString}'")
+
+  // We could also check for group name here, but that can have a
+  // significant runtime overhead because every RegField can be
+  // annotated with the group name,
+  // so we put the check in the RegFieldGroup helper function instead.
+
 }
 
 object RegFieldDesc {
   def reserved: RegFieldDesc = RegFieldDesc("reserved", "", access=RegFieldAccessType.R, reset=Some(0))
 
+  // This Regex is considerably more limited than the IP-XACT standard,
+  // ours is designed for simplicity and consistency in register naming.
   private val nameRegex: Regex = """[A-Za-z_][A-Za-z0-9_]*""".r
 
   def nameAcceptable(name: String): Boolean = name match {
@@ -89,7 +97,7 @@ object RegFieldDesc {
 object RegFieldGroup {
   def apply (name: String, desc: Option[String], regs: Seq[RegField], descFirstOnly: Boolean = true): Seq[RegField] = {
     require(RegFieldDesc.nameAcceptable(name),
-      s"RegFieldDesc.group of '$name' is not of the form '[A-Za-z_][A-Za-z0-9_]*'")
+      s"RegFieldDesc.group of '$name' is not of the form '${RegFieldDesc.nameRegex.toString}'")
     regs.zipWithIndex.map {case (r, i) =>
       val gDesc = if ((i > 0) & descFirstOnly) None else desc
       r.desc.map { d =>


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

RegFieldDesc.name and RegFieldDesc.group must match specific regular expression `^[_:A-Za-z][-._:A-Za-z0-9]*$` or the design will not elaborate.