### PR TITLE
Use self-location in wake rules

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -1,4 +1,6 @@
 
+global def rocketChipRoot = here
+
 global def hardfloatScalaModule =
   makeScalaModuleFromJSON here "hardfloat"
   | setScalaModuleRootDir "hardfloat"
@@ -7,7 +9,7 @@ global def hardfloatScalaModule =
 
 global def rocketchipMacros =
   makeScalaModuleFromJSON here "rocketchipMacros"
-  | setScalaModuleRootDir "rocket-chip/macros"
+  | setScalaModuleRootDir "{rocketChipRoot}/macros"
   | addMacrosParadiseCompilerPlugin
 
 global def rocketchipScalaModule =
@@ -18,13 +20,13 @@ global def rocketchipScalaModule =
     apiConfigChipsallianceScalaModule,
     Nil
   makeScalaModuleFromJSON here "rocketchip"
-  | setScalaModuleRootDir "rocket-chip"
+  | setScalaModuleRootDir rocketChipRoot
   | setScalaModuleDeps deps
   | setScalaModuleScalacOptions ("-Xsource:2.11", Nil)
   | addMacrosParadiseCompilerPlugin
 
-def vlsi_mem_gen = source "rocket-chip/scripts/vlsi_mem_gen"
-def vlsi_rom_gen = source "rocket-chip/scripts/vlsi_rom_gen"
+def vlsi_mem_gen = source "{rocketChipRoot}/scripts/vlsi_mem_gen"
+def vlsi_rom_gen = source "{rocketChipRoot}/scripts/vlsi_rom_gen"
 
 tuple VLSIRomGenOptions =
   global ConfFile:   Path
@@ -108,7 +110,7 @@ def getClassName fullClassName = fullClassName | tokenize `\.` | reverse | head 
 
 global def runRocketChipGenerator options =
   def jars = options.getRocketChipGeneratorOptionsJars
-  def runDir = "rocket-chip"
+  def runDir = rocketChipRoot
   def targetDir = options.getRocketChipGeneratorOptionsTargetDir
 
   def cmdline =
@@ -128,7 +130,7 @@ global def runRocketChipGenerator options =
     baseFileName
 
   def inputs =
-    def bootrom = source 'rocket-chip/bootrom/bootrom.img'
+    def bootrom = source '{rocketChipRoot}/bootrom/bootrom.img'
     def extras = options.getRocketChipGeneratorOptionsExtraSources
     (bootrom, targetDir, extras) ++ jars
 


### PR DESCRIPTION
This adds a self-location def `rocketChipRoot` so that other wake rules can find this repository regardless of where it is located in the collection of repositories that makes up your workspace.

Some repository layouts expect a flat list of repositories while others expect a hierarchy, this helps make a repository location-independent if consumers of the repository use the `<reponame>Root` definition as a base prefix when referencing components



**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
