### PR TITLE
PRCI: use RecordMap API to get easier to follow names on clock group signals

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,10 @@
 	url = https://github.com/ucb-bar/riscv-torture.git
 [submodule "chisel3"]
 	path = chisel3
-	url = https://github.com/ucb-bar/chisel3.git
+	url = https://github.com/freechipsproject/chisel3.git
 [submodule "firrtl"]
 	path = firrtl
-	url = https://github.com/ucb-bar/firrtl.git
+	url = https://github.com/freechipsproject/firrtl.git
 [submodule "api-config-chipsalliance"]
 	path = api-config-chipsalliance
 	url = https://github.com/chipsalliance/api-config-chipsalliance.git

--- a/src/main/scala/prci/ClockBundles.scala
+++ b/src/main/scala/prci/ClockBundles.scala
@@ -2,7 +2,9 @@
 package freechips.rocketchip.prci
 
 import chisel3._
-import freechips.rocketchip.util.HeterogeneousBag
+import freechips.rocketchip.util.RecordMap
+import scala.collection.immutable.ListMap
+
 
 class ClockBundle(val params: ClockBundleParameters) extends Bundle
 {
@@ -12,5 +14,7 @@ class ClockBundle(val params: ClockBundleParameters) extends Bundle
 
 class ClockGroupBundle(val params: ClockGroupBundleParameters) extends Bundle
 {
-  val member = HeterogeneousBag(params.members.map(p => new ClockBundle(p)))
+  val member: RecordMap[ClockBundle] = RecordMap(params.members.map { case (k, v) =>
+    k -> new ClockBundle(v)
+  })
 }

--- a/src/main/scala/prci/ClockGroup.scala
+++ b/src/main/scala/prci/ClockGroup.scala
@@ -22,7 +22,7 @@ class ClockGroup(groupName: String)(implicit p: Parameters) extends LazyModule
     require (node.in.size == 1)
     require (in.member.size == out.size)
 
-    (in.member zip out) foreach { case (i, o) => o := i }
+    (in.member.data zip out) foreach { case (i, o) => o := i }
   }
 }
 
@@ -43,11 +43,11 @@ class ClockGroupAggregator(groupName: String)(implicit p: Parameters) extends La
   lazy val module = new LazyRawModuleImp(this) {
     val (in, _) = node.in.unzip
     val (out, _) = node.out.unzip
-    val outputs = out.flatMap(_.member)
+    val outputs = out.flatMap(_.member.data)
 
     require (node.in.size == 1)
     require (in.head.member.size == outputs.size)
-    in.head.member.zip(outputs).foreach { case (i, o) => o := i }
+    in.head.member.data.zip(outputs).foreach { case (i, o) => o := i }
   }
 }
 
@@ -61,9 +61,12 @@ class SimpleClockGroupSource(numSources: Int = 1)(implicit p: Parameters) extend
   val node = ClockGroupSourceNode(List.fill(numSources) { ClockGroupSourceParameters() })
 
   lazy val module = new LazyModuleImp(this) {
+
     val (out, _) = node.out.unzip
-    val outputs = out.flatMap(_.member)
-    outputs.foreach { o => o.clock := clock; o.reset := reset }
+    out.map { out: ClockGroupBundle =>
+      out.member.data.foreach { o =>
+        o.clock := clock; o.reset := reset }
+    }
   }
 }
 

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.prci.SimpleClockGroupSource
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util.DontTouch
 

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -48,6 +48,13 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
   fixedClockNode := clockGroup.node // first member of group is always domain's own clock
   clockSinkNode := fixedClockNode
 
+  InModuleBody {
+    // make sure the above connections work properly because mismatched-by-name signals will just be ignored.
+    (clockGroup.node.edges.in zip clockGroupAggregator.node.edges.out).zipWithIndex map { case ((in: ClockGroupEdgeParameters , out: ClockGroupEdgeParameters), i) =>
+      require(in.members.keys == out.members.keys, s"clockGroup := clockGroupAggregator not working as you expect for index ${i}, becuase clockGroup has ${in.members.keys} and clockGroupAggregator has ${out.members.keys}")
+    }
+  }
+
   def clockBundle = clockSinkNode.in.head._1
   def beatBytes = params.beatBytes
   def blockBytes = params.blockBytes

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -15,7 +15,7 @@
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "1443a31ffed88dc1a7c94910bb980c64f8a4b1d6",
+        "commit": "c07da8a581789b88f7e6ffc98c8e810565034ad9",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

Redo of #2487 which seems to have rebase issues
Bumps FIRRTL along 1.3.x 

~This builds on top of #2486 and will be rebased on top of it as that API changes.~

This demonstrates the use of the new RecordMap. API to get better names for clock group signals

In the comments I'll include a diff before and after this change.

<!-- choose one -->
**Type of change**:feature request

<!-- choose one -->
**Impact**: API modification

(Generated RTL will have different output)
Also bumps firrtl along 1.3.x branch which notably changes the Dedup behavior (this was a bug before)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

I/O and internal signals in the clock related modules (ClockSource, ClockGroup, etc) will have more meaningful I/O names vs simply indexed names. This also results in less deduplication of ClockGroup-related modules as their names are different.

## Firrtl Bump Notes

### Feature
* Constant propagate reduction operators (https://github.com/freechipsproject/firrtl/pull/1558)
* Add `find_heap_bound.py` (https://github.com/freechipsproject/firrtl/pull/1648)
* Squash skips and nested blocks in `Block.mapStmt` (https://github.com/freechipsproject/firrtl/pull/1648)

### Bugfix
* Improved source locators when using append info (https://github.com/freechipsproject/firrtl/pull/1580)
* Fix some missing transform invalidations (https://github.com/freechipsproject/firrtl/pull/1541)
* Fix handling of non-reset registers in `RemoveReset` (https://github.com/freechipsproject/firrtl/pull/1627) 
* Don't dedup main module (https://github.com/freechipsproject/firrtl/pull/1594)
* Don't crash on `-ll trace` when annotations aren't serializable (https://github.com/freechipsproject/firrtl/pull/1639)
* Fix stack overflows in CheckWidths (https://github.com/freechipsproject/firrtl/pull/1646)
  * Also performance improvement for some designs
* Remove non-determinism in transform ordering (https://github.com/freechipsproject/firrtl/pull/1686)
* Restore `1.2.x` meaning of `-X high` in CLI (https://github.com/freechipsproject/firrtl/pull/1704)
* Add support for `ValidIf` to ProtoBuf [de]serialization (https://github.com/freechipsproject/firrtl/pull/1707)
* Don't Dedup modules if it would break connection semantics (https://github.com/freechipsproject/firrtl/pull/1713)

### Performance
* Speed up InferTypes and CInferTypes (https://github.com/freechipsproject/firrtl/pull/1601)
* Speed up Deduplication (https://github.com/freechipsproject/firrtl/pull/1602)
* Speed up ResolveKinds (https://github.com/freechipsproject/firrtl/pull/1475)
* Speed up ExpandWhens for some very large designs (https://github.com/freechipsproject/firrtl/pull/1666)



