### PR TITLE
Bundle Bridge Tile MMIO Address Prefix

### DIFF
--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -97,7 +97,7 @@ case class BundleBridgeNexusNode[T <: Data](default: Option[() => T] = None,
                                            (implicit valName: ValName)
   extends NexusNode(new BundleBridgeImp[T])(
     dFn = seq => seq.headOption.getOrElse(BundleBridgeParams(default)),
-    uFn = seq => seq.headOption.getOrElse(BundleBridgeParams(default)),
+    uFn = seq => seq.headOption.getOrElse(BundleBridgeParams(None)),
     inputRequiresOutput = inputRequiresOutput,
     outputRequiresInput = !default.isDefined)
 

--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -57,6 +57,12 @@ case class BundleBridgeSink[T <: Data](genOpt: Option[() => T] = None)
   def makeIO(name: String): T = makeIO()(ValName(name))
 }
 
+object BundleBridgeSink {
+  def apply[T <: Data]()(implicit valName: ValName): BundleBridgeSink[T] = {
+    BundleBridgeSink(None)
+  }
+}
+
 case class BundleBridgeSource[T <: Data](genOpt: Option[() => T] = None)(implicit valName: ValName) extends SourceNode(new BundleBridgeImp[T])(Seq(BundleBridgeParams(genOpt)))
 {
   def bundle: T = out(0)._1
@@ -83,7 +89,10 @@ case class BundleBridgeSource[T <: Data](genOpt: Option[() => T] = None)(implici
   }
 }
 
-case object BundleBridgeSource {
+object BundleBridgeSource {
+  def apply[T <: Data]()(implicit valName: ValName): BundleBridgeSource[T] = {
+    BundleBridgeSource(None)
+  }
   def apply[T <: Data](gen: () => T)(implicit valName: ValName): BundleBridgeSource[T] = {
     BundleBridgeSource(Some(gen))
   }

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -86,11 +86,14 @@ abstract class BaseNode(implicit val valName: ValName)
     parents.map(_.name).mkString("/") + "' at " +
     scope.map(_.line).getOrElse("<undef>") + ")"
 
+  /** Determines the name to be used in elements of auto-punched bundles
+    * by taking the name of the node as determined from valName,
+    * converting camel case into snake case, and stripping "Node" or "NodeOpt" suffixes.
+    */
   def wirePrefix = {
     val camelCase = "([a-z])([A-Z])".r
     val decamel = camelCase.replaceAllIn(valName.name, _ match { case camelCase(l, h) => l + "_" + h })
-    val trimNode = "_?node$".r
-    val name = trimNode.replaceFirstIn(decamel.toLowerCase, "")
+    val name = decamel.toLowerCase.stripSuffix("_opt").stripSuffix("node").stripSuffix("_")
     if (name.isEmpty) "" else name + "_"
   }
 

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -40,9 +40,9 @@ abstract class GroundTestTile(
   val slaveNode: TLInwardNode = TLIdentityNode()
 
   val dcacheOpt = params.dcache.map { dc => LazyModule(
-    if (dc.nMSHRs == 0) new DCache(hartId, crossing)
-    else new NonBlockingDCache(hartId))
-  }
+    if (dc.nMSHRs == 0) new DCache(staticIdForMetadataUseOnly, crossing)
+    else new NonBlockingDCache(staticIdForMetadataUseOnly)
+  )}
 
   dcacheOpt.foreach { _.hartIdSinkNode := hartIdNode }
 

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -44,7 +44,7 @@ abstract class GroundTestTile(
     else new NonBlockingDCache(staticIdForMetadataUseOnly)
   )}
 
-  dcacheOpt.foreach { _.hartIdSinkNodeOpt.foreach { _ := hartIdNode } }
+  dcacheOpt.foreach { _.hartIdSinkNodeOpt.foreach { _ := hartIdNexusNode } }
 
   override lazy val module = new GroundTestTileModuleImp(this)
 }

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -44,7 +44,7 @@ abstract class GroundTestTile(
     else new NonBlockingDCache(staticIdForMetadataUseOnly)
   )}
 
-  dcacheOpt.foreach { _.hartIdSinkNode := hartIdNode }
+  dcacheOpt.foreach { _.hartIdSinkNodeOpt.foreach { _ := hartIdNode } }
 
   override lazy val module = new GroundTestTileModuleImp(this)
 }

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -251,7 +251,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   val s1_victim_way = Wire(init = replacer.way)
   val (s1_hit_way, s1_hit_state, s1_meta, s1_victim_meta) =
     if (usingDataScratchpad) {
-      val baseAddr = p(LookupByHartId)(_.dcache.flatMap(_.scratch.map(_.U)), io_hartid)
+      val baseAddr = p(LookupByHartId)(_.dcache.flatMap(_.scratch.map(_.U)), io_hartid.get) | io_mmio_address_prefix.get
       val inScratchpad = s1_paddr >= baseAddr && s1_paddr < baseAddr + nSets * cacheBlockBytes
       val hitState = Mux(inScratchpad, ClientMetadata.maximum, ClientMetadata.onReset)
       val dummyMeta = L1Metadata(UInt(0), ClientMetadata.onReset)

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -352,7 +352,8 @@ trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   val frontend = LazyModule(new Frontend(tileParams.icache.get, staticIdForMetadataUseOnly))
   tlMasterXbar.node := frontend.masterNode
   connectTLSlave(frontend.slaveNode, tileParams.core.fetchBytes)
-  frontend.icache.hartIdSinkNode := hartIdNode
+  frontend.icache.hartIdSinkNodeOpt.foreach { _ := hartIdNode }
+  frontend.icache.mmioAddressPrefixSinkNodeOpt.foreach { _ := mmioAddressPrefixNode }
   frontend.resetVectorSinkNode := resetVectorNode
   nPTWPorts += 1
 

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -352,9 +352,9 @@ trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   val frontend = LazyModule(new Frontend(tileParams.icache.get, staticIdForMetadataUseOnly))
   tlMasterXbar.node := frontend.masterNode
   connectTLSlave(frontend.slaveNode, tileParams.core.fetchBytes)
-  frontend.icache.hartIdSinkNodeOpt.foreach { _ := hartIdNode }
-  frontend.icache.mmioAddressPrefixSinkNodeOpt.foreach { _ := mmioAddressPrefixNode }
-  frontend.resetVectorSinkNode := resetVectorNode
+  frontend.icache.hartIdSinkNodeOpt.foreach { _ := hartIdNexusNode }
+  frontend.icache.mmioAddressPrefixSinkNodeOpt.foreach { _ := mmioAddressPrefixNexusNode }
+  frontend.resetVectorSinkNode := resetVectorNexusNode
   nPTWPorts += 1
 
   // This should be a None in the case of not having an ITIM address, when we

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -256,8 +256,8 @@ trait HasHellaCache { this: BaseTile =>
   lazy val dcache: HellaCache = LazyModule(p(BuildHellaCache)(this)(p))
 
   tlMasterXbar.node := dcache.node
-  dcache.hartIdSinkNodeOpt.map { _ := hartIdNode }
-  dcache.mmioAddressPrefixSinkNodeOpt.map { _ := mmioAddressPrefixNode }
+  dcache.hartIdSinkNodeOpt.map { _ := hartIdNexusNode }
+  dcache.mmioAddressPrefixSinkNodeOpt.map { _ := mmioAddressPrefixNexusNode }
 }
 
 trait HasHellaCacheModule {

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -196,7 +196,8 @@ abstract class HellaCache(staticIdForMetadataUseOnly: Int)(implicit p: Parameter
     minLatency = 1,
     requestFields = tileParams.core.useVM.option(Seq()).getOrElse(Seq(AMBAProtField())))))
 
-  val hartIdSinkNode = BundleBridgeSink[UInt]()
+  val hartIdSinkNodeOpt = cfg.scratch.map(_ => BundleBridgeSink[UInt]())
+  val mmioAddressPrefixSinkNodeOpt = cfg.scratch.map(_ => BundleBridgeSink[UInt]())
 
   val module: HellaCacheModule
 
@@ -220,7 +221,8 @@ class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
   implicit val edge = outer.node.edges.out(0)
   val (tl_out, _) = outer.node.out(0)
   val io = IO(new HellaCacheBundle(outer))
-  val io_hartid = outer.hartIdSinkNode.bundle
+  val io_hartid = outer.hartIdSinkNodeOpt.map(_.bundle)
+  val io_mmio_address_prefix = outer.mmioAddressPrefixSinkNodeOpt.map(_.bundle)
   dontTouch(io.cpu.resp) // Users like to monitor these fields even if the core ignores some signals
   dontTouch(io.cpu.s1_data)
 
@@ -254,7 +256,8 @@ trait HasHellaCache { this: BaseTile =>
   lazy val dcache: HellaCache = LazyModule(p(BuildHellaCache)(this)(p))
 
   tlMasterXbar.node := dcache.node
-  dcache.hartIdSinkNode := hartIdNode
+  dcache.hartIdSinkNodeOpt.map { _ := hartIdNode }
+  dcache.mmioAddressPrefixSinkNodeOpt.map { _ := mmioAddressPrefixNode }
 }
 
 trait HasHellaCacheModule {

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -55,7 +55,7 @@ class ICacheErrors(implicit p: Parameters) extends CoreBundle()(p)
 class ICache(val icacheParams: ICacheParams, val staticIdForMetadataUseOnly: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new ICacheModule(this)
   val hartIdSinkNodeOpt = icacheParams.itimAddr.map(_ => BundleBridgeSink[UInt]())
-  val mmioAddressPrefixSinkNodeOpt= icacheParams.itimAddr.map(_ => BundleBridgeSink[UInt]())
+  val mmioAddressPrefixSinkNodeOpt = icacheParams.itimAddr.map(_ => BundleBridgeSink[UInt]())
   val useVM = p(TileKey).core.useVM
   val masterNode = TLClientNode(Seq(TLMasterPortParameters.v1(
     clients = Seq(TLMasterParameters.v1(

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -54,7 +54,8 @@ class ICacheErrors(implicit p: Parameters) extends CoreBundle()(p)
 
 class ICache(val icacheParams: ICacheParams, val staticIdForMetadataUseOnly: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new ICacheModule(this)
-  val hartIdSinkNode = BundleBridgeSink[UInt]()
+  val hartIdSinkNodeOpt = icacheParams.itimAddr.map(_ => BundleBridgeSink[UInt]())
+  val mmioAddressPrefixSinkNodeOpt= icacheParams.itimAddr.map(_ => BundleBridgeSink[UInt]())
   val useVM = p(TileKey).core.useVM
   val masterNode = TLClientNode(Seq(TLMasterPortParameters.v1(
     clients = Seq(TLMasterParameters.v1(
@@ -143,12 +144,13 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   require(!usingVM || outer.icacheParams.itimAddr.isEmpty || pgIdxBits >= untagBits,
     s"When VM and ITIM are enabled, I$$ set size must not exceed ${1<<(pgIdxBits-10)} KiB; got ${(outer.size/nWays)>>10} KiB")
 
-  val io_hartid = outer.hartIdSinkNode.bundle
+  val io_hartid = outer.hartIdSinkNodeOpt.map(_.bundle)
+  val io_mmio_address_prefix = outer.mmioAddressPrefixSinkNodeOpt.map(_.bundle)
   val scratchpadOn = RegInit(false.B)
   val scratchpadMax = tl_in.map(tl => Reg(UInt(width = log2Ceil(nSets * (nWays - 1)))))
   def lineInScratchpad(line: UInt) = scratchpadMax.map(scratchpadOn && line <= _).getOrElse(false.B)
   val scratchpadBase = outer.icacheParams.itimAddr.map { dummy =>
-    p(LookupByHartId)(_.icache.flatMap(_.itimAddr.map(_.U)), io_hartid)
+    p(LookupByHartId)(_.icache.flatMap(_.itimAddr.map(_.U)), io_hartid.get) | io_mmio_address_prefix.get
   }
   def addrMaybeInScratchpad(addr: UInt) = scratchpadBase.map(base => addr >= base && addr < base + outer.size).getOrElse(false.B)
   def addrInScratchpad(addr: UInt) = addrMaybeInScratchpad(addr) && lineInScratchpad(addr(untagBits+log2Ceil(nWays)-1, blockOffBits))

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -45,8 +45,8 @@ trait TileCrossingParamsLike {
   def master: TilePortParamsLike
   /** Parameters describing the contents and behavior of the point where the tile is attached as an interconnect slave. */
   def slave: TilePortParamsLike
-  /** The subnetwork location of the device selecting the apparent base address of control registers inside the tile */
-  def controlBaseAddressPrefixWhere: TLBusWrapperLocation
+  /** The subnetwork location of the device selecting the apparent base address of MMIO devices inside the tile */
+  def mmioBaseAddressPrefixWhere: TLBusWrapperLocation
 }
 
 /** An interface for describing the parameterization of how a particular tile port is connected to an interconnect */
@@ -312,7 +312,7 @@ trait CanAttachTile {
     implicit val p = context.p
     tile.hartIdNode := context.tileHartIdNode
     tile.resetVectorNode := context.tileResetVectorNode
-    context.locateTLBusWrapper(crossingParams.controlBaseAddressPrefixWhere).prefixNode.foreach {
+    context.locateTLBusWrapper(crossingParams.mmioBaseAddressPrefixWhere).prefixNode.foreach {
       tile.mmioAddressPrefixNode := _
     }
   }

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -40,11 +40,13 @@ case object SubsystemExternalResetVectorKey extends Field[Boolean](true)
 /** An interface for describing the parameteization of how Tiles are connected to interconnects */
 trait TileCrossingParamsLike {
   /** The type of clock crossing that should be inserted at the tile boundary. */
-  val crossingType: ClockCrossingType
+  def crossingType: ClockCrossingType
   /** Parameters describing the contents and behavior of the point where the tile is attached as an interconnect master. */
-  val master: TilePortParamsLike
+  def master: TilePortParamsLike
   /** Parameters describing the contents and behavior of the point where the tile is attached as an interconnect slave. */
-  val slave: TilePortParamsLike
+  def slave: TilePortParamsLike
+  /** The subnetwork location of the device selecting the apparent base address of control registers inside the tile */
+  def controlBaseAddressPrefixWhere: TLBusWrapperLocation
 }
 
 /** An interface for describing the parameterization of how a particular tile port is connected to an interconnect */
@@ -310,6 +312,9 @@ trait CanAttachTile {
     implicit val p = context.p
     tile.hartIdNode := context.tileHartIdNode
     tile.resetVectorNode := context.tileResetVectorNode
+    context.locateTLBusWrapper(crossingParams.controlBaseAddressPrefixWhere).prefixNode.foreach {
+      tile.controlAddressPrefixNode := _
+    }
   }
 }
 

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -137,7 +137,7 @@ trait HasTileInputConstants extends InstantiatesTiles { this: BaseSubsystem =>
       val y = dontTouch(prefix | hartIdList(i).U(p(MaxHartIdBits).W))
       if (p(InsertTimingClosureRegistersOnHartIds)) BundleBridgeNexus.safeRegNext(y) else y
     },
-    default = Some(() => 0.U(p(MaxHartIdBits).W)),
+    default = Some(() => 0.U(1.W)),
     inputRequiresOutput = true // guard against this being driven but then ignored in tileHartIdIONodes below
   )
   // TODO: Replace the DebugModuleHartSelFuncs config key with logic to consume the dynamic hart IDs

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -139,7 +139,7 @@ trait HasTileInputConstants extends InstantiatesTiles { this: BaseSubsystem =>
       val y = dontTouch(prefix | hartIdList(i).U(p(MaxHartIdBits).W))
       if (p(InsertTimingClosureRegistersOnHartIds)) BundleBridgeNexus.safeRegNext(y) else y
     },
-    default = Some(() => 0.U(1.W)),
+    default = Some(() => 0.U(p(MaxHartIdBits).W)),
     inputRequiresOutput = true // guard against this being driven but then ignored in tileHartIdIONodes below
   )
   // TODO: Replace the DebugModuleHartSelFuncs config key with logic to consume the dynamic hart IDs

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -313,7 +313,7 @@ trait CanAttachTile {
     tile.hartIdNode := context.tileHartIdNode
     tile.resetVectorNode := context.tileResetVectorNode
     context.locateTLBusWrapper(crossingParams.controlBaseAddressPrefixWhere).prefixNode.foreach {
-      tile.controlAddressPrefixNode := _
+      tile.mmioAddressPrefixNode := _
     }
   }
 }

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -36,7 +36,10 @@ class MemoryBus(params: MemoryBusParams, name: String = "memory_bus")(implicit p
     extends TLBusWrapper(params, name)(p)
 {
   private val replicator = params.replication.map(r => LazyModule(new RegionReplicator(r)))
-  val prefixNode = replicator.map(_.prefix)
+  val prefixNode = replicator.map { r =>
+    r.prefix := addressPrefixNexusNode
+    addressPrefixNexusNode
+  }
 
   private val xbar = LazyModule(new TLXbar).suggestName(busName + "_xbar")
   val inwardNode: TLInwardNode =

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -40,7 +40,10 @@ class PeripheryBus(params: PeripheryBusParams, name: String)(implicit p: Paramet
     extends TLBusWrapper(params, name)
 {
   private val replicator = params.replication.map(r => LazyModule(new RegionReplicator(r)))
-  val prefixNode = replicator.map(_.prefix)
+  val prefixNode = replicator.map { r =>
+    r.prefix := addressPrefixNexusNode
+    addressPrefixNexusNode
+  }
 
   private val fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.all))
   private val node: TLNode = params.atomics.map { pa =>

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -16,7 +16,7 @@ case class RocketCrossingParams(
   crossingType: ClockCrossingType = SynchronousCrossing(),
   master: TileMasterPortParams = TileMasterPortParams(),
   slave: TileSlavePortParams = TileSlavePortParams(),
-  controlBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS
+  mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS
 ) extends TileCrossingParamsLike
 
 case class RocketTileAttachParams(

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -15,7 +15,8 @@ import freechips.rocketchip.tile._
 case class RocketCrossingParams(
   crossingType: ClockCrossingType = SynchronousCrossing(),
   master: TileMasterPortParams = TileMasterPortParams(),
-  slave: TileSlavePortParams = TileSlavePortParams()
+  slave: TileSlavePortParams = TileSlavePortParams(),
+  controlBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS
 ) extends TileCrossingParamsLike
 
 case class RocketTileAttachParams(

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -33,7 +33,10 @@ class SystemBus(params: SystemBusParams, name: String = "system_bus")(implicit p
     extends TLBusWrapper(params, name)
 {
   private val replicator = params.replication.map(r => LazyModule(new RegionReplicator(r)))
-  val prefixNode = replicator.map(_.prefix)
+  val prefixNode = replicator.map { r =>
+    r.prefix := addressPrefixNexusNode
+    addressPrefixNexusNode
+  }
 
   private val system_bus_xbar = LazyModule(new TLXbar(policy = params.policy))
   val inwardNode: TLInwardNode = system_bus_xbar.node :=* TLFIFOFixer(TLFIFOFixer.allVolatile) :=* replicator.map(_.node).getOrElse(TLTempNode())

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -201,6 +201,13 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   val resetVectorSinkNode = BundleBridgeSink[UInt](Some(() => UInt(visiblePhysAddrBits.W)))
   resetVectorSinkNode := resetVectorNode
 
+  /** Node for prefixing base addresses of MMIO slaves. */
+  val controlAddressPrefixNode = BundleBridgeNexus[UInt](
+    inputFn = BundleBridgeNexus.orReduction[UInt](registered = true) _,
+    outputFn = BundleBridgeNexus.fillN[UInt](registered = true) _,
+    default = Some(() => 0.U(1.W))
+  )
+
   // Node for legacy instruction trace from core
   val traceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth, new TracedInstruction()))
   val traceNode = BundleBroadcast[Vec[TracedInstruction]](Some("trace"))

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -227,8 +227,8 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
     * with a static base address (which is looked up based on the driven hartid value).
     */
   val mmioAddressPrefixNexusNode = BundleBridgeNexus[UInt](
-    inputFn = BundleBridgeNexus.orReduction[UInt](registered = true) _,
-    outputFn = BundleBridgeNexus.fillN[UInt](registered = true) _,
+    inputFn = BundleBridgeNexus.orReduction[UInt](registered = false) _,
+    outputFn = BundleBridgeNexus.fillN[UInt](registered = false) _,
     default = Some(() => 0.U(1.W))
   )
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -76,7 +76,7 @@ trait HasNonDiplomaticTileParameters {
     *   a property which is important for hierarchical place & route flows.
     */
   def staticIdForMetadataUseOnly: Int = tileParams.hartId
-  @deprecated("use hartIdSinkNode.bundle or staticIdForMetadataUseOnly", "rocket-chip 1.3")
+  @deprecated("use hartIdSinkNodeOpt.map(_.bundle) or staticIdForMetadataUseOnly", "rocket-chip 1.3")
   def hartId: Int = staticIdForMetadataUseOnly
 
   def cacheBlockBytes = p(CacheBlockBytes)
@@ -202,7 +202,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   resetVectorSinkNode := resetVectorNode
 
   /** Node for prefixing base addresses of MMIO slaves. */
-  val controlAddressPrefixNode = BundleBridgeNexus[UInt](
+  val mmioAddressPrefixNode = BundleBridgeNexus[UInt](
     inputFn = BundleBridgeNexus.orReduction[UInt](registered = true) _,
     outputFn = BundleBridgeNexus.fillN[UInt](registered = true) _,
     default = Some(() => 0.U(1.W))

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -239,7 +239,6 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   protected def traceRetireWidth = tileParams.core.retireWidth
   protected def traceCoreParams = new TraceCoreParams()
   protected def traceCoreSignalName = "tracecore"
-  protected def coreNBreakpoints = tileParams.core.nBreakpoints
   // TODO: Any node marked "consumed by the core" or "driven by the core"
   //       should be moved to either be: a member of a BaseTile subclass,
   //       or actually just a member of the core itself,
@@ -276,7 +275,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
     BundleBridgeNameNode(traceCoreSignalName) :*= traceCoreNexusNode := traceCoreSourceNode
 
   /** Node for watchpoints to control trace driven by core. */
-  val bpwatchSourceNode = BundleBridgeSource(() => Vec(coreNBreakpoints, new BPWatch(traceRetireWidth)))
+  val bpwatchSourceNode = BundleBridgeSource(() => Vec(tileParams.core.nBreakpoints, new BPWatch(traceRetireWidth)))
   /** Node to broadcast watchpoints to control trace. */
   val bpwatchNexusNode = BundleBroadcast[Vec[BPWatch]]()
   /** Node for external consumers to source watchpoints to control trace. */
@@ -366,6 +365,16 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
 
   /** Use for ObjectModel representation of this tile. Subclasses might override this. */
   val logicalTreeNode: LogicalTreeNode = new GenericLogicalTreeNode
+
+  /** Can be used to access derived params calculated by HasCoreParameters
+    *
+    * However, callers must ensure they do not access a diplomatically-determined parameter
+    * before the graph in question has been fully connected.
+    */
+  protected lazy val lazyCoreParamsView: HasCoreParameters = {
+    class C(implicit val p: Parameters) extends HasCoreParameters
+    new C
+  }
 
   this.suggestName(tileParams.name)
 }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -56,11 +56,7 @@ class RocketTile private(
   override val logicalTreeNode = new RocketLogicalTreeNode(this, p(XLen), pgLevels)
 
   val dtim_adapter = tileParams.dcache.flatMap { d => d.scratch.map { s =>
-    val coreParams = {
-      class C(implicit val p: Parameters) extends HasCoreParameters
-      new C
-    }
-    LazyModule(new ScratchpadSlavePort(AddressSet.misaligned(s, d.dataScratchpadBytes), coreParams.coreDataBytes, tileParams.core.useAtomics && !tileParams.core.useAtomicsOnlyForIO))
+    LazyModule(new ScratchpadSlavePort(AddressSet.misaligned(s, d.dataScratchpadBytes), lazyCoreParamsView.coreDataBytes, tileParams.core.useAtomics && !tileParams.core.useAtomicsOnlyForIO))
   }}
   dtim_adapter.foreach(lm => connectTLSlave(lm.node, lm.node.portParams.head.beatBytes))
 

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -69,10 +69,12 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
   def inwardNode: TLInwardNode
   def outwardNode: TLOutwardNode
   def busView: TLEdge
-  val prefixNode: Option[BundleBridgeSink[UInt]]
+  def prefixNode: Option[BundleBridgeNode[UInt]]
   def unifyManagers: List[TLManagerParameters] = ManagerUnification(busView.manager.managers)
   def crossOutHelper = this.crossOut(outwardNode)(ValName("bus_xing"))
   def crossInHelper = this.crossIn(inwardNode)(ValName("bus_xing"))
+
+  protected val addressPrefixNexusNode = BundleBroadcast[UInt](registered = true, default = Some(() => 0.U(1.W)))
 
   def to[T](name: String)(body: => T): T = {
     this { LazyScope(s"coupler_to_${name}") { body } }
@@ -386,7 +388,10 @@ class AddressAdjusterWrapper(params: AddressAdjusterWrapperParams, name: String)
   val inwardNode: TLInwardNode = address_adjuster.map(_.node :*=* TLFIFOFixer(params.policy) :*=* viewNode).getOrElse(viewNode)
   def outwardNode: TLOutwardNode = address_adjuster.map(_.node).getOrElse(viewNode)
   def busView: TLEdge = viewNode.edges.in.head
-  val prefixNode = address_adjuster.map(_.prefix)
+  val prefixNode = address_adjuster.map { a =>
+    a.prefix := addressPrefixNexusNode
+    addressPrefixNexusNode
+  }
   val builtInDevices = BuiltInDevices.none
 }
 

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -74,7 +74,7 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
   def crossOutHelper = this.crossOut(outwardNode)(ValName("bus_xing"))
   def crossInHelper = this.crossIn(inwardNode)(ValName("bus_xing"))
 
-  protected val addressPrefixNexusNode = BundleBroadcast[UInt](registered = true, default = Some(() => 0.U(1.W)))
+  protected val addressPrefixNexusNode = BundleBroadcast[UInt](registered = false, default = Some(() => 0.U(1.W)))
 
   def to[T](name: String)(body: => T): T = {
     this { LazyScope(s"coupler_to_${name}") { body } }


### PR DESCRIPTION
In some configurations we want to be able to relocate the apparent base address of MMIO devices inside the tile. This is problematic for the fast path that the RocketCore has to the ITIM and DTIM, which has to know what the overridden base address should be. To address this limitation this PR adds another (optional) tile input "constant" that is or'd with the base address used in the ITIM and DTIM hit calculations.

This PR also cleans up a few loose ends left over from #2521 and #2497 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
- `BaseTile.mmioAddressPrefixNode` propagates a prefix or supplies a default `0.U`
- `TileCrossingParamsLike.controlBaseAddressPrefixWhere` to lookup prefix information location for tiles
- `mmioAddressPrefixSinkNodeOpt` and `hartIdSinkNodeOpt` in `HellaCache` and `ICache`, defined iff the scratchpads are
- certain `TLBusWrapper` subclasses will propagate their `prefix` information