### PR TITLE
build.wake: Fix string interpolation of bootrom path.

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -130,7 +130,7 @@ global def runRocketChipGenerator options =
     baseFileName
 
   def inputs =
-    def bootrom = source '{rocketChipRoot}/bootrom/bootrom.img'
+    def bootrom = source "{rocketChipRoot}/bootrom/bootrom.img"
     def extras = options.getRocketChipGeneratorOptionsExtraSources
     (bootrom, targetDir, extras) ++ jars
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

I can't actually add @mmjconolly as a reviewer, since he does not have write access to this repo, so @jackkoenig will have to be one to actually approve this PR.

In https://github.com/chipsalliance/rocket-chip/pull/2526, one of the strings that we changed was a single-quoted string, which does not do string interpolation, which resulted in a string that literally had a value of `{rocketChipRoot}/bootrom/bootrom.img`. This fixes it to be a double-quoted string, which _is_ interpolated.

BTW, if either of you knows how to set up a Vim syntax highlighting file to specially highlight interpolated expressions within a string, it'd be nice to get this into the Wake Vim syntax highlighting file so that it's more obvious when a string is not interpolated: https://github.com/sifive/wake/blob/96a0323d49ab12a9313ec0b4c385329e2d0f4232/share/doc/wake/syntax/vim/syntax/wake.vim