### PR TITLE
GitHub Actions: Install the same packages in all jobs.

### DIFF
--- a/.github/workflows/apt-packages.txt
+++ b/.github/workflows/apt-packages.txt
@@ -1,0 +1,16 @@
+autoconf
+automake
+autotools-dev
+bison
+build-essential
+device-tree-compiler
+flex
+g++-4.8
+gawk
+gcc-4.8
+gperf
+libgmp-dev
+libmpc-dev
+libmpfr-dev
+libusb-1.0-0-dev
+texinfo

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,24 +40,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get install -y \
-            autoconf \
-            automake \
-            autotools-dev \
-            bison \
-            build-essential \
-            device-tree-compiler \
-            flex \
-            g++-4.8 \
-            gawk \
-            gcc-4.8 \
-            gperf \
-            libgmp-dev \
-            libmpc-dev \
-            libmpfr-dev \
-            libusb-1.0-0-dev \
-            texinfo
+        run: sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
 
       - if: steps.cache.outputs.cache-hit != 'true'
         env:
@@ -82,7 +65,7 @@ jobs:
       # some C struct not being ABI-compatible across gcc 4 and 5, which we have
       # not debugged yet.
       - name: Install Dependencies
-        run: sudo apt-get install -y autoconf bison flex g++-4.8 gcc-4.8
+        run: sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
 
       - env:
           CXX: g++-4.8
@@ -143,10 +126,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install -y \
-            device-tree-compiler \
-            g++-4.8 \
-            gcc-4.8
+          sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
           python3 -m pip install pexpect==4.3.1
 
       - env:


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

GitHub seems to have a very high failure rate when restoring artifacts from the cache. When this happens, the build will attempt to compile some of the cached artifacts, such as riscv-tools, from scratch. Because we were not installing all of the packages required for building the artifacts in the later jobs, if the cache restoration step fails, then the build will fail.

Installing the same packages across all jobs will ensure that even if the cache fails to restore, then our jobs will still succeed, albeit more slowly.