### PR TITLE
Add CoreMonitorBundles to for late latency writes

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -681,6 +681,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   csr.io.hartid := io.hartid
   io.fpu.fcsr_rm := csr.io.fcsr_rm
   csr.io.fcsr_flags := io.fpu.fcsr_flags
+  io.fpu.time := csr.io.time(31,0)
+  io.fpu.hartid := io.hartid
   csr.io.rocc_interrupt := io.rocc.interrupt
   csr.io.pc := wb_reg_pc
   val tval_valid = wb_xcpt && wb_cause.isOneOf(Causes.illegal_instruction, Causes.breakpoint,
@@ -930,6 +932,27 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
          coreMonitorBundle.inst, coreMonitorBundle.inst)
     }
   }
+
+  // CoreMonitorBundle for late latency writes
+  val xrfWriteBundle = Wire(new CoreMonitorBundle(xLen))
+
+  xrfWriteBundle.clock := clock
+  xrfWriteBundle.reset := reset
+  xrfWriteBundle.hartid := io.hartid
+  xrfWriteBundle.timer := csr.io.time(31,0)
+  xrfWriteBundle.valid := false.B
+  xrfWriteBundle.pc := 0.U
+  xrfWriteBundle.wrdst := rf_waddr
+  xrfWriteBundle.wrenx := rf_wen && !(coreMonitorBundle.wrenx && (rf_waddr === coreMonitorBundle.wrdst))
+  xrfWriteBundle.wrenf := false.B
+  xrfWriteBundle.wrdata := rf_wdata
+  xrfWriteBundle.rd0src := 0.U
+  xrfWriteBundle.rd0val := 0.U
+  xrfWriteBundle.rd1src := 0.U
+  xrfWriteBundle.rd1val := 0.U
+  xrfWriteBundle.inst := 0.U
+  xrfWriteBundle.excpt := false.B
+  xrfWriteBundle.priv_mode := csr.io.trace(0).priv
 
   PlusArg.timeout(
     name = "max_core_cycles",

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -741,27 +741,6 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
       printf("f%d p%d 0x%x\n", load_wb_tag, load_wb_tag + 32, load_wb_data)
   }
 
-  // CoreMonitorBundle to monitor fp register file writes
-  val frfWriteBundle = Wire(new CoreMonitorBundle(xLen))
-
-  frfWriteBundle.clock := clock
-  frfWriteBundle.reset := reset
-  frfWriteBundle.hartid := io.hartid
-  frfWriteBundle.timer := io.time(31,0)
-  frfWriteBundle.valid := false.B
-  frfWriteBundle.pc := 0.U
-  frfWriteBundle.wrdst := Mux(load_wb, load_wb_tag, waddr)
-  frfWriteBundle.wrenx := false.B
-  frfWriteBundle.wrenf := (!wbInfo(0).cp && wen(0)) || divSqrt_wen || load_wb
-  frfWriteBundle.wrdata := Mux(load_wb, load_wb_data, ieee(wdata))
-  frfWriteBundle.rd0src := 0.U
-  frfWriteBundle.rd0val := 0.U
-  frfWriteBundle.rd1src := 0.U
-  frfWriteBundle.rd1val := 0.U
-  frfWriteBundle.inst := 0.U
-  frfWriteBundle.excpt := false.B
-  frfWriteBundle.priv_mode := 0.U
-
   val ex_rs = ex_ra.map(a => regfile(a))
   when (io.valid) {
     when (id_ctrl.ren1) {
@@ -896,6 +875,27 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
     io.cp_resp.valid := Bool(true)
   }
   io.cp_req.ready := !ex_reg_valid
+
+  // CoreMonitorBundle to monitor fp register file writes
+  val frfWriteBundle = Wire(new CoreMonitorBundle(xLen))
+
+  frfWriteBundle.clock := clock
+  frfWriteBundle.reset := reset
+  frfWriteBundle.hartid := io.hartid
+  frfWriteBundle.timer := io.time(31,0)
+  frfWriteBundle.valid := false.B
+  frfWriteBundle.pc := 0.U
+  frfWriteBundle.wrdst := Mux(load_wb, load_wb_tag, waddr)
+  frfWriteBundle.wrenx := false.B
+  frfWriteBundle.wrenf := (!wbInfo(0).cp && wen(0)) || divSqrt_wen || load_wb
+  frfWriteBundle.wrdata := Mux(load_wb, load_wb_data, ieee(wdata))
+  frfWriteBundle.rd0src := 0.U
+  frfWriteBundle.rd0val := 0.U
+  frfWriteBundle.rd1src := 0.U
+  frfWriteBundle.rd1val := 0.U
+  frfWriteBundle.inst := 0.U
+  frfWriteBundle.excpt := false.B
+  frfWriteBundle.priv_mode := 0.U
 
   val wb_toint_valid = wb_reg_valid && wb_ctrl.toint
   val wb_toint_exc = RegEnable(fpiu.io.out.bits.exc, mem_ctrl.toint)

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -579,7 +579,7 @@ class FPToFP(val latency: Int)(implicit p: Parameters) extends FPUModule()(p) wi
 
 class MulAddRecFNPipe(latency: Int, expWidth: Int, sigWidth: Int) extends Module
 {
-    require(latency<=2)
+    require(latency<=2) 
 
     val io = new Bundle {
         val validin = Bool(INPUT)
@@ -613,7 +613,7 @@ class MulAddRecFNPipe(latency: Int, expWidth: Int, sigWidth: Int) extends Module
     val valid_stage0 = Wire(Bool())
     val roundingMode_stage0 = Wire(UInt(width=3))
     val detectTininess_stage0 = Wire(UInt(width=1))
-
+  
     val postmul_regs = if(latency>0) 1 else 0
     mulAddRecFNToRaw_postMul.io.fromPreMul   := Pipe(io.validin, mulAddRecFNToRaw_preMul.io.toPostMul, postmul_regs).bits
     mulAddRecFNToRaw_postMul.io.mulAddResult := Pipe(io.validin, mulAddResult, postmul_regs).bits
@@ -621,7 +621,7 @@ class MulAddRecFNPipe(latency: Int, expWidth: Int, sigWidth: Int) extends Module
     roundingMode_stage0                      := Pipe(io.validin, io.roundingMode, postmul_regs).bits
     detectTininess_stage0                    := Pipe(io.validin, io.detectTininess, postmul_regs).bits
     valid_stage0                             := Pipe(io.validin, false.B, postmul_regs).valid
-
+    
     //------------------------------------------------------------------------
     //------------------------------------------------------------------------
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
The current coreMonitorBundle does not detect the late latency load writes and fp writes. This is adding the CoreMonitorBundle definitions to detect such cases.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
