### PR TITLE
Bump chisel3 to v3.3.2-ish

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -10,7 +10,7 @@
         "source": "git@github.com:sifive/api-chisel3-sifive.git"
     },
     {
-        "commit": "21ea734d809395962a8d3195a76377f6e44308f3",
+        "commit": "cc2971feb15d4bc8cb4a8138b5a095ccbc92dcc3",
         "name": "chisel3",
         "source": "git@github.com:freechipsproject/chisel3.git"
     },


### PR DESCRIPTION
Bumps to 3.3.x merge-base with v3.3.2

### Feature
* Add Grouping API (https://github.com/freechipsproject/chisel3/pull/1073)
* Provide `Decoupled.empty` (https://github.com/freechipsproject/chisel3/pull/785)

### Bugfixes
* Report errors as exceptions when hit outside of Chisel contexts (https://github.com/freechipsproject/chisel3/pull/1425)

### Performance
* Fix Double Elaboration (https://github.com/freechipsproject/chisel3/pull/1426)
* Memoize hashcode of ChiselCircuitAnnotation (https://github.com/freechipsproject/chisel3/pull/1485)
  * Fixes a performance bug affecting Stage/Phase users


<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Bump Chisel to near v3.3.2
