### PR TITLE
wake: publish location of the ivydependencies.json

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -1,5 +1,6 @@
 
 global def rocketChipRoot = here
+publish ivyDepLocations = rocketChipRoot, Nil
 
 global def hardfloatScalaModule =
   makeScalaModuleFromJSON here "hardfloat"

--- a/ci-tests/wake_scala_compilation
+++ b/ci-tests/wake_scala_compilation
@@ -34,5 +34,5 @@ echo "Compile Scala"
 
 export WAKE_PATH=$PATH
 wake --init .
-wake --no-tty -j1 -dv 'compileScalaModule rocketchipScalaModule | getPathResult'
+wake --no-tty -p1 -dv 'compileScalaModule rocketchipScalaModule | getPathResult'
 cd ..

--- a/ci-tests/wake_scala_compilation
+++ b/ci-tests/wake_scala_compilation
@@ -3,8 +3,8 @@ set -ex
 
 echo "Installing Wake"
 
-wget https://github.com/sifive/wake/releases/download/v0.15.1/ubuntu-16.04-wake_0.15.1-1_amd64.deb
-sudo dpkg -i ubuntu-16.04-wake_0.15.1-1_amd64.deb
+wget https://github.com/sifive/wake/releases/download/v0.17.2/ubuntu-16-04-wake_0.17.2-1_amd64.deb
+sudo dpkg -i ubuntu-16-04-wake_0.17.2-1_amd64.deb
 
 
 echo "Installing Protobuf"

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -28,5 +28,10 @@
         "commit": "d619ca850846d2ec36da64bf8a28e7d9a3d9ed1b",
         "name": "api-config-chipsalliance",
         "source": "git@github.com:chipsalliance/api-config-chipsalliance.git"
+    },
+    {
+        "commit": "771f11581b86079bf3411f85ce77495e7444c08e",
+        "name": "api-scala-sifive",
+        "source": "git@github.com:sifive/api-scala-sifive.git"
     }
 ]


### PR DESCRIPTION
Publish the directory location of the ivydependencies.json for the api-scala wake rules to consume

Note: 
* adds direct wit dependency on api-scala-sifive, as we now use the `ivyDepLocations` topic
* api-scala-sifive requires use of wake 0.17.2, so update the rocket-chip CI to reflect this

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
