### PR TITLE
HartId/ResetVector: Correct the input width calculation

### DIFF
--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.tile
 
 import Chisel._
+
 import freechips.rocketchip.config._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.util._

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.tile
 
 import Chisel._
-import Chisel.ImplicitConversions._
 import freechips.rocketchip.config._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.util._

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.tile
 
 import Chisel._
-
+import Chisel.ImplicitConversions._
 import freechips.rocketchip.config._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.util._
@@ -131,8 +131,8 @@ class CoreInterrupts(implicit p: Parameters) extends TileInterrupts()(p) {
 trait HasCoreIO extends HasTileParameters {
   implicit val p: Parameters
   val io = new CoreBundle()(p) {
-    val hartid = UInt(hartIdLen).asInput
-    val reset_vector = UInt(resetVectorLen).asInput
+    val hartid = UInt(hartIdLen.W).asInput
+    val reset_vector = UInt(resetVectorLen.W).asInput
     val interrupts = new CoreInterrupts().asInput
     val imem  = new FrontendIO
     val dmem = new HellaCacheIO


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Follow up to #2531 which introduced this bug (https://github.com/chipsalliance/rocket-chip/blame/master/src/main/scala/tile/Core.scala#L134)

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix a bug in the computation of HartID and ResetVector width going into the Tile due to improper use of Chisel compatibility mode functions.