### PR TITLE
Add mergify.io automation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,58 @@
+pull_request_rules:
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews:
+
+pull_request_rules:
+  - name: automatic squash-and-merge on CI success and review
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - base=master
+      - label="Please Merge"
+      - label!="DO NOT MERGE"
+      - label!="bp-conflict"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+        strict_method: merge
+
+  - name: backport to 1.3.x
+    conditions:
+      - merged
+      - base=master
+      - milestone=1.3.x
+    actions:
+      backport:
+        branches:
+          - 1.3.x
+        ignore_conflicts: True
+        label_conflicts: "bp-conflict"
+      label:
+        add: [Backported]
+
+  - name: label Mergify backport PR
+    conditions:
+      - base=1.3.x
+      - body~=This is an automated backport of pull request \#\d+ done by Mergify
+    actions:
+      label:
+        add: [Backport]
+
+  - name: automatic squash-and-merge of backport PRs
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "#changes-requested-reviews-by=0"
+      - base=1.3.x
+      - label="Backport"
+      - label!="DO NOT MERGE"
+      - label!="bp-conflict"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+        strict_method: merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,4 @@
 pull_request_rules:
-  - name: remove outdated reviews
-    conditions:
-      - base=master
-    actions:
-      dismiss_reviews:
-
-pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
       - status-success=continuous-integration/travis-ci/pr
@@ -20,36 +13,15 @@ pull_request_rules:
         method: merge
         strict: smart
         strict_method: merge
-
-  - name: backport to 2020.04.x
-    conditions:
-      - merged
-      - base=master
-      - label=bp-to-2020.04.x
-    actions:
-      backport:
-        branches:
-          - 2020.04.x
-        ignore_conflicts: True
-        label_conflicts: "bp-conflict"
-      label:
-        add: [Backported]
-
-  - name: label Mergify backport PR
-    conditions:
-      - base=2020.04.x
-      - body~=This is an automated backport of pull request \#\d+ done by Mergify
-    actions:
-      label:
-        add: [Backport]
-
-  - name: automatic squash-and-merge of backport PRs
+        
+  - name: automatic squash and merge on CI success and review
     conditions:
       - status-success=continuous-integration/travis-ci/pr
+      - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
-      - base=2020.04.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
+      - base=master
+      - label="SQUASH & MERGE WITH MERGIFY"
+      - label!="DONT MERGE"
       - label!="bp-conflict"
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,8 +12,8 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - base=master
-      - label="Please Merge"
-      - label!="DO NOT MERGE"
+      - label="MERGE WITH MERGIFY"
+      - label!="DONT MERGE"
       - label!="bp-conflict"
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,8 @@
 pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
+      - status-success=Check Wit Manifest
       - status-success=Prepare riscv-tools Cache
-      - status-success=Check With Manifest
       - status-success=Prepare Verilator Cache
       - status-success=Check Wake Compilation
       - status-success=Test (1)
@@ -27,8 +27,8 @@ pull_request_rules:
         
   - name: automatic squash and merge on CI success and review
     conditions:
+      - status-success=Check Wit Manifest
       - status-success=Prepare riscv-tools Cache
-      - status-success=Check With Manifest
       - status-success=Prepare Verilator Cache
       - status-success=Check Wake Compilation
       - status-success=Test (1)

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,15 +21,15 @@ pull_request_rules:
         strict: smart
         strict_method: merge
 
-  - name: backport to 1.3.x
+  - name: backport to 2020.04.x
     conditions:
       - merged
       - base=master
-      - milestone=1.3.x
+      - label=bp-to-2020.04.x
     actions:
       backport:
         branches:
-          - 1.3.x
+          - 2020.04.x
         ignore_conflicts: True
         label_conflicts: "bp-conflict"
       label:
@@ -37,7 +37,7 @@ pull_request_rules:
 
   - name: label Mergify backport PR
     conditions:
-      - base=1.3.x
+      - base=2020.04.x
       - body~=This is an automated backport of pull request \#\d+ done by Mergify
     actions:
       label:
@@ -47,7 +47,7 @@ pull_request_rules:
     conditions:
       - status-success=continuous-integration/travis-ci/pr
       - "#changes-requested-reviews-by=0"
-      - base=1.3.x
+      - base=2020.04.x
       - label="Backport"
       - label!="DO NOT MERGE"
       - label!="bp-conflict"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,7 +17,7 @@ pull_request_rules:
       - label!="bp-conflict"
     actions:
       merge:
-        method: squash
+        method: merge
         strict: smart
         strict_method: merge
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
       dismiss_reviews:
 
 pull_request_rules:
-  - name: automatic squash-and-merge on CI success and review
+  - name: automatic merge on CI success and review
     conditions:
       - status-success=continuous-integration/travis-ci/pr
       - "#approved-reviews-by>=1"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,18 @@
 pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Prepare riscv-tools Cache
+      - status-success=Check With Manifest
+      - status-success=Prepare Verilator Cache
+      - status-success=Check Wake Compilation
+      - status-success=Test (1)
+      - status-success=Test (2)
+      - status-success=Test (3)
+      - status-success=Test (4)
+      - status-success=Test (5)
+      - status-success=Test (6)
+      - status-success=Test (7)
+      - status-success=Test (8)
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - base=master
@@ -16,7 +27,18 @@ pull_request_rules:
         
   - name: automatic squash and merge on CI success and review
     conditions:
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Prepare riscv-tools Cache
+      - status-success=Check With Manifest
+      - status-success=Prepare Verilator Cache
+      - status-success=Check Wake Compilation
+      - status-success=Test (1)
+      - status-success=Test (2)
+      - status-success=Test (3)
+      - status-success=Test (4)
+      - status-success=Test (5)
+      - status-success=Test (6)
+      - status-success=Test (7)
+      - status-success=Test (8)
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - base=master

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,6 @@ pull_request_rules:
       - base=master
       - label="MERGE WITH MERGIFY"
       - label!="DONT MERGE"
-      - label!="bp-conflict"
     actions:
       merge:
         method: merge
@@ -44,7 +43,6 @@ pull_request_rules:
       - base=master
       - label="SQUASH & MERGE WITH MERGIFY"
       - label!="DONT MERGE"
-      - label!="bp-conflict"
     actions:
       merge:
         method: squash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,24 @@ Please ensure to fill out the PR template appropriately and update it if your PR
 
 Currently, the requirements for merging a PR are:
  + At least one approved review from an administrator
- + Passing at least one of the GitHub actions checks or the Travis checks
+ + Passing at least one of the GitHub actions checks or the Travis checks (Travis is currently disabled).
+ 
+#### <a name="merging"></a> Automatic Merging with mergify.io
+
+This repository uses https://mergify.io/ to automate some pull request tasks.
+Currently, the only rule is that a PR to `master` can be merged automatically if the following conditions are met:
+ + At least one approved review from an administrator
+ + No disapproving reviews
+ + No merge conflicts
+ + All GitHub Actions CI checks passing
+ + The `DONT MERGE` label is not applied
+ + One of the `MERGE WITH MERGIFY` or `SQUASH & MERGE WITH MERGIFY` labels are applied
+ 
+Our Mergify setup uses a `strict` merge: PRs that match the above conditions will not be merged unless they have passed CI _and are up to date with the current tip of master branch_. Mergify handles updating the matching PRs automatically.
+This ensures that two conflicting PRs won't break CI unexpectedly.
+However, this means your PR may need to keep running CI if others are merging.
+To mitigate the effects of this, we have enabled Mergify's "smart" strict strategy.
+Mergify will automatically queue the mergify-managed PRs and update them serially, one at a time.
 
 ### <a name="bumping"></a> Bumping Submodules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Currently, the only rule is that a PR to `master` can be merged automatically if
  + The `DONT MERGE` label is not applied
  + One of the `MERGE WITH MERGIFY` or `SQUASH & MERGE WITH MERGIFY` labels are applied
  
-Our Mergify setup uses a `strict` merge: PRs that match the above conditions will not be merged unless they have passed CI _and are up to date with the current tip of master branch_. Mergify handles updating the matching PRs automatically.
+Our Mergify setup enforces a `strict` merge: PRs that match the above conditions will not be merged unless they have passed CI _and are up to date with the current tip of master branch_. Mergify handles updating the matching PRs automatically.
 This ensures that two conflicting PRs won't break CI unexpectedly.
 However, this means your PR may need to keep running CI if others are merging.
 To mitigate the effects of this, we have enabled Mergify's "smart" strict strategy.
@@ -45,7 +45,7 @@ Mergify will automatically queue the mergify-managed PRs and update them seriall
 
 Several projects are managed as git submodules as well as [Wit](https://github.com/sifive/wit) dependencies.
 
-### When to bump
+#### When to bump
 
 Most projects will be bumped by developers as needed; however,
 sometimes users may wish to speed up the bumping process.
@@ -53,7 +53,7 @@ For more stable projects like Chisel 3 and FIRRTL,
 please only bump to stable branches as defined by the specific subproject.
 As of March 2020 these branches are `3.2.x` in Chisel 3 and `1.2.x` in FIRRTL.
 
-### How to bump
+#### How to bump
 
 1. Bump the Git submodule
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to Rocket Chip!
 
 + [Submitting a PR](#submitting)
 + [Conditions for Merging a PR](#merging)
+  + [Automatic Merging with mergify.io](#mergify)
 + [Bumping Submodules](#bumping)
 
 ### <a name="submitting"></a> Submitting a PR
@@ -24,7 +25,7 @@ Currently, the requirements for merging a PR are:
  + At least one approved review from an administrator
  + Passing at least one of the GitHub actions checks or the Travis checks (Travis is currently disabled).
  
-#### <a name="merging"></a> Automatic Merging with mergify.io
+#### <a name="mergify"></a> Automatic Merging with mergify.io
 
 This repository uses https://mergify.io/ to automate some pull request tasks.
 Currently, the only rule is that a PR to `master` can be merged automatically if the following conditions are met:


### PR DESCRIPTION
This PR adds mergify (https://mergify.io/) rules to enable automated merge-on-pass and smart ordering of PR merges. It would also enable backporting to release branches if that were a thing.

~I am marking this as DRAFT because I will be playing around with this on a personal fork of this repo.~

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable --> None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

mergify.io automation added to enable simpler pull request merging and potentially backporting to stable branches.