### PR TITLE
Tile PRCI Domain Wrappers

### DIFF
--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -24,11 +24,13 @@ class GroundTestSubsystem(implicit p: Parameters)
   // No PLIC in ground test; so just sink the interrupts to nowhere
   IntSinkNode(IntSinkPortSimple()) :=* ibus.toPLIC
 
+  val tileStatusNodes = tiles.collect { case t: GroundTestTile => t.statusNode.makeSink() }
+
   override lazy val module = new GroundTestSubsystemModuleImp(this)
 }
 
 class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer) {
   val success = IO(Bool(OUTPUT))
-  val status = dontTouch(DebugCombiner(outer.tiles.collect { case t: GroundTestTile => t.module.status }))
+  val status = dontTouch(DebugCombiner(outer.tileStatusNodes.map(_.bundle)))
   success := outer.tileCeaseSinkNode.in.head._1.asUInt.andR
 }

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -38,6 +38,7 @@ abstract class GroundTestTile(
   val cpuDevice: SimpleDevice = new SimpleDevice("groundtest", Nil)
   val intOutwardNode: IntOutwardNode = IntIdentityNode()
   val slaveNode: TLInwardNode = TLIdentityNode()
+  val statusNode = BundleBridgeSource(() => new GroundTestStatus)
 
   val dcacheOpt = params.dcache.map { dc => LazyModule(
     if (dc.nMSHRs == 0) new DCache(staticIdForMetadataUseOnly, crossing)
@@ -50,7 +51,7 @@ abstract class GroundTestTile(
 }
 
 class GroundTestTileModuleImp(outer: GroundTestTile) extends BaseTileModuleImp(outer) {
-  val status = IO(new GroundTestStatus)
+  val status = outer.statusNode.bundle
   val halt_and_catch_fire = None
 
   outer.dcacheOpt foreach { dcache =>

--- a/src/main/scala/prci/ClockBundles.scala
+++ b/src/main/scala/prci/ClockBundles.scala
@@ -8,8 +8,8 @@ import scala.collection.immutable.ListMap
 
 class ClockBundle(val params: ClockBundleParameters) extends Bundle
 {
-  val clock = Clock()
-  val reset = Reset()
+  val clock = Output(Clock())
+  val reset = Output(Reset())
 }
 
 class ClockGroupBundle(val params: ClockGroupBundleParameters) extends Bundle

--- a/src/main/scala/prci/ClockDomain.scala
+++ b/src/main/scala/prci/ClockDomain.scala
@@ -23,14 +23,20 @@ abstract class ClockDomain(implicit p: Parameters) extends LazyModule
   }
 }
 
-class ClockSinkDomain(take: Option[ClockParameters] = None)(implicit p: Parameters) extends ClockDomain
+class ClockSinkDomain(
+  take: Option[ClockParameters] = None,
+  name: Option[String] = None)
+  (implicit p: Parameters) extends ClockDomain
 {
-  val clockNode = ClockSinkNode(Seq(ClockSinkParameters(take = take)))
+  val clockNode = ClockSinkNode(Seq(ClockSinkParameters(take = take, name = name)))
   def clockBundle = clockNode.in.head._1
 }
 
-class ClockSourceDomain(give: Option[ClockParameters] = None)(implicit p: Parameters) extends ClockDomain
+class ClockSourceDomain(
+  give: Option[ClockParameters] = None,
+  name: Option[String] = None)
+  (implicit p: Parameters) extends ClockDomain
 {
-  val clockNode = ClockSourceNode(Seq(ClockSourceParameters(give = give)))
+  val clockNode = ClockSourceNode(Seq(ClockSourceParameters(give = give, name = name)))
   def clockBundle = clockNode.out.head._1
 }

--- a/src/main/scala/prci/ClockGroupDriver.scala
+++ b/src/main/scala/prci/ClockGroupDriver.scala
@@ -2,36 +2,46 @@
 package freechips.rocketchip.prci
 
 import chisel3._
+import chisel3.experimental.IO
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{InModuleBody, ModuleValue, ValName}
-import freechips.rocketchip.util.{HeterogeneousBag}
+import freechips.rocketchip.util.{RecordMap}
 
 /** Used to parameterize the creation of simple clock group drivers */
 case class ClockGroupDriverParameters(
   num: Int = 1,
   driveFn: ClockGroupDriver.DriveFn = ClockGroupDriver.driveFromImplicitClock
 ) {
-  def drive(node: ClockGroupEphemeralNode)(implicit p: Parameters, vn: ValName): ModuleValue[HeterogeneousBag[ClockGroupBundle]] = {
+  def drive(node: ClockGroupEphemeralNode)(implicit p: Parameters, vn: ValName): ModuleValue[RecordMap[ClockBundle]] = {
     driveFn(node, num, p, vn)
   }
 }
 
 object ClockGroupDriver {
-  type DriveFn = (ClockGroupEphemeralNode, Int, Parameters, ValName) => ModuleValue[HeterogeneousBag[ClockGroupBundle]]
+  type DriveFn = (ClockGroupEphemeralNode, Int, Parameters, ValName) => ModuleValue[RecordMap[ClockBundle]]
 
   /** Drive all members of all groups from the Chisel implicit clock */
   def driveFromImplicitClock: DriveFn = { (groups, num, p, vn) =>
     implicit val pp = p
     val dummyClockGroupSourceNode: ClockGroupSourceNode = SimpleClockGroupSource(num)
     groups :*= dummyClockGroupSourceNode
-    InModuleBody { HeterogeneousBag[ClockGroupBundle](Nil) }
+    InModuleBody { RecordMap[ClockBundle]() }
   }
 
-  /** Drive all members of all groups from cloned IOs */
+  /** Drive all members of all groups from a flattened IO representation */
   def driveFromIOs: DriveFn = { (groups, num, p, vn) =>
     implicit val pp = p
     val ioClockGroupSourceNode = ClockGroupSourceNode(List.fill(num) { ClockGroupSourceParameters() })
     groups :*= ioClockGroupSourceNode
-    InModuleBody { ioClockGroupSourceNode.makeIOs()(vn) }
+    InModuleBody {
+      val bundles = ioClockGroupSourceNode.out.map(_._1)
+      val elements =  bundles.map(_.member.elements).flatten
+      val io = IO(Flipped(RecordMap(elements.map { case (name, data) =>
+        name -> data.cloneType
+      }:_*)))
+
+      elements.foreach { case (name, data) => io(name).foreach { data := _ } }
+      io.suggestName(vn.name)
+    }
   }
 }

--- a/src/main/scala/prci/ClockGroupDriver.scala
+++ b/src/main/scala/prci/ClockGroupDriver.scala
@@ -1,0 +1,37 @@
+// See LICENSE.SiFive for license details.
+package freechips.rocketchip.prci
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy.{InModuleBody, ModuleValue, ValName}
+import freechips.rocketchip.util.{HeterogeneousBag}
+
+/** Used to parameterize the creation of simple clock group drivers */
+case class ClockGroupDriverParameters(
+  num: Int = 1,
+  driveFn: ClockGroupDriver.DriveFn = ClockGroupDriver.driveFromImplicitClock
+) {
+  def drive(node: ClockGroupEphemeralNode)(implicit p: Parameters, vn: ValName): ModuleValue[HeterogeneousBag[ClockGroupBundle]] = {
+    driveFn(node, num, p, vn)
+  }
+}
+
+object ClockGroupDriver {
+  type DriveFn = (ClockGroupEphemeralNode, Int, Parameters, ValName) => ModuleValue[HeterogeneousBag[ClockGroupBundle]]
+
+  /** Drive all members of all groups from the Chisel implicit clock */
+  def driveFromImplicitClock: DriveFn = { (groups, num, p, vn) =>
+    implicit val pp = p
+    val dummyClockGroupSourceNode: ClockGroupSourceNode = SimpleClockGroupSource(num)
+    groups :*= dummyClockGroupSourceNode
+    InModuleBody { HeterogeneousBag[ClockGroupBundle](Nil) }
+  }
+
+  /** Drive all members of all groups from cloned IOs */
+  def driveFromIOs: DriveFn = { (groups, num, p, vn) =>
+    implicit val pp = p
+    val ioClockGroupSourceNode = ClockGroupSourceNode(List.fill(num) { ClockGroupSourceParameters() })
+    groups :*= ioClockGroupSourceNode
+    InModuleBody { ioClockGroupSourceNode.makeIOs()(vn) }
+  }
+}

--- a/src/main/scala/prci/ClockNodes.scala
+++ b/src/main/scala/prci/ClockNodes.scala
@@ -37,6 +37,16 @@ case class ClockIdentityNode()(implicit valName: ValName) extends IdentityNode(C
 
 case class ClockEphemeralNode()(implicit valName: ValName) extends EphemeralNode(ClockImp)()
 
+object ClockNameNode {
+  def apply(name: ValName) = ClockIdentityNode()(name)
+  def apply(name: Option[String]): ClockIdentityNode = apply(ValName(name.getOrElse("with_no_name")))
+  def apply(name: String): ClockIdentityNode = apply(Some(name))
+}
+
+object ClockTempNode {
+  def apply(): ClockEphemeralNode = ClockEphemeralNode()(ValName("temp"))
+}
+
 object ClockSinkNode
 {
   def apply(

--- a/src/main/scala/prci/ClockParameters.scala
+++ b/src/main/scala/prci/ClockParameters.scala
@@ -23,7 +23,8 @@ case class ClockParameters(
 
 case class ClockSourceParameters(
   jitterPS: Option[Double] = None, // if known at chisel elaboration
-  give:     Option[ClockParameters] = None)
+  give:     Option[ClockParameters] = None,
+  name:     Option[String] = None)
 
 case class ClockSinkParameters(
   phaseDeg:      Double = 0,
@@ -31,7 +32,8 @@ case class ClockSinkParameters(
   phaseErrorDeg: Double = 5,
   freqErrorPPM:  Double = 10000,
   jitterPS:      Double = 200,
-  take:          Option[ClockParameters] = None) 
+  take:          Option[ClockParameters] = None,
+  name:          Option[String] = None)
 {
   require (phaseErrorDeg >= 0)
   require (freqErrorPPM >= 0)
@@ -74,7 +76,7 @@ case class ClockGroupEdgeParameters(
   val sourceParameters = ClockSourceParameters()
   val members: ListMap[String, ClockEdgeParameters] = ListMap(
     sink.members.zipWithIndex.map { case (s, i) =>
-      s"${sink.name}_${i}" -> ClockEdgeParameters(sourceParameters, s, params, sourceInfo)
+      s"${sink.name}_${s.name.getOrElse(i)}" -> ClockEdgeParameters(sourceParameters, s, params, sourceInfo)
   }:_*)
 
   val bundle = ClockGroupBundleParameters(members.map{ case (k, v) => k -> v.bundle})

--- a/src/main/scala/prci/ClockParameters.scala
+++ b/src/main/scala/prci/ClockParameters.scala
@@ -4,8 +4,6 @@ package freechips.rocketchip.prci
 import chisel3._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy.{InModuleBody, ModuleValue, ValName}
-import freechips.rocketchip.util.{HeterogeneousBag}
 import scala.math.max
 import scala.collection.immutable.ListMap
 
@@ -80,32 +78,4 @@ case class ClockGroupEdgeParameters(
   }:_*)
 
   val bundle = ClockGroupBundleParameters(members.map{ case (k, v) => k -> v.bundle})
-}
-
-// Used to create simple clock group drivers that just use the Chisel implicit clock
-case class ClockGroupDriverParameters(
-  num: Int = 1,
-  driveFn: ClockGroupDriver.DriveFn = ClockGroupDriver.driveFromImplicitClock
-) {
-  def drive(node: ClockGroupEphemeralNode)(implicit p: Parameters, vn: ValName): ModuleValue[HeterogeneousBag[ClockGroupBundle]] = {
-    driveFn(node, num, p, vn)
-  }
-}
-
-object ClockGroupDriver {
-  type DriveFn = (ClockGroupEphemeralNode, Int, Parameters, ValName) => ModuleValue[HeterogeneousBag[ClockGroupBundle]]
-
-  def driveFromImplicitClock: DriveFn = { (groups, num, p, vn) =>
-    implicit val pp = p
-    val dummyClockGroupSourceNode: ClockGroupSourceNode = SimpleClockGroupSource(num)
-    groups :*= dummyClockGroupSourceNode
-    InModuleBody { HeterogeneousBag[ClockGroupBundle](Nil) }
-  }
-
-  def driveFromIOs: DriveFn = { (groups, num, p, vn) =>
-    implicit val pp = p
-    val ioClockGroupSourceNode = ClockGroupSourceNode(List.fill(num) { ClockGroupSourceParameters() })
-    groups :*= ioClockGroupSourceNode
-    InModuleBody { ioClockGroupSourceNode.makeIOs()(vn) }
-  }
 }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.util._
 
 case object SubsystemDriveAsyncClockGroupsKey extends Field[Option[ClockGroupDriverParameters]](Some(ClockGroupDriverParameters(1)))
-case object AsyncClockGroupsKey extends Field[ClockGroupEphemeralNode](ClockGroupEphemeralNode()(ValName("async_clock_groups")))
+case object AsyncClockGroupsKey extends Field[ClockGroupEphemeralNode](ClockGroupEphemeralNode()(ValName("clock_sources")))
 case class TLNetworkTopologyLocated(where: HierarchicalLocation) extends Field[Seq[CanInstantiateWithinContextThatHasTileLinkLocations with CanConnectWithinContextThatHasTileLinkLocations]]
 case class TLManagerViewpointLocated(where: HierarchicalLocation) extends Field[Location[TLBusWrapper]](SBUS)
 
@@ -50,10 +50,10 @@ case object SubsystemResetSchemeKey extends Field[SubsystemResetScheme](ResetSyn
 trait HasConfigurablePRCILocations { this: HasPRCILocations =>
   val ibus = new InterruptBusWrapper()
   implicit val asyncClockGroupsNode = p(AsyncClockGroupsKey)
-  val async_clock_groups =
+  val clock_sources: ModuleValue[RecordMap[ClockBundle]] =
     p(SubsystemDriveAsyncClockGroupsKey)
       .map(_.drive(asyncClockGroupsNode))
-      .getOrElse(InModuleBody { HeterogeneousBag[ClockGroupBundle](Nil) })
+      .getOrElse(InModuleBody { RecordMap[ClockBundle]() })
 }
 
 /** Look up the topology configuration for the TL buses located within this layer of the hierarchy */

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -10,8 +10,9 @@ import freechips.rocketchip.devices.tilelink.{BasicBusBlocker, BasicBusBlockerPa
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalModuleTree}
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tile.{BaseTile, LookupByHartIdImpl, TileParams, InstantiableTileParams, MaxHartIdBits}
+import freechips.rocketchip.tile.{BaseTile, LookupByHartIdImpl, TileParams, InstantiableTileParams, MaxHartIdBits, TilePRCIDomain}
 import freechips.rocketchip.tilelink._
+import freechips.rocketchip.prci.ClockGroup
 import freechips.rocketchip.util._
 
 /** Entry point for Config-uring the presence of Tiles */
@@ -223,98 +224,119 @@ trait CanAttachTile {
   def lookup: LookupByHartIdImpl
 
   /** Narrow waist through which all tiles are intended to pass while being instantiated. */
-  def instantiate(implicit p: Parameters): TileType = {
-    val tile = LazyModule(tileParams.instantiate(crossingParams, lookup))
-    tile
+  def instantiate(implicit p: Parameters): TilePRCIDomain[TileType] = {
+    val tile_prci_domain = LazyModule(new TilePRCIDomain[TileType] {
+      val tile = LazyModule(tileParams.instantiate(crossingParams, lookup))
+    })
+    tile_prci_domain
   }
 
   /** A default set of connections that need to occur for most tile types */
-  def connect(tile: TileType, context: TileContextType): Unit = {
-    connectMasterPorts(tile, context)
-    connectSlavePorts(tile, context)
-    connectInterrupts(tile, context)
-    connectInputConstants(tile, context)
-    LogicalModuleTree.add(context.logicalTreeNode, tile.logicalTreeNode)
+  def connect(domain: TilePRCIDomain[TileType], context: TileContextType): Unit = {
+    connectMasterPorts(domain, context)
+    connectSlavePorts(domain, context)
+    connectInterrupts(domain, context)
+    connectPRC(domain, context)
+    connectOutputNotifications(domain.tile, context)
+    connectInputConstants(domain.tile, context)
+    LogicalModuleTree.add(context.logicalTreeNode, domain.tile.logicalTreeNode)
   }
 
   /** Connect the port where the tile is the master to a TileLink interconnect. */
-  def connectMasterPorts(tile: TileType, context: Attachable): Unit = {
+  def connectMasterPorts(domain: TilePRCIDomain[TileType], context: Attachable): Unit = {
     implicit val p = context.p
     val dataBus = context.locateTLBusWrapper(crossingParams.master.where)
     dataBus.coupleFrom(tileParams.name.getOrElse("tile")) { bus =>
-      bus :=* crossingParams.master.injectNode(context) :=* tile.crossMasterPort()
+      bus :=* crossingParams.master.injectNode(context) :=* domain.crossMasterPort(crossingParams.crossingType)
     }
   }
 
   /** Connect the port where the tile is the slave to a TileLink interconnect. */
-  def connectSlavePorts(tile: TileType, context: Attachable): Unit = {
+  def connectSlavePorts(domain: TilePRCIDomain[TileType], context: Attachable): Unit = {
     implicit val p = context.p
     DisableMonitors { implicit p =>
       val controlBus = context.locateTLBusWrapper(crossingParams.slave.where)
       controlBus.coupleTo(tileParams.name.getOrElse("tile")) { bus =>
-        tile.crossSlavePort() :*= crossingParams.slave.injectNode(context) :*= TLWidthWidget(controlBus.beatBytes) :*= bus
+        domain.crossSlavePort(crossingParams.crossingType) :*= crossingParams.slave.injectNode(context) :*= TLWidthWidget(controlBus.beatBytes) :*= bus
       }
     }
   }
 
-  /** Connect the various interrupt and notification wires going to and from the tile. */
-  def connectInterrupts(tile: TileType, context: TileContextType): Unit = {
+  /** Connect the various interrupts sent to and and raised by the tile. */
+  def connectInterrupts(domain: TilePRCIDomain[TileType], context: TileContextType): Unit = {
     implicit val p = context.p
     // NOTE: The order of calls to := matters! They must match how interrupts
     //       are decoded from tile.intInwardNode inside the tile. For this reason,
     //       we stub out missing interrupts with constant sources here.
 
     // 1. Debug interrupt is definitely asynchronous in all cases.
-    tile.intInwardNode :=
+    domain.tile.intInwardNode :=
       context.debugOpt
-        .map { tile { IntSyncAsyncCrossingSink(3) } := _.intnode }
+        .map { domain { IntSyncAsyncCrossingSink(3) } := _.intnode }
         .getOrElse { NullIntSource() }
 
     // 2. The CLINT and PLIC output interrupts are synchronous to the TileLink bus clock,
     //    so might need to be synchronized depending on the Tile's crossing type.
 
     //    From CLINT: "msip" and "mtip"
-    tile.crossIntIn() :=
+    domain.crossIntIn(crossingParams.crossingType) :=
       context.clintOpt.map { _.intnode }
         .getOrElse { NullIntSource(sources = CLINTConsts.ints) }
 
     //    From PLIC: "meip"
-    tile.crossIntIn() :=
+    domain.crossIntIn(crossingParams.crossingType) :=
       context.plicOpt .map { _.intnode }
         .getOrElse { context.meipNode.get }
 
     //    From PLIC: "seip" (only if supervisor mode is enabled)
-    if (tile.tileParams.core.hasSupervisorMode) {
-      tile.crossIntIn() :=
+    if (domain.tile.tileParams.core.hasSupervisorMode) {
+      domain.crossIntIn(crossingParams.crossingType) :=
         context.plicOpt .map { _.intnode }
           .getOrElse { NullIntSource() }
     }
 
     // 3. Local Interrupts ("lip") are required to already be synchronous to the Tile's clock.
-    // (they are connected to tile.intInwardNode in a seperate trait)
+    // (they are connected to domain.tile.intInwardNode in a seperate trait)
 
     // 4. Interrupts coming out of the tile are sent to the PLIC,
     //    so might need to be synchronized depending on the Tile's crossing type.
     context.plicOpt.foreach { plic =>
       FlipRendering { implicit p =>
-        plic.intnode :=* tile.crossIntOut()
+        plic.intnode :=* domain.crossIntOut(crossingParams.crossingType)
       }
     }
+  }
 
-    // 5. Notifications of tile status are collected without needing to be clock-crossed
+  /** Notifications of tile status are connected to be broadcast without needing to be clock-crossed. */
+  def connectOutputNotifications(tile: TileType, context: TileContextType): Unit = {
+    implicit val p = context.p
     context.tileHaltXbarNode :=* tile.haltNode
     context.tileWFIXbarNode :=* tile.wfiNode
     context.tileCeaseXbarNode :=* tile.ceaseNode
   }
 
-  /** Connect the input to the tile that are assumed to be constant during normal operation. */
+  /** Connect inputs to the tile that are assumed to be constant during normal operation, and so are not clock-crossed. */
   def connectInputConstants(tile: TileType, context: TileContextType): Unit = {
     implicit val p = context.p
+    val tlBusToGetPrefixFrom = context.locateTLBusWrapper(crossingParams.mmioBaseAddressPrefixWhere)
     tile.hartIdNode := context.tileHartIdNode
     tile.resetVectorNode := context.tileResetVectorNode
-    context.locateTLBusWrapper(crossingParams.mmioBaseAddressPrefixWhere).prefixNode.foreach {
-      tile.mmioAddressPrefixNode := _
-    }
+    tlBusToGetPrefixFrom.prefixNode.foreach { tile.mmioAddressPrefixNode := _ }
+  }
+
+  /** Connect power/reset/clock resources. */
+  def connectPRC(domain: TilePRCIDomain[TileType], context: TileContextType): Unit = {
+    implicit val p = context.p
+    val tlBusToGetClockDriverFrom = context.locateTLBusWrapper(crossingParams.master.where)
+    domain.clockNode := (crossingParams.crossingType match {
+      case _: SynchronousCrossing => tlBusToGetClockDriverFrom.fixedClockNode
+      case _: RationalCrossing => tlBusToGetClockDriverFrom.clockNode
+      case _: AsynchronousCrossing => {
+        val tileClockGroup = ClockGroup()
+        tileClockGroup := context.asyncClockGroupsNode
+        tileClockGroup
+      }
+    })
   }
 }
 
@@ -330,7 +352,8 @@ trait InstantiatesTiles { this: BaseSubsystem =>
   val tileAttachParams: Seq[CanAttachTile] = p(TilesLocated(location)).sortBy(_.tileParams.hartId)
 
   /** The actual list of instantiated tiles in this subsystem. */
-  val tiles: Seq[BaseTile] = tileAttachParams.map(_.instantiate(p))
+  val tile_prci_domains: Seq[TilePRCIDomain[_]] = tileAttachParams.map(_.instantiate(p))
+  val tiles: Seq[BaseTile] = tile_prci_domains.map(_.tile.asInstanceOf[BaseTile])
 
   // Helper functions for accessing certain parameters that are popular to refer to in subsystem code
   val tileParams: Seq[TileParams] = tileAttachParams.map(_.tileParams)
@@ -348,8 +371,8 @@ trait HasTiles extends InstantiatesTiles with HasCoreMonitorBundles with Default
   implicit val p: Parameters
 
   // connect all the tiles to interconnect attachment points made available in this subsystem context
-  tileAttachParams.zip(tiles).foreach { case (params, t) =>
-    params.connect(t.asInstanceOf[params.TileType], this.asInstanceOf[params.TileContextType])
+  tileAttachParams.zip(tile_prci_domains).foreach { case (params, td) =>
+    params.connect(td.asInstanceOf[TilePRCIDomain[params.TileType]], this.asInstanceOf[params.TileContextType])
   }
 }
 

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -227,7 +227,7 @@ trait CanAttachTile {
 
   /** Narrow waist through which all tiles are intended to pass while being instantiated. */
   def instantiate(implicit p: Parameters): TilePRCIDomain[TileType] = {
-    val tile_prci_domain = LazyModule(new TilePRCIDomain[TileType] {
+    val tile_prci_domain = LazyModule(new TilePRCIDomain[TileType](tileParams.hartId) {
       val tile = LazyModule(tileParams.instantiate(crossingParams, lookup))
     })
     tile_prci_domain

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -22,6 +22,7 @@ case class RocketCrossingParams(
   def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = {
     ClockTempNode() // TODO reset stretcher could go here, parameterized by args to this case class
   }
+  def forceSeparateClockReset: Boolean = false
 }
 
 case class RocketTileAttachParams(

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -10,6 +10,7 @@ import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugM
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
 import freechips.rocketchip.diplomaticobjectmodel.model._
+import freechips.rocketchip.prci.{ClockNode, ClockTempNode}
 import freechips.rocketchip.tile._
 
 case class RocketCrossingParams(
@@ -17,7 +18,11 @@ case class RocketCrossingParams(
   master: TileMasterPortParams = TileMasterPortParams(),
   slave: TileSlavePortParams = TileSlavePortParams(),
   mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS
-) extends TileCrossingParamsLike
+) extends TileCrossingParamsLike {
+  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = {
+    ClockTempNode() // TODO reset stretcher could go here, parameterized by args to this case class
+  }
+}
 
 case class RocketTileAttachParams(
   tileParams: RocketTileParams,

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -325,18 +325,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
     * microarchitecture specific, so this may need to be overridden
     * in subclasses of this class.
     */
-  protected def makeMasterBoundaryBuffers(implicit p: Parameters) = TLBuffer(BufferParams.none)
-
-  /** External code looking to connect the ports where this tile masters an interconnect
-    * (while also crossing clock domains) can call this.
-    */
-  def crossMasterPort(): TLOutwardNode = {
-    val tlMasterXing = this.crossOut(crossing match {
-      case RationalCrossing(_) => this { makeMasterBoundaryBuffers } :=* masterNode
-      case _ => masterNode
-    })
-    tlMasterXing(crossing)
-  }
+  def makeMasterBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = TLBuffer(BufferParams.none)
 
   /** Helper function to insert additional buffers on slave ports at the boundary of the tile.
     *
@@ -344,24 +333,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
     * microarchitecture specific, so this may need to be overridden
     * in subclasses of this class.
     */
-  protected def makeSlaveBoundaryBuffers(implicit p: Parameters) = TLBuffer(BufferParams.none)
-
-  /** External code looking to connect the ports where this tile is slaved to an interconnect
-    * (while also crossing clock domains) can call this.
-    */
-  def crossSlavePort(): TLInwardNode = { DisableMonitors { implicit p => FlipRendering { implicit p =>
-    val tlSlaveXing = this.crossIn(crossing match {
-      case RationalCrossing(_) => slaveNode :*= this { makeSlaveBoundaryBuffers }
-      case _ => slaveNode
-    })
-    tlSlaveXing(crossing)
-  } } }
-
-  /** External code looking to connect and clock-cross the interrupts driven into this tile can call this. */
-  def crossIntIn(): IntInwardNode = crossIntIn(intInwardNode)
-
-  /** External code looking to connect and clock-cross the interrupts raised by devices inside this tile can call this. */
-  def crossIntOut(): IntOutwardNode = crossIntOut(intOutwardNode)
+ def makeSlaveBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = TLBuffer(BufferParams.none)
 
   /** Use for ObjectModel representation of this tile. Subclasses might override this. */
   val logicalTreeNode: LogicalTreeNode = new GenericLogicalTreeNode

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{DCacheLogicalTree
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.rocket._
-import freechips.rocketchip.subsystem.{SubsystemResetSchemeKey, ResetSynchronous, TileCrossingParamsLike}
+import freechips.rocketchip.subsystem.TileCrossingParamsLike
 import freechips.rocketchip.util._
 
 case class RocketTileParams(
@@ -128,9 +128,6 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
     with HasLazyRoCCModule
     with HasICacheFrontendModule {
   Annotated.params(this, outer.rocketParams)
-
-  require(p(SubsystemResetSchemeKey)  == ResetSynchronous,
-    "Rocket only supports synchronous reset at  this time")
 
   val core = Module(new Rocket(outer)(outer.p))
 

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -104,14 +104,18 @@ class RocketTile private(
 
   override lazy val module = new RocketTileModuleImp(this)
 
-  override def makeMasterBoundaryBuffers(implicit p: Parameters) = {
-    if (!rocketParams.boundaryBuffers) super.makeMasterBoundaryBuffers
-    else TLBuffer(BufferParams.none, BufferParams.flow, BufferParams.none, BufferParams.flow, BufferParams(1))
+  override def makeMasterBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = crossing match {
+    case _: RationalCrossing =>
+      if (!rocketParams.boundaryBuffers) TLBuffer(BufferParams.none)
+      else TLBuffer(BufferParams.none, BufferParams.flow, BufferParams.none, BufferParams.flow, BufferParams(1))
+    case _ => TLBuffer(BufferParams.none)
   }
 
-  override def makeSlaveBoundaryBuffers(implicit p: Parameters) = {
-    if (!rocketParams.boundaryBuffers) super.makeSlaveBoundaryBuffers
-    else TLBuffer(BufferParams.flow, BufferParams.none, BufferParams.none, BufferParams.none, BufferParams.none)
+  override def makeSlaveBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = crossing match {
+    case _: RationalCrossing =>
+      if (!rocketParams.boundaryBuffers) TLBuffer(BufferParams.none)
+      else TLBuffer(BufferParams.flow, BufferParams.none, BufferParams.none, BufferParams.none, BufferParams.none)
+    case _ => TLBuffer(BufferParams.none)
   }
 
   val dCacheLogicalTreeNode = new DCacheLogicalTreeNode(dcache, dtim_adapter.map(_.device), rocketParams.dcache.get)

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.tile
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.prci.ClockSinkDomain
+import freechips.rocketchip.prci._
 import freechips.rocketchip.tilelink._
 
 /** A wrapper containing all logic necessary to safely place a tile
@@ -17,9 +17,13 @@ import freechips.rocketchip.tilelink._
   * and any other IOs related to PRCI control.
   */
 abstract class TilePRCIDomain[T <: BaseTile](id: Int)(implicit p: Parameters)
-    extends ClockSinkDomain(take = None, name = Some(s"core_$id"))
+    extends ClockDomain
 {
   val tile: T
+
+  val clockNode = ClockIdentityNode()
+  val clockSinkNode = ClockSinkNode(Seq(ClockSinkParameters(take = None, name = Some(s"core_$id"))))
+  def clockBundle = clockSinkNode.in.head._1
 
   /** External code looking to connect and clock-cross the interrupts driven into this tile can call this. */
   def crossIntIn(crossing: ClockCrossingType):  IntInwardNode = {

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -1,0 +1,53 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tile
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
+import freechips.rocketchip.prci.ClockSinkDomain
+import freechips.rocketchip.tilelink._
+
+/** A wrapper containing all logic necessary to safely place a tile
+  * inside of a particular Power/Reset/Clock/Interrupt domain.
+  *
+  * This adds a layer to the module hierarchy which is a parent of the tile
+  * and should contain all logic related to clock crossings, isolation cells,
+  * hierarchical P&R boundary buffers, core-local interrupt handling,
+  * and any other IOs related to PRCI control.
+  */
+abstract class TilePRCIDomain[T <: BaseTile](implicit p: Parameters) extends ClockSinkDomain(None) {
+  val tile: T
+
+  /** External code looking to connect and clock-cross the interrupts driven into this tile can call this. */
+  def crossIntIn(crossing: ClockCrossingType):  IntInwardNode = {
+    val intInXing = this.crossIn(tile.intInwardNode)
+    intInXing(crossing)
+  }
+
+  /** External code looking to connect and clock-cross the interrupts raised by devices inside this tile can call this. */
+  def crossIntOut(crossing: ClockCrossingType): IntOutwardNode = {
+    val intOutXing = this.crossOut(tile.intOutwardNode)
+    intOutXing(crossing)
+  }
+
+  /** External code looking to connect the ports where this tile is slaved to an interconnect
+    * (while also crossing clock domains) can call this.
+    */
+  def crossSlavePort(crossing: ClockCrossingType): TLInwardNode = { DisableMonitors { implicit p => FlipRendering { implicit p =>
+    val tlSlaveXing = this.crossIn({
+      tile.slaveNode :*= this { tile.makeSlaveBoundaryBuffers(crossing) }
+    })
+    tlSlaveXing(crossing)
+  } } }
+
+  /** External code looking to connect the ports where this tile masters an interconnect
+    * (while also crossing clock domains) can call this.
+    */
+  def crossMasterPort(crossing: ClockCrossingType): TLOutwardNode = {
+    val tlMasterXing = this.crossOut({
+      this { tile.makeMasterBoundaryBuffers(crossing) } :=* tile.masterNode
+    })
+    tlMasterXing(crossing)
+  }
+}

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -16,7 +16,9 @@ import freechips.rocketchip.tilelink._
   * hierarchical P&R boundary buffers, core-local interrupt handling,
   * and any other IOs related to PRCI control.
   */
-abstract class TilePRCIDomain[T <: BaseTile](implicit p: Parameters) extends ClockSinkDomain(None) {
+abstract class TilePRCIDomain[T <: BaseTile](id: Int)(implicit p: Parameters)
+    extends ClockSinkDomain(take = None, name = Some(s"core_$id"))
+{
   val tile: T
 
   /** External code looking to connect and clock-cross the interrupts driven into this tile can call this. */


### PR DESCRIPTION
Tiles are now instantiated inside of a wrapper whose purpose is to contain logic related to their Power, Clock, Reset and/or Interrupt domain. In particular:
- The layer has a diplomatically-derived clock and reset, which are used to drive the tile clock and reset.
- The portion of TileLink clock crossings that are supposed to be in the tile clock domain are instantiated in this layer.
- Interrupt synchronizers are instantiated in this layer.
- Boundary buffers and isolation cells related to hierarchical P&R are to be instantiated in this layer.
- In the future core-local interrupt handlers could be instantiated in this layer.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
- All tiles are now instantiated inside of a wrapper that contains logic related to their power, reset, clock and interrupt domain. This change adds a level to the module hierarchy path to the tile.
