### PR TITLE
Port LazyRoCC examples to chisel3

### DIFF
--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -299,7 +299,6 @@ class CharacterCountExampleModuleImp(outer: CharacterCountExample)(implicit p: P
     count := 0.U
     finished := false.B
     state := s_acq
-    printf(p"received cmd 0x${Hexadecimal(io.cmd.bits.inst.asUInt)} addr=0x${Hexadecimal(io.cmd.bits.rs1)} needle=0x${Hexadecimal(io.cmd.bits.rs2)}\n");
   }
 
   when (tl_out.a.fire()) { state := s_gnt }

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -340,6 +340,7 @@ class BlackBoxExample(opcodes: OpcodeSet, blackBoxFile: String)(implicit p: Para
 
 class BlackBoxExampleModuleImp(outer: BlackBoxExample, blackBoxFile: String)(implicit p: Parameters)
     extends LazyRoCCModuleImp(outer)
+    with RequireSyncReset
     with HasCoreParameters {
 
   val blackbox = {
@@ -361,7 +362,7 @@ class BlackBoxExampleModuleImp(outer: BlackBoxExample, blackBoxFile: String)(imp
         val io = IO( new Bundle {
                       val clock = Input(Clock())
                       val reset = Input(Reset())
-                      val rocc = roccIo.cloneType
+                      val rocc = chiselTypeOf(roccIo)
                     })
         override def desiredName: String = blackBoxFile
         addResource(s"/vsrc/$blackBoxFile.v")

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -254,7 +254,7 @@ class CharacterCountExampleModuleImp(outer: CharacterCountExample)(implicit p: P
   val needle = Reg(UInt(8.W))
   val addr = Reg(UInt(coreMaxAddrBits.W))
   val count = Reg(UInt(xLen.W))
-  val resp_rd = Reg(io.resp.bits.rd.cloneType)
+  val resp_rd = Reg(chiselTypeOf(io.resp.bits.rd))
 
   val addr_block = addr(coreMaxAddrBits - 1, blockOffset)
   val offset = addr(blockOffset - 1, 0)

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -197,7 +197,7 @@ class  TranslatorExample(opcodes: OpcodeSet)(implicit p: Parameters) extends Laz
 class TranslatorExampleModuleImp(outer: TranslatorExample)(implicit p: Parameters) extends LazyRoCCModuleImp(outer)
     with HasCoreParameters {
   val req_addr = Reg(UInt(coreMaxAddrBits.W))
-  val req_rd = Reg(io.resp.bits.rd.cloneType)
+  val req_rd = Reg(chiselTypeOf(io.resp.bits.rd))
   val req_offset = req_addr(pgIdxBits - 1, 0)
   val req_vpn = req_addr(coreMaxAddrBits - 1, pgIdxBits)
   val pte = Reg(new PTE)

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -7,7 +7,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.util.HasBlackBoxResource
 import chisel3.experimental.IntParam
-import chisel3.internal.naming.chiselName
+import chisel3.experimental.chiselName
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.rocket._

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -77,14 +77,14 @@ trait HasLazyRoCC extends CanHavePTW { this: BaseTile =>
   roccs.map(_.atlNode).foreach { atl => tlMasterXbar.node :=* atl }
   roccs.map(_.tlNode).foreach { tl => tlOtherMastersNode :=* tl }
 
-  nPTWPorts += roccs.map(_.nPTWPorts).foldLeft(0)(_ + _)
+  nPTWPorts += roccs.map(_.nPTWPorts).sum
   nDCachePorts += roccs.size
 }
 
 trait HasLazyRoCCModule extends CanHavePTWModule
     with HasCoreParameters { this: RocketTileModuleImp with HasFpuOpt =>
 
-  val (respArb, cmdRouter) = if(outer.roccs.size > 0) {
+  val (respArb, cmdRouter) = if(outer.roccs.nonEmpty) {
     val respArb = Module(new RRArbiter(new RoCCResponse()(outer.p), outer.roccs.size))
     val cmdRouter = Module(new RoccCommandRouter(outer.roccs.map(_.opcodes))(outer.p))
     outer.roccs.zipWithIndex.foreach { case (rocc, i) =>


### PR DESCRIPTION
Convert LazyRoCC examples to use chisel3 syntax instead of legacy Chisel compatibility.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
