### PR TITLE
Add CreditedIO to support register-register interfacing for AXI4 and TL

### DIFF
--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -109,3 +109,12 @@ class AXI4AsyncBundle(params: AXI4AsyncBundleParameters) extends AXI4AsyncBundle
   val ar = new AsyncBundle(new AXI4BundleAR(params.base), params.async)
   val r  = new AsyncBundle(new AXI4BundleR (params.base), params.async).flip
 }
+
+class AXI4CreditedBundle(params: AXI4BundleParameters) extends AXI4BundleBase(params)
+{
+  val aw = CreditedIO(new AXI4BundleAW(params))
+  val w  = CreditedIO(new AXI4BundleW (params))
+  val b  = CreditedIO(new AXI4BundleB (params)).flip
+  val ar = CreditedIO(new AXI4BundleAR(params))
+  val r  = CreditedIO(new AXI4BundleR (params)).flip
+}

--- a/src/main/scala/amba/axi4/Credited.scala
+++ b/src/main/scala/amba/axi4/Credited.scala
@@ -82,3 +82,32 @@ object AXI4CreditedSink {
   def apply(delay: CreditedDelay)(implicit p: Parameters): AXI4CreditedSinkNode = apply(AXI4CreditedDelay(delay))
   def apply()(implicit p: Parameters): AXI4CreditedSinkNode = apply(CreditedDelay(1, 1))
 }
+
+/** Synthesizeable unit tests */
+import freechips.rocketchip.unittest._
+
+class AXI4RAMCreditedCrossing(txns: Int, params: CreditedCrossing)(implicit p: Parameters) extends LazyModule {
+  val model = LazyModule(new TLRAMModel("AXI4CreditedCrossing"))
+  val fuzz = LazyModule(new TLFuzzer(txns))
+  val toaxi = LazyModule(new TLToAXI4)
+  val island = LazyModule(new CrossingWrapper(params))
+  val ram  = island { LazyModule(new AXI4RAM(AddressSet(0x0, 0x3ff))) }
+
+  island.crossAXI4In(ram.node) := toaxi.node := TLDelayer(0.1) := model.node := fuzz.node
+
+  lazy val module = new LazyModuleImp(this) with UnitTestModule {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class AXI4RAMCreditedCrossingTest(txns: Int = 5000, timeout: Int = 500000)(implicit p: Parameters) extends UnitTest(timeout) {
+  val dut_1000 = Module(LazyModule(new AXI4RAMCreditedCrossing(txns, CreditedCrossing(CreditedDelay(1, 0), CreditedDelay(0, 0)))).module)
+  val dut_0100 = Module(LazyModule(new AXI4RAMCreditedCrossing(txns, CreditedCrossing(CreditedDelay(0, 1), CreditedDelay(0, 0)))).module)
+  val dut_0010 = Module(LazyModule(new AXI4RAMCreditedCrossing(txns, CreditedCrossing(CreditedDelay(0, 0), CreditedDelay(1, 0)))).module)
+  val dut_0001 = Module(LazyModule(new AXI4RAMCreditedCrossing(txns, CreditedCrossing(CreditedDelay(0, 0), CreditedDelay(0, 1)))).module)
+  val dut_1111 = Module(LazyModule(new AXI4RAMCreditedCrossing(txns, CreditedCrossing(CreditedDelay(1, 1), CreditedDelay(1, 1)))).module)
+
+  val duts = Seq(dut_1000, dut_0100, dut_0010, dut_0001, dut_1111)
+  duts.foreach { _.io.start := true.B }
+  io.finished := duts.map(_.io.finished).reduce(_ && _)
+}

--- a/src/main/scala/amba/axi4/Credited.scala
+++ b/src/main/scala/amba/axi4/Credited.scala
@@ -1,0 +1,84 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.amba.axi4
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.subsystem.CrossingWrapper
+import freechips.rocketchip.util._
+
+class AXI4CreditedBuffer(delay: AXI4CreditedDelay)(implicit p: Parameters) extends LazyModule
+{
+  val node = AXI4CreditedAdapterNode(
+    masterFn = p => p.copy(delay = delay + p.delay),
+    slaveFn  = p => p.copy(delay = delay + p.delay))
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      out.aw :<> in.aw.pipeline(delay.aw)
+      out.w :<> in.w.pipeline(delay.w)
+      in.b :<> out.b.pipeline(delay.b)
+      out.ar :<> in.ar.pipeline(delay.ar)
+      in.r :<> out.r.pipeline(delay.r)
+    }
+  }
+}
+
+object AXI4CreditedBuffer {
+  def apply(delay: AXI4CreditedDelay)(implicit p: Parameters): AXI4CreditedAdapterNode = {
+    val buffer = LazyModule(new AXI4CreditedBuffer(delay))
+    buffer.node
+  }
+  def apply(delay: CreditedDelay)(implicit p: Parameters): AXI4CreditedAdapterNode = apply(AXI4CreditedDelay(delay))
+  def apply()(implicit p: Parameters): AXI4CreditedAdapterNode = apply(CreditedDelay(1, 1))
+}
+
+class AXI4CreditedSource(delay: AXI4CreditedDelay)(implicit p: Parameters) extends LazyModule
+{
+  val node = AXI4CreditedSourceNode(delay)
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      val tld = edgeOut.delay
+      out.aw :<> CreditedIO.fromSender(in.aw, tld.aw.total).pipeline(delay.aw)
+      out.w :<> CreditedIO.fromSender(in.w, tld.w.total).pipeline(delay.w)
+      in.b :<> out.b.pipeline(delay.b).toReceiver(tld.b.total)
+      out.ar :<> CreditedIO.fromSender(in.ar, tld.ar.total).pipeline(delay.ar)
+      in.r :<> out.r.pipeline(delay.r).toReceiver(tld.r.total)
+    }
+  }
+}
+
+object AXI4CreditedSource {
+  def apply(delay: AXI4CreditedDelay)(implicit p: Parameters): AXI4CreditedSourceNode = {
+    val source = LazyModule(new AXI4CreditedSource(delay))
+    source.node
+  }
+  def apply(delay: CreditedDelay)(implicit p: Parameters): AXI4CreditedSourceNode = apply(AXI4CreditedDelay(delay))
+  def apply()(implicit p: Parameters): AXI4CreditedSourceNode = apply(CreditedDelay(1, 1))
+}
+
+class AXI4CreditedSink(delay: AXI4CreditedDelay)(implicit p: Parameters) extends LazyModule
+{
+  val node = AXI4CreditedSinkNode(delay)
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      val tld = edgeIn.delay
+      out.aw :<> in.aw.pipeline(delay.aw).toReceiver(tld.aw.total)
+      out.w :<> in.w.pipeline(delay.w).toReceiver(tld.w.total)
+      in.b :<> CreditedIO.fromSender(out.b, tld.b.total).pipeline(delay.b)
+      out.ar :<> in.ar.pipeline(delay.ar).toReceiver(tld.ar.total)
+      in.r :<> CreditedIO.fromSender(out.r, tld.r.total).pipeline(delay.r)
+    }
+  }
+}
+
+object AXI4CreditedSink {
+  def apply(delay: AXI4CreditedDelay)(implicit p: Parameters): AXI4CreditedSinkNode = {
+    val sink = LazyModule(new AXI4CreditedSink(delay))
+    sink.node
+  }
+  def apply(delay: CreditedDelay)(implicit p: Parameters): AXI4CreditedSinkNode = apply(AXI4CreditedDelay(delay))
+  def apply()(implicit p: Parameters): AXI4CreditedSinkNode = apply(CreditedDelay(1, 1))
+}

--- a/src/main/scala/amba/axi4/CrossingHelper.scala
+++ b/src/main/scala/amba/axi4/CrossingHelper.scala
@@ -14,6 +14,8 @@ case class AXI4InwardCrossingHelper(name: String, scope: LazyScope, node: AXI4In
         throw new IllegalArgumentException("AXI4 Rational crossing unimplemented")
       case SynchronousCrossing(buffer) =>
         node :*=* scope { AXI4Buffer(buffer) :*=* AXI4NameNode(name) } :*=* AXI4NameNode(name)
+      case CreditedCrossing(sourceDelay, sinkDelay) =>
+        node :*=* scope { AXI4CreditedSink(sinkDelay) :*=* AXI4CreditedNameNode(name) } :*=* AXI4CreditedNameNode(name) :*=* AXI4CreditedSource(sourceDelay)
     }
   }
 }
@@ -27,6 +29,8 @@ case class AXI4OutwardCrossingHelper(name: String, scope: LazyScope, node: AXI4O
         throw new IllegalArgumentException("AXI4 Rational crossing unimplemented")
       case SynchronousCrossing(buffer) =>
         AXI4NameNode(name) :*=* scope { AXI4NameNode(name) :*=* AXI4Buffer(buffer) } :*=* node
+      case CreditedCrossing(sourceDelay, sinkDelay) =>
+        AXI4CreditedSink(sinkDelay) :*=* AXI4CreditedNameNode(name) :*=* scope { AXI4CreditedNameNode(name) :*=* AXI4CreditedSource(sourceDelay) } :*=* node
     }
   }
 }

--- a/src/main/scala/amba/axi4/Nodes.scala
+++ b/src/main/scala/amba/axi4/Nodes.scala
@@ -78,3 +78,39 @@ object AXI4AsyncNameNode {
   def apply(name: Option[String]): AXI4AsyncIdentityNode = apply((ValName(name.getOrElse("with_no_name"))))
   def apply(name: String): AXI4AsyncIdentityNode = apply(Some(name))
 }
+
+object AXI4CreditedImp extends SimpleNodeImp[AXI4CreditedMasterPortParameters, AXI4CreditedSlavePortParameters, AXI4CreditedEdgeParameters, AXI4CreditedBundle]
+{
+  def edge(pd: AXI4CreditedMasterPortParameters, pu: AXI4CreditedSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4CreditedEdgeParameters(pd, pu, p, sourceInfo)
+  def bundle(e: AXI4CreditedEdgeParameters) = new AXI4CreditedBundle(e.bundle)
+  def render(e: AXI4CreditedEdgeParameters) = RenderedEdge(colour = "#ffff00" /* yellow */, label = e.delay.toString)
+
+  override def mixO(pd: AXI4CreditedMasterPortParameters, node: OutwardNode[AXI4CreditedMasterPortParameters, AXI4CreditedSlavePortParameters, AXI4CreditedBundle]): AXI4CreditedMasterPortParameters  =
+   pd.copy(base = pd.base.copy(masters = pd.base.masters.map  { c => c.copy (nodePath = node +: c.nodePath) }))
+  override def mixI(pu: AXI4CreditedSlavePortParameters, node: InwardNode[AXI4CreditedMasterPortParameters, AXI4CreditedSlavePortParameters, AXI4CreditedBundle]): AXI4CreditedSlavePortParameters =
+   pu.copy(base = pu.base.copy(slaves  = pu.base.slaves.map { m => m.copy (nodePath = node +: m.nodePath) }))
+}
+
+case class AXI4CreditedSourceNode(delay: AXI4CreditedDelay)(implicit valName: ValName)
+  extends MixedAdapterNode(AXI4Imp, AXI4CreditedImp)(
+    dFn = { p => AXI4CreditedMasterPortParameters(delay, p) },
+    uFn = { p => p.base.copy(minLatency = 1) })
+
+case class AXI4CreditedSinkNode(delay: AXI4CreditedDelay)(implicit valName: ValName)
+  extends MixedAdapterNode(AXI4CreditedImp, AXI4Imp)(
+    dFn = { p => p.base },
+    uFn = { p => AXI4CreditedSlavePortParameters(delay, p) })
+
+case class AXI4CreditedAdapterNode(
+  masterFn: AXI4CreditedMasterPortParameters => AXI4CreditedMasterPortParameters = { s => s },
+  slaveFn:  AXI4CreditedSlavePortParameters  => AXI4CreditedSlavePortParameters  = { s => s })(
+  implicit valName: ValName)
+  extends AdapterNode(AXI4CreditedImp)(masterFn, slaveFn)
+
+case class AXI4CreditedIdentityNode()(implicit valName: ValName) extends IdentityNode(AXI4CreditedImp)()
+
+object AXI4CreditedNameNode {
+  def apply(name: ValName) = AXI4CreditedIdentityNode()(name)
+  def apply(name: Option[String]): AXI4CreditedIdentityNode = apply((ValName(name.getOrElse("with_no_name"))))
+  def apply(name: String): AXI4CreditedIdentityNode = apply(Some(name))
+}

--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -174,6 +174,35 @@ case class AXI4BufferParams(
   def copyInOut(x: BufferParams) = this.copyIn(x).copyOut(x)
 }
 
+case class AXI4CreditedDelay(
+  aw: CreditedDelay,
+  w:  CreditedDelay,
+  b:  CreditedDelay,
+  ar: CreditedDelay,
+  r:  CreditedDelay)
+{
+  def + (that: AXI4CreditedDelay): AXI4CreditedDelay = AXI4CreditedDelay(
+    aw = aw + that.aw,
+    w  = w  + that.w,
+    b  = b  + that.b,
+    ar = ar + that.ar,
+    r  = r  + that.r)
+
+  override def toString = s"(${aw}, ${w}, ${b}, ${ar}, ${r})"
+}
+
+object AXI4CreditedDelay {
+  def apply(delay: CreditedDelay): AXI4CreditedDelay = apply(delay, delay, delay.flip, delay, delay.flip)
+}
+
+case class AXI4CreditedSlavePortParameters(delay: AXI4CreditedDelay, base: AXI4SlavePortParameters)
+case class AXI4CreditedMasterPortParameters(delay: AXI4CreditedDelay, base: AXI4MasterPortParameters)
+case class AXI4CreditedEdgeParameters(master: AXI4CreditedMasterPortParameters, slave: AXI4CreditedSlavePortParameters, params: Parameters, sourceInfo: SourceInfo)
+{
+  val delay = master.delay + slave.delay
+  val bundle = AXI4BundleParameters(master.base, slave.base)
+}
+
 /** Pretty printing of AXI4 source id maps */
 class AXI4IdMap(axi4: AXI4MasterPortParameters) extends IdMap[AXI4IdMapEntry] {
   private val axi4Digits = String.valueOf(axi4.endId-1).length()

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.diplomacy
 
 import Chisel._
 import chisel3.util.{IrrevocableIO,ReadyValidIO}
-import freechips.rocketchip.util.{ShiftQueue, RationalDirection, FastToSlow, AsyncQueueParams}
+import freechips.rocketchip.util.{ShiftQueue, RationalDirection, FastToSlow, AsyncQueueParams, CreditedDelay}
 import scala.reflect.ClassTag
 
 /** Options for describing the attributes of memory regions */
@@ -315,6 +315,12 @@ case class RationalCrossing(direction: RationalDirection = FastToSlow) extends C
 case class AsynchronousCrossing(depth: Int = 8, sourceSync: Int = 3, sinkSync: Int = 3, safe: Boolean = true, narrow: Boolean = false) extends ClockCrossingType
 {
   def asSinkParams = AsyncQueueParams(depth, sinkSync, safe, narrow)
+}
+case class CreditedCrossing(sourceDelay: CreditedDelay, sinkDelay: CreditedDelay) extends ClockCrossingType
+
+object CreditedCrossing {
+  def apply(delay: CreditedDelay): CreditedCrossing = CreditedCrossing(delay, delay.flip)
+  def apply(): CreditedCrossing = CreditedCrossing(CreditedDelay(1, 1))
 }
 
 trait DirectedBuffers[T] {

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -306,3 +306,12 @@ class TLRationalBundle(params: TLBundleParameters) extends TLBundleBase(params)
   val d = RationalIO(new TLBundleD(params)).flip
   val e = RationalIO(new TLBundleE(params))
 }
+
+class TLCreditedBundle(params: TLBundleParameters) extends TLBundleBase(params)
+{
+  val a = CreditedIO(new TLBundleA(params))
+  val b = CreditedIO(new TLBundleB(params)).flip
+  val c = CreditedIO(new TLBundleC(params))
+  val d = CreditedIO(new TLBundleD(params)).flip
+  val e = CreditedIO(new TLBundleE(params))
+}

--- a/src/main/scala/tilelink/Credited.scala
+++ b/src/main/scala/tilelink/Credited.scala
@@ -1,0 +1,84 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tilelink
+
+import chisel3._
+import chisel3.util.Decoupled
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.subsystem.CrossingWrapper
+import freechips.rocketchip.util._
+
+class TLCreditedBuffer(delay: TLCreditedDelay)(implicit p: Parameters) extends LazyModule
+{
+  val node = TLCreditedAdapterNode(
+    clientFn  = p => p.copy(delay = delay + p.delay),
+    managerFn = p => p.copy(delay = delay + p.delay))
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      out.a :<> in.a.pipeline(delay.a)
+      in.b :<> out.b.pipeline(delay.b)
+      out.c :<> in.c.pipeline(delay.c)
+      in.d :<> out.d.pipeline(delay.d)
+      out.e :<> in.e.pipeline(delay.e)
+    }
+  }
+}
+
+object TLCreditedBuffer {
+  def apply(delay: TLCreditedDelay)(implicit p: Parameters): TLCreditedAdapterNode = {
+    val buffer = LazyModule(new TLCreditedBuffer(delay))
+    buffer.node
+  }
+  def apply(delay: CreditedDelay)(implicit p: Parameters): TLCreditedAdapterNode = apply(TLCreditedDelay(delay))
+  def apply()(implicit p: Parameters): TLCreditedAdapterNode = apply(CreditedDelay(1, 1))
+}
+
+class TLCreditedSource(delay: TLCreditedDelay)(implicit p: Parameters) extends LazyModule
+{
+  val node = TLCreditedSourceNode(delay)
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      val tld = edgeOut.delay
+      out.a :<> CreditedIO.fromSender(in.a, tld.a.total).pipeline(delay.a)
+      in.b :<> Decoupled(out.b.pipeline(delay.b).toReceiver(tld.b.total))
+      out.c :<> CreditedIO.fromSender(in.c, tld.c.total).pipeline(delay.c)
+      in.d :<> Decoupled(out.d.pipeline(delay.d).toReceiver(tld.d.total))
+      out.e :<> CreditedIO.fromSender(in.e, tld.e.total).pipeline(delay.e)
+    }
+  }
+}
+
+object TLCreditedSource {
+  def apply(delay: TLCreditedDelay)(implicit p: Parameters): TLCreditedSourceNode = {
+    val source = LazyModule(new TLCreditedSource(delay))
+    source.node
+  }
+  def apply(delay: CreditedDelay)(implicit p: Parameters): TLCreditedSourceNode = apply(TLCreditedDelay(delay))
+  def apply()(implicit p: Parameters): TLCreditedSourceNode = apply(CreditedDelay(1, 1))
+}
+
+class TLCreditedSink(delay: TLCreditedDelay)(implicit p: Parameters) extends LazyModule
+{
+  val node = TLCreditedSinkNode(delay)
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      val tld = edgeIn.delay
+      out.a :<> Decoupled(in.a.pipeline(delay.a).toReceiver(tld.a.total))
+      in.b :<> CreditedIO.fromSender(out.b, tld.b.total).pipeline(delay.b)
+      out.c :<> Decoupled(in.c.pipeline(delay.c).toReceiver(tld.c.total))
+      in.d :<> CreditedIO.fromSender(out.d, tld.d.total).pipeline(delay.d)
+      out.e :<> Decoupled(in.e.pipeline(delay.e).toReceiver(tld.e.total))
+    }
+  }
+}
+
+object TLCreditedSink {
+  def apply(delay: TLCreditedDelay)(implicit p: Parameters): TLCreditedSinkNode = {
+    val sink = LazyModule(new TLCreditedSink(delay))
+    sink.node
+  }
+  def apply(delay: CreditedDelay)(implicit p: Parameters): TLCreditedSinkNode = apply(TLCreditedDelay(delay))
+  def apply()(implicit p: Parameters): TLCreditedSinkNode = apply(CreditedDelay(1, 1))
+}

--- a/src/main/scala/tilelink/CrossingHelper.scala
+++ b/src/main/scala/tilelink/CrossingHelper.scala
@@ -15,6 +15,8 @@ case class TLInwardCrossingHelper(name: String, scope: LazyScope, node: TLInward
         node :*=* scope { TLRationalCrossingSink(direction.flip) :*=* TLRationalNameNode(name) } :*=* TLRationalNameNode(name) :*=* TLRationalCrossingSource()
       case SynchronousCrossing(buffer) =>
         node :*=* scope { TLBuffer(buffer) :*=* TLNameNode(name) } :*=* TLNameNode(name)
+      case CreditedCrossing(sourceDelay, sinkDelay) =>
+        node :*=* scope { TLCreditedSink(sinkDelay) :*=* TLCreditedNameNode(name) } :*=* TLCreditedNameNode(name) :*=* TLCreditedSource(sourceDelay)
     }
   }
 }
@@ -28,6 +30,8 @@ case class TLOutwardCrossingHelper(name: String, scope: LazyScope, node: TLOutwa
         TLRationalCrossingSink(direction) :*=* TLRationalNameNode(name) :*=* scope { TLRationalNameNode(name) :*=* TLRationalCrossingSource() } :*=* node
       case SynchronousCrossing(buffer) =>
         TLNameNode(name) :*=* scope { TLNameNode(name) :*=* TLBuffer(buffer) } :*=* node
+      case CreditedCrossing(sourceDelay, sinkDelay) =>
+        TLCreditedSink(sinkDelay) :*=* TLCreditedNameNode(name) :*=* scope { TLCreditedNameNode(name) :*=* TLCreditedSource(sourceDelay) } :*=* node
     }
   }
 }

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -1264,6 +1264,36 @@ case class TLEdgeParameters(
   def formatEdge = master.infoString + "\n" + slave.infoString
 }
 
+case class TLCreditedDelay(
+  a: CreditedDelay,
+  b: CreditedDelay,
+  c: CreditedDelay,
+  d: CreditedDelay,
+  e: CreditedDelay)
+{
+  def + (that: TLCreditedDelay): TLCreditedDelay = TLCreditedDelay(
+    a = a + that.a,
+    b = b + that.b,
+    c = c + that.c,
+    d = d + that.d,
+    e = e + that.e)
+
+  override def toString = s"(${a}, ${b}, ${c}, ${d}, ${e})"
+}
+
+object TLCreditedDelay {
+  def apply(delay: CreditedDelay): TLCreditedDelay = apply(delay, delay.flip, delay, delay.flip, delay)
+}
+
+case class TLCreditedManagerPortParameters(delay: TLCreditedDelay, base: TLSlavePortParameters) {def infoString = base.infoString}
+case class TLCreditedClientPortParameters(delay: TLCreditedDelay, base: TLMasterPortParameters) {def infoString = base.infoString}
+case class TLCreditedEdgeParameters(client: TLCreditedClientPortParameters, manager: TLCreditedManagerPortParameters, params: Parameters, sourceInfo: SourceInfo) extends FormatEdge
+{
+  val delay = client.delay + manager.delay
+  val bundle = TLBundleParameters(client.base, manager.base)
+  def formatEdge = client.infoString + "\n" + manager.infoString
+}
+
 case class TLAsyncManagerPortParameters(async: AsyncQueueParams, base: TLSlavePortParameters) {def infoString = base.infoString}
 case class TLAsyncClientPortParameters(base: TLMasterPortParameters) {def infoString = base.infoString}
 case class TLAsyncBundleParameters(async: AsyncQueueParams, base: TLBundleParameters)

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -53,6 +53,7 @@ class WithTLSimpleUnitTests extends Config((site, here, up) => {
       Module(new TLRR1Test(                txns= 3*txns, timeout=timeout)),
       Module(new TLRAMRationalCrossingTest(txns= 3*txns, timeout=timeout)),
       Module(new TLRAMAsyncCrossingTest(   txns= 5*txns, timeout=timeout)),
+      Module(new TLRAMCreditedCrossingTest(txns= 5*txns, timeout=timeout)),
       Module(new TLRAMAtomicAutomataTest(  txns=10*txns, timeout=timeout)),
       Module(new TLRAMECCTest(8, 4,        txns=15*txns, timeout=timeout)),
       Module(new TLRAMECCTest(4, 1,        txns=15*txns, timeout=timeout)),

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -34,7 +34,8 @@ class WithAMBAUnitTests extends Config((site, here, up) => {
       Module(new AXI4FullFuzzRAMTest(        txns=3*txns, timeout=timeout)),
       Module(new AXI4BridgeTest(             txns=3*txns, timeout=timeout)),
       Module(new AXI4XbarTest(               txns=1*txns, timeout=timeout)),
-      Module(new AXI4RAMAsyncCrossingTest(   txns=3*txns, timeout=timeout))) }
+      Module(new AXI4RAMAsyncCrossingTest(   txns=3*txns, timeout=timeout)),
+      Module(new AXI4RAMCreditedCrossingTest(txns=3*txns, timeout=timeout))) }
 })
 
 class WithTLSimpleUnitTests extends Config((site, here, up) => {

--- a/src/main/scala/util/CreditedIO.scala
+++ b/src/main/scala/util/CreditedIO.scala
@@ -1,0 +1,152 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import chisel3._
+import chisel3.util._
+
+/** Transmission delay in credit-debit systems.
+  * debit delay is the number of cycles it takes debit+'bits' to transit the link.
+  * credit delay is the number of cycles it takes credits to be returned.
+  * round trip / total delay is the sum of debit and credit delay.
+  * The system must have a positive total delay, otherwise you have a combinational loop.
+  */
+case class CreditedDelay(debit: Int, credit: Int)
+{
+  val total = debit + credit
+  require (debit >= 0)
+  require (credit >= 0)
+
+  def flip: CreditedDelay = CreditedDelay(credit, debit)
+
+  def +(that: CreditedDelay): CreditedDelay =
+    CreditedDelay(debit + that.debit, credit + that.credit)
+
+  override def toString = s"${debit}:${credit}"
+}
+
+/** CreditedIO provides credit-debit-based flow control for arbitrary Data.
+  * The sender may only transmit Data when it has non-zero credits.
+  * Receivers provide 0 or 1 credits to senders using the credit field.
+  * Senders consume 0 or 1 credits by setting the debit field.
+  * The bits Data field is DontCare when debit=0.
+  * credit MAY depend combinationally on debit.
+  * debit MAY depend combinationally on credit.
+  * WARNING: The user must ensure the round trip time is > 0.
+  * Failure to comply will result in a combinational loop!
+  */
+final class CreditedIO[T <: Data](gen: T) extends Bundle
+{
+  override def cloneType: this.type = new CreditedIO(genType).asInstanceOf[this.type]
+  def genType: T = gen
+
+  val credit = Input (Bool()) // 1: a credit is given to the sender by the receiver
+  val debit  = Output(Bool()) // 1: a credit is consumed by the sender to transfer 'bits'
+  val bits   = Output(genType)
+
+  /** Provide a DecoupledIO interface for sending CreditedIO[Data].
+    * Convert an IrrevocableIO input to DecoupledIO via Decoupled().
+    * depth controls the maximum number of Data beats inflight.
+    * Sender powers on with credits=depth, so sender and receiver must agree on depth.
+    * pipe=false increases the receiver=>sender trip time by one cycle.
+    * pipe=true causes debit to depend on credit.
+    */
+  def toSender(depth: Int, pipe: Boolean = true): DecoupledIO[T] = {
+    require (depth >= 1)
+    val res = Wire(DecoupledIO(genType))
+    val counter = new CreditedIOCounter(depth, depth)
+    counter.update(this)
+    res.ready := !counter.empty || (pipe.B && credit)
+    debit := res.fire()
+    bits  := res.bits
+    res
+  }
+
+  /** Provide an IrrevocableIO interface for receiving CreditedIO[Data].
+    * Conversion to DecoupledIO is done via application of Decoupled().
+    * depth controls the Queue depth and thus maximum number of elements inflight.
+    * flow=false increases the sender=>receiver trip time by one cycle.
+    * flow=true causes credit to depend on debit.
+    */
+  def toReceiver(depth: Int, flow: Boolean = true): IrrevocableIO[T] = {
+    require (depth >= 1)
+    val enq = Wire(DecoupledIO(genType))
+    enq.valid := debit
+    enq.bits := bits
+    assert (!enq.valid || enq.ready)
+    val res = Queue.irrevocable(enq, depth, pipe=true, flow=flow)
+    credit := res.fire()
+    res
+  }
+
+  /** Add register stages to the sender and receiver paths.
+    * Apply this method to the producer/sender-facing bundle.
+    * The round-trip-time (RTT) is increased by sender+receiver.
+    */
+  def pipeline(debitDelay: Int, creditDelay: Int): CreditedIO[T] = {
+    val res = Wire(CreditedIO(genType))
+    if (debitDelay <= 0) {
+      credit := ShiftRegister(res.credit, creditDelay)
+      res.debit := debit
+      res.bits  := bits
+    } else {
+      // We can't use ShiftRegister, because we want debit-gated enables
+      val out = pipeline(debitDelay-1, creditDelay)
+      out.credit := res.credit
+      res.debit := RegNext(out.debit)
+      res.bits  := RegEnable(out.bits, out.debit)
+    }
+    res
+  }
+
+  def pipeline(delay: CreditedDelay): CreditedIO[T] =
+    pipeline(delay.debit, delay.credit)
+}
+
+object CreditedIO
+{
+  def apply[T <: Data](genType: T) = new CreditedIO(genType)
+
+  def fromSender[T <: Data](x: ReadyValidIO[T], depth: Int, pipe: Boolean = true): CreditedIO[T] = {
+    val res = Wire(CreditedIO(chiselTypeOf(x.bits)))
+    val dec = res.toSender(depth, pipe)
+    dec.valid := x.valid
+    dec.bits := x.bits
+    x.ready := dec.ready
+    res
+  }
+
+  def fromReceiver[T <: Data](x: ReadyValidIO[T], depth: Int, flow: Boolean = true): CreditedIO[T] = {
+    val res = Wire(CreditedIO(chiselTypeOf(x.bits)))
+    val irr = res.toReceiver(depth, flow)
+    x.valid := irr.valid
+    x.bits := irr.bits
+    irr.ready := x.ready
+    res
+  }
+}
+
+class CreditedIOCounter(val init: Int, val depth: Int) {
+  require (0 <= init)
+  require (init <= depth)
+
+  private val v = RegInit(init.U(log2Ceil(depth+1).W))
+  private val nextV = WireInit(v)
+
+  val value = v + 0.U
+  val nextValue = nextV + 0.U
+
+  def full: Bool = v === depth.U
+  def empty: Bool = v === 0.U
+
+  def update(credit: Bool, debit: Bool) {
+    assert((!(credit && full) || debit) && (!(debit && empty) || credit))
+    val next = Mux(credit, v + 1.U, v - 1.U)
+    when (credit =/= debit) {
+      nextV := next
+      v := next
+    }
+  }
+
+  def update(c: CreditedIO[_]) { update(c.credit, c.debit) }
+}

--- a/src/main/scala/util/CreditedIO.scala
+++ b/src/main/scala/util/CreditedIO.scala
@@ -86,14 +86,14 @@ final class CreditedIO[T <: Data](gen: T) extends Bundle
   def pipeline(debitDelay: Int, creditDelay: Int): CreditedIO[T] = {
     val res = Wire(CreditedIO(genType))
     if (debitDelay <= 0) {
-      credit := ShiftRegister(res.credit, creditDelay)
+      credit := ShiftRegister(res.credit, creditDelay, false.B, true.B)
       res.debit := debit
       res.bits  := bits
     } else {
       // We can't use ShiftRegister, because we want debit-gated enables
       val out = pipeline(debitDelay-1, creditDelay)
       out.credit := res.credit
-      res.debit := RegNext(out.debit)
+      res.debit := RegNext(out.debit, false.B)
       res.bits  := RegEnable(out.bits, out.debit)
     }
     res


### PR DESCRIPTION
This PR adds a new kind of flow control, CreditedIO, which fills the same role for credit/debit systems that DecoupledIO fills for ready/valid systems. Included in this PR are conversion methods to and from Decoupled as well as adapters for TileLink and AXI4.

The advantage of a credit/debit system is that you can add an arbitrary number of fanout=1 fanin=1 pipeline stages in both the data delivery and credit return paths. By comparison, adding ready/valid pipeline stages invariably includes at least a fan of degree 2.

See the following design diagram: https://app.lucidchart.com/invitations/accept/8271ee7b-98ba-44a4-ab3e-e8ae5af9fb43

**Type of change**:  feature request
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation