### PR TITLE
plusarg default bit width

### DIFF
--- a/src/main/resources/vsrc/plusarg_reader.v
+++ b/src/main/resources/vsrc/plusarg_reader.v
@@ -4,7 +4,7 @@
 
 // No default parameter values are intended, nor does IEEE 1800-2012 require them (clause A.2.4 param_assignment),
 // but Incisive demands them. These default values should never be used.
-module plusarg_reader #(parameter FORMAT="borked=%d", DEFAULT=0, WIDTH=1) (
+module plusarg_reader #(parameter FORMAT="borked=%d", WIDTH=1, bit [WIDTH-1:0] DEFAULT=0) (
    output [WIDTH-1:0] out
 );
 


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
fix VCS Lint warning message:
```
Lint-[WMIA-L] Width mismatch in assignment
plusarg_reader.v, 18
  Width mismatch between LHS and RHS is found in assignment:
  The following 32-bit wide expression is assigned to a 6-bit LHS target:
  Source info: myplus = DEFAULT;
  Expression: myplus
```