### PR TITLE
Debug: Fix address sent from DM to SB2TL

### DIFF
--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -129,7 +129,7 @@ object SystemBusAccessModule
       }
     }
 
-    sb2tl.module.io.addrIn := Mux(sb2tl.module.io.rdEn,
+    sb2tl.module.io.addrIn := Mux(SBADDRESSWrEn(0),
       Cat(Cat(SBADDRESSFieldsReg.drop(1).reverse), SBADDRESSWrData(0)),
       Cat(SBADDRESSFieldsReg.reverse))
     anyAddressWrEn         := SBADDRESSWrEn.reduce(_ || _)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The address being sent from the trace encoder to the sb2tl module takes on the wrong value in the cycle when sbdata0 is read when sbreadondata is set (sbreadondata causes the SBA to initiate a read transaction on the bus when sbdata0 is read).  Although the actual data transaction has the correct address, the address legality check does not process the correct address and may not flag illegal addresses.