### PR TITLE
Fix duplication problem in traceCoreNode logic

### DIFF
--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -271,7 +271,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   /** Node to broadcast V1.0 instruction trace to external consumers. */
   val traceCoreNexusNode = BundleBroadcast[TraceCoreInterface]()
   /** Node for external consumers to source  a V1.0 instruction trace from the core. */
-  def traceCoreNode: BundleBridgeOutwardNode[TraceCoreInterface] =
+  val traceCoreNode: BundleBridgeOutwardNode[TraceCoreInterface] =
     BundleBridgeNameNode(traceCoreSignalName) :*= traceCoreNexusNode := traceCoreSourceNode
 
   /** Node for watchpoints to control trace driven by core. */


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
@hcook A recent change to the trace-related BundleBridges in BaseTile.scala caused an issue when more than 1 sink node was connected to traceCoreNode: multiple connections to traceCoreSourceNode.  This change will make multiple connections correctly.