### PR TITLE
fix "plusarg default bit width"

### DIFF
--- a/src/main/resources/vsrc/plusarg_reader.v
+++ b/src/main/resources/vsrc/plusarg_reader.v
@@ -4,7 +4,11 @@
 
 // No default parameter values are intended, nor does IEEE 1800-2012 require them (clause A.2.4 param_assignment),
 // but Incisive demands them. These default values should never be used.
-module plusarg_reader #(parameter FORMAT="borked=%d", WIDTH=1, bit [WIDTH-1:0] DEFAULT=0) (
+module plusarg_reader #(
+   parameter FORMAT="borked=%d",
+   parameter WIDTH=1,
+   parameter [WIDTH-1:0] DEFAULT=0
+) (
    output [WIDTH-1:0] out
 );
 


### PR DESCRIPTION
Fixes chipsalliance/rocket-chip#2558 to use Verilog syntax `parameter`, not SystemVerilog `bit`.