### PR TITLE
Add Reset Stretcher in PRCI Domain for async reset systems

### DIFF
--- a/src/main/scala/prci/ResetStretcher.scala
+++ b/src/main/scala/prci/ResetStretcher.scala
@@ -1,0 +1,29 @@
+// See LICENSE.SiFive for license details.
+package freechips.rocketchip.prci
+
+import chisel3._
+import chisel3.util.log2Ceil
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+/* Stretch async reset
+*/
+class ResetStretcher(cycles: Int)(implicit p: Parameters) extends LazyModule {
+  val node = ClockAdapterNode()(ValName("reset_stretcher"))
+  require(cycles > 1, s"ResetStretcher only supports cycles > 1 but got ${cycles}")
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out).foreach { case ((in, _), (out, _)) =>
+      out.clock := in.clock
+      out.reset := withClockAndReset(in.clock, in.reset) {
+        val count = RegInit(0.U(log2Ceil(cycles).W))
+        val resetout = RegInit(true.B)
+        when (resetout) {
+          count := count + 1.U
+          resetout := (count < (cycles-1).U)
+        }
+        resetout
+      }
+    }
+  }
+}

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -17,11 +17,12 @@ case class RocketCrossingParams(
   crossingType: ClockCrossingType = SynchronousCrossing(),
   master: TileMasterPortParams = TileMasterPortParams(),
   slave: TileSlavePortParams = TileSlavePortParams(),
-  mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS
+  mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS,
+  stretchResetCycles: Option[Int] = None
 ) extends TileCrossingParamsLike {
   def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = {
-    if (p(SubsystemResetSchemeKey) != ResetSynchronous) {
-      val rs = LazyModule(new ResetStretcher(16))
+    if (stretchResetCycles.isDefined) {
+      val rs = LazyModule(new ResetStretcher(stretchResetCycles.get))
       rs.node
     } else {
       ClockTempNode()

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugM
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
 import freechips.rocketchip.diplomaticobjectmodel.model._
-import freechips.rocketchip.prci.{ClockNode, ClockTempNode}
+import freechips.rocketchip.prci.{ClockAdapterNode, ClockNode, ClockTempNode, ResetStretcher}
 import freechips.rocketchip.tile._
 
 case class RocketCrossingParams(
@@ -20,7 +20,12 @@ case class RocketCrossingParams(
   mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS
 ) extends TileCrossingParamsLike {
   def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = {
-    ClockTempNode() // TODO reset stretcher could go here, parameterized by args to this case class
+    if (p(SubsystemResetSchemeKey) != ResetSynchronous) {
+      val rs = LazyModule(new ResetStretcher(16))
+      rs.node
+    } else {
+      ClockTempNode()
+    }
   }
   def forceSeparateClockReset: Boolean = false
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The Rocket Tile is not currently written to support an asynchronous reset.  When the rest of a system has an asynchronous reset configured by SubsystemResetSchemeKey, a module is inserted into the reset path in the PRCI domain that synchronizes and stretches the core_reset to be a minimum of 16 cycles as required by the core design.  The Tile and everything it contains is generated with synchronous reset.