### PR TITLE
TileLink Diplomacy parameters supportsProbe -> supports.probe

### DIFF
--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -24,13 +24,13 @@ case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCus
   def mapParamsD(n: Int, p: Seq[TLMasterPortParameters]): Seq[TLMasterPortParameters] =
     (p zip ids) map { case (cp, id) => cp.v1copy(clients = cp.clients.map { c => c.v1copy(
       visibility         = c.visibility.flatMap { a => a.intersect(AddressSet(id, ~mask))},
-      supportsProbe      = c.supportsProbe      intersect maxXfer,
-      supportsArithmetic = c.supportsArithmetic intersect maxXfer,
-      supportsLogical    = c.supportsLogical    intersect maxXfer,
-      supportsGet        = c.supportsGet        intersect maxXfer,
-      supportsPutFull    = c.supportsPutFull    intersect maxXfer,
-      supportsPutPartial = c.supportsPutPartial intersect maxXfer,
-      supportsHint       = c.supportsHint       intersect maxXfer)})}
+      supportsProbe      = c.supports.probe      intersect maxXfer,
+      supportsArithmetic = c.supports.arithmetic intersect maxXfer,
+      supportsLogical    = c.supports.logical    intersect maxXfer,
+      supportsGet        = c.supports.get        intersect maxXfer,
+      supportsPutFull    = c.supports.putFull    intersect maxXfer,
+      supportsPutPartial = c.supports.putPartial intersect maxXfer,
+      supportsHint       = c.supports.hint       intersect maxXfer)})}
 
   def mapParamsU(n: Int, p: Seq[TLSlavePortParameters]): Seq[TLSlavePortParameters] =
     (p zip ids) map { case (mp, id) => mp.v1copy(managers = mp.managers.flatMap { m =>

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -90,7 +90,7 @@ class TLBroadcast(params: TLBroadcastParams)(implicit p: Parameters) extends Laz
 
       require (params.lineBytes >= edgeOut.manager.beatBytes)
       // For the probe walker, we need to identify all the caches
-      val caches = clients.filter(_.supportsProbe).map(_.sourceId)
+      val caches = clients.filter(_.supports.probe).map(_.sourceId)
       val cache_targets = caches.map(c => c.start.U)
 
       // Create the probe filter

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -32,7 +32,7 @@ class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Paramet
         out <> in
       } else {
         val clients = edgeIn.client.clients
-        val caches = clients.filter(_.supportsProbe)
+        val caches = clients.filter(_.supports.probe)
         require (clients.size == 1 || caches.size == 0 || unsafe, s"Only one client can safely use a TLCacheCork; ${clients.map(_.name)}")
         require (caches.size <= 1 || unsafe, s"Only one caching client allowed; ${clients.map(_.name)}")
         edgeOut.manager.managers.foreach { case m =>

--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -17,13 +17,13 @@ class TLFilter(
       val out = cfilter(c)
       out.map { o => // Confirm the filter only REMOVES capability
         require (c.sourceId.contains(o.sourceId))
-        require (c.supportsProbe.contains(o.supportsProbe))
-        require (c.supportsArithmetic.contains(o.supportsArithmetic))
-        require (c.supportsLogical.contains(o.supportsLogical))
-        require (c.supportsGet.contains(o.supportsGet))
-        require (c.supportsPutFull.contains(o.supportsPutFull))
-        require (c.supportsPutPartial.contains(o.supportsPutPartial))
-        require (c.supportsHint.contains(o.supportsHint))
+        require (c.supports.probe.contains(o.supports.probe))
+        require (c.supports.arithmetic.contains(o.supports.arithmetic))
+        require (c.supports.logical.contains(o.supports.logical))
+        require (c.supports.get.contains(o.supports.get))
+        require (c.supports.putFull.contains(o.supports.putFull))
+        require (c.supports.putPartial.contains(o.supports.putPartial))
+        require (c.supports.hint.contains(o.supports.hint))
         require (!c.requestFifo || o.requestFifo)
       }
       out
@@ -146,11 +146,11 @@ object TLFilter
   }
   // hide all caching clients
   def cHideCaching: ClientFilter = { c =>
-    if (c.supportsProbe) None else Some(c)
+    if (c.supports.probe) None else Some(c)
   }
   // onyl caching clients are visible
   def cSelectCaching: ClientFilter = { c =>
-    if (c.supportsProbe) Some(c) else None
+    if (c.supports.probe) Some(c) else None
   }
 
   // default application applies neither type of filter unless overridden

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -859,24 +859,24 @@ class TLMasterParameters private(
 
   require (!sourceId.isEmpty)
   require (!visibility.isEmpty)
-  require (supportsPutFull.contains(supportsPutPartial))
+  require (supports.putFull.contains(supports.putPartial))
   // We only support these operations if we support Probe (ie: we're a cache)
-  require (supportsProbe.contains(supportsArithmetic))
-  require (supportsProbe.contains(supportsLogical))
-  require (supportsProbe.contains(supportsGet))
-  require (supportsProbe.contains(supportsPutFull))
-  require (supportsProbe.contains(supportsPutPartial))
-  require (supportsProbe.contains(supportsHint))
+  require (supports.probe.contains(supports.arithmetic))
+  require (supports.probe.contains(supports.logical))
+  require (supports.probe.contains(supports.get))
+  require (supports.probe.contains(supports.putFull))
+  require (supports.probe.contains(supports.putPartial))
+  require (supports.probe.contains(supports.hint))
 
   visibility.combinations(2).foreach { case Seq(x,y) => require (!x.overlaps(y), s"$x and $y overlap.") }
 
   val maxTransfer = List(
-    supportsProbe.max,
-    supportsArithmetic.max,
-    supportsLogical.max,
-    supportsGet.max,
-    supportsPutFull.max,
-    supportsPutPartial.max).max
+    supports.probe.max,
+    supports.arithmetic.max,
+    supports.logical.max,
+    supports.get.max,
+    supports.putFull.max,
+    supports.putPartial.max).max
 
   def infoString = {
     s"""Master Name = ${name}
@@ -1120,22 +1120,22 @@ class TLMasterPortParameters private(
   }
 
   // Operation sizes supported by all inward Masters
-  val allSupportProbe      = masters.map(_.supportsProbe)     .reduce(_ intersect _)
-  val allSupportArithmetic = masters.map(_.supportsArithmetic).reduce(_ intersect _)
-  val allSupportLogical    = masters.map(_.supportsLogical)   .reduce(_ intersect _)
-  val allSupportGet        = masters.map(_.supportsGet)       .reduce(_ intersect _)
-  val allSupportPutFull    = masters.map(_.supportsPutFull)   .reduce(_ intersect _)
-  val allSupportPutPartial = masters.map(_.supportsPutPartial).reduce(_ intersect _)
-  val allSupportHint       = masters.map(_.supportsHint)      .reduce(_ intersect _)
+  val allSupportProbe      = masters.map(_.supports.probe)     .reduce(_ intersect _)
+  val allSupportArithmetic = masters.map(_.supports.arithmetic).reduce(_ intersect _)
+  val allSupportLogical    = masters.map(_.supports.logical)   .reduce(_ intersect _)
+  val allSupportGet        = masters.map(_.supports.get)       .reduce(_ intersect _)
+  val allSupportPutFull    = masters.map(_.supports.putFull)   .reduce(_ intersect _)
+  val allSupportPutPartial = masters.map(_.supports.putPartial).reduce(_ intersect _)
+  val allSupportHint       = masters.map(_.supports.hint)      .reduce(_ intersect _)
 
   // Operation is supported by at least one master
-  val anySupportProbe      = masters.map(!_.supportsProbe.none)     .reduce(_ || _)
-  val anySupportArithmetic = masters.map(!_.supportsArithmetic.none).reduce(_ || _)
-  val anySupportLogical    = masters.map(!_.supportsLogical.none)   .reduce(_ || _)
-  val anySupportGet        = masters.map(!_.supportsGet.none)       .reduce(_ || _)
-  val anySupportPutFull    = masters.map(!_.supportsPutFull.none)   .reduce(_ || _)
-  val anySupportPutPartial = masters.map(!_.supportsPutPartial.none).reduce(_ || _)
-  val anySupportHint       = masters.map(!_.supportsHint.none)      .reduce(_ || _)
+  val anySupportProbe      = masters.map(!_.supports.probe.none)     .reduce(_ || _)
+  val anySupportArithmetic = masters.map(!_.supports.arithmetic.none).reduce(_ || _)
+  val anySupportLogical    = masters.map(!_.supports.logical.none)   .reduce(_ || _)
+  val anySupportGet        = masters.map(!_.supports.get.none)       .reduce(_ || _)
+  val anySupportPutFull    = masters.map(!_.supports.putFull.none)   .reduce(_ || _)
+  val anySupportPutPartial = masters.map(!_.supports.putPartial.none).reduce(_ || _)
+  val anySupportHint       = masters.map(!_.supports.hint.none)      .reduce(_ || _)
 
   // These return Option[TLMasterParameters] for your convenience
   def find(id: Int) = masters.find(_.sourceId.contains(id))
@@ -1505,7 +1505,7 @@ class TLSourceIdMap(tl: TLMasterPortParameters) extends IdMap[TLSourceIdMapEntry
   private val sorted = tl.masters.sortBy(_.sourceId)
 
   val mapping: Seq[TLSourceIdMapEntry] = sorted.map { case c =>
-    TLSourceIdMapEntry(c.sourceId, c.name, c.supportsProbe, c.requestFifo)
+    TLSourceIdMapEntry(c.sourceId, c.name, c.supports.probe, c.requestFifo)
   }
 }
 

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -33,7 +33,7 @@ class TLtoAXI4IdMap(tl: TLMasterPortParameters, axi4: AXI4MasterPortParameters)
   private val sorted = tl.clients.sortBy(_.sourceId).sortWith(TLToAXI4.sortByType)
 
   val mapping: Seq[TLToAXI4IdMapEntry] = (sorted zip axi4.masters) map { case (c, m) =>
-    TLToAXI4IdMapEntry(m.id, c.sourceId, c.name, c.supportsProbe, c.requestFifo)
+    TLToAXI4IdMapEntry(m.id, c.sourceId, c.name, c.supports.probe, c.requestFifo)
   }
 }
 
@@ -278,10 +278,10 @@ object TLToAXI4
   }
 
   def sortByType(a: TLMasterParameters, b: TLMasterParameters): Boolean = {
-    if ( a.supportsProbe && !b.supportsProbe) return false
-    if (!a.supportsProbe &&  b.supportsProbe) return true
-    if ( a.requestFifo   && !b.requestFifo  ) return false
-    if (!a.requestFifo   &&  b.requestFifo  ) return true
+    if ( a.supports.probe && !b.supports.probe) return false
+    if (!a.supports.probe &&  b.supports.probe) return true
+    if ( a.requestFifo    && !b.requestFifo   ) return false
+    if (!a.requestFifo    &&  b.requestFifo   ) return true
     return false
   }
 }


### PR DESCRIPTION
**Related issue**: deprecated in https://github.com/chipsalliance/rocket-chip/pull/2505

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
fix these Chisel compile deprecation warnings:
```
[warn] /rocket-chip/src/main/scala/tilelink/BankBinder.scala:27:30: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]       supportsProbe      = c.supportsProbe      intersect maxXfer,
[warn]                              ^
[warn] /rocket-chip/src/main/scala/tilelink/BankBinder.scala:28:30: method supportsArithmetic in class TLMasterParameters is deprecated: Use supports.arithmetic instead of supportsArithmetic
[warn]       supportsArithmetic = c.supportsArithmetic intersect maxXfer,
[warn]                              ^
[warn] /rocket-chip/src/main/scala/tilelink/BankBinder.scala:29:30: method supportsLogical in class TLMasterParameters is deprecated: Use supports.logical instead of supportsLogical
[warn]       supportsLogical    = c.supportsLogical    intersect maxXfer,
[warn]                              ^
[warn] /rocket-chip/src/main/scala/tilelink/BankBinder.scala:30:30: method supportsGet in class TLMasterParameters is deprecated: Use supports.get instead of supportsGet
[warn]       supportsGet        = c.supportsGet        intersect maxXfer,
[warn]                              ^
[warn] /rocket-chip/src/main/scala/tilelink/BankBinder.scala:31:30: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]       supportsPutFull    = c.supportsPutFull    intersect maxXfer,
[warn]                              ^
[warn] /rocket-chip/src/main/scala/tilelink/BankBinder.scala:32:30: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]       supportsPutPartial = c.supportsPutPartial intersect maxXfer,
[warn]                              ^
[warn] /rocket-chip/src/main/scala/tilelink/BankBinder.scala:33:30: method supportsHint in class TLMasterParameters is deprecated: Use supports.hint instead of supportsHint
[warn]       supportsHint       = c.supportsHint       intersect maxXfer)})}
[warn]                              ^
[warn] /rocket-chip/src/main/scala/tilelink/Broadcast.scala:93:37: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]       val caches = clients.filter(_.supportsProbe).map(_.sourceId)
[warn]                                     ^
[warn] /rocket-chip/src/main/scala/tilelink/CacheCork.scala:35:39: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]         val caches = clients.filter(_.supportsProbe)
[warn]                                       ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:20:20: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]         require (c.supportsProbe.contains(o.supportsProbe))
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:20:45: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]         require (c.supportsProbe.contains(o.supportsProbe))
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:21:20: method supportsArithmetic in class TLMasterParameters is deprecated: Use supports.arithmetic instead of supportsArithmetic
[warn]         require (c.supportsArithmetic.contains(o.supportsArithmetic))
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:21:50: method supportsArithmetic in class TLMasterParameters is deprecated: Use supports.arithmetic instead of supportsArithmetic
[warn]         require (c.supportsArithmetic.contains(o.supportsArithmetic))
[warn]                                                  ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:22:20: method supportsLogical in class TLMasterParameters is deprecated: Use supports.logical instead of supportsLogical
[warn]         require (c.supportsLogical.contains(o.supportsLogical))
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:22:47: method supportsLogical in class TLMasterParameters is deprecated: Use supports.logical instead of supportsLogical
[warn]         require (c.supportsLogical.contains(o.supportsLogical))
[warn]                                               ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:23:20: method supportsGet in class TLMasterParameters is deprecated: Use supports.get instead of supportsGet
[warn]         require (c.supportsGet.contains(o.supportsGet))
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:23:43: method supportsGet in class TLMasterParameters is deprecated: Use supports.get instead of supportsGet
[warn]         require (c.supportsGet.contains(o.supportsGet))
[warn]                                           ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:24:20: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]         require (c.supportsPutFull.contains(o.supportsPutFull))
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:24:47: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]         require (c.supportsPutFull.contains(o.supportsPutFull))
[warn]                                               ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:25:20: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]         require (c.supportsPutPartial.contains(o.supportsPutPartial))
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:25:50: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]         require (c.supportsPutPartial.contains(o.supportsPutPartial))
[warn]                                                  ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:26:20: method supportsHint in class TLMasterParameters is deprecated: Use supports.hint instead of supportsHint
[warn]         require (c.supportsHint.contains(o.supportsHint))
[warn]                    ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:26:44: method supportsHint in class TLMasterParameters is deprecated: Use supports.hint instead of supportsHint
[warn]         require (c.supportsHint.contains(o.supportsHint))
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:149:11: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     if (c.supportsProbe) None else Some(c)
[warn]           ^
[warn] /rocket-chip/src/main/scala/tilelink/Filter.scala:153:11: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     if (c.supportsProbe) Some(c) else None
[warn]           ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:862:12: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]   require (supportsPutFull.contains(supportsPutPartial))
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:862:37: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]   require (supportsPutFull.contains(supportsPutPartial))
[warn]                                     ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:864:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   require (supportsProbe.contains(supportsArithmetic))
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:864:35: method supportsArithmetic in class TLMasterParameters is deprecated: Use supports.arithmetic instead of supportsArithmetic
[warn]   require (supportsProbe.contains(supportsArithmetic))
[warn]                                   ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:865:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   require (supportsProbe.contains(supportsLogical))
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:865:35: method supportsLogical in class TLMasterParameters is deprecated: Use supports.logical instead of supportsLogical
[warn]   require (supportsProbe.contains(supportsLogical))
[warn]                                   ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:866:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   require (supportsProbe.contains(supportsGet))
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:866:35: method supportsGet in class TLMasterParameters is deprecated: Use supports.get instead of supportsGet
[warn]   require (supportsProbe.contains(supportsGet))
[warn]                                   ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:867:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   require (supportsProbe.contains(supportsPutFull))
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:867:35: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]   require (supportsProbe.contains(supportsPutFull))
[warn]                                   ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:868:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   require (supportsProbe.contains(supportsPutPartial))
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:868:35: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]   require (supportsProbe.contains(supportsPutPartial))
[warn]                                   ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:869:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   require (supportsProbe.contains(supportsHint))
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:869:35: method supportsHint in class TLMasterParameters is deprecated: Use supports.hint instead of supportsHint
[warn]   require (supportsProbe.contains(supportsHint))
[warn]                                   ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:874:5: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     supportsProbe.max,
[warn]     ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:875:5: method supportsArithmetic in class TLMasterParameters is deprecated: Use supports.arithmetic instead of supportsArithmetic
[warn]     supportsArithmetic.max,
[warn]     ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:876:5: method supportsLogical in class TLMasterParameters is deprecated: Use supports.logical instead of supportsLogical
[warn]     supportsLogical.max,
[warn]     ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:877:5: method supportsGet in class TLMasterParameters is deprecated: Use supports.get instead of supportsGet
[warn]     supportsGet.max,
[warn]     ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:878:5: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]     supportsPutFull.max,
[warn]     ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:879:5: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]     supportsPutPartial.max).max
[warn]     ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1123:44: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   val allSupportProbe      = masters.map(_.supportsProbe)     .reduce(_ intersect _)
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1124:44: method supportsArithmetic in class TLMasterParameters is deprecated: Use supports.arithmetic instead of supportsArithmetic
[warn]   val allSupportArithmetic = masters.map(_.supportsArithmetic).reduce(_ intersect _)
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1125:44: method supportsLogical in class TLMasterParameters is deprecated: Use supports.logical instead of supportsLogical
[warn]   val allSupportLogical    = masters.map(_.supportsLogical)   .reduce(_ intersect _)
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1126:44: method supportsGet in class TLMasterParameters is deprecated: Use supports.get instead of supportsGet
[warn]   val allSupportGet        = masters.map(_.supportsGet)       .reduce(_ intersect _)
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1127:44: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]   val allSupportPutFull    = masters.map(_.supportsPutFull)   .reduce(_ intersect _)
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1128:44: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]   val allSupportPutPartial = masters.map(_.supportsPutPartial).reduce(_ intersect _)
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1129:44: method supportsHint in class TLMasterParameters is deprecated: Use supports.hint instead of supportsHint
[warn]   val allSupportHint       = masters.map(_.supportsHint)      .reduce(_ intersect _)
[warn]                                            ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1132:45: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   val anySupportProbe      = masters.map(!_.supportsProbe.none)     .reduce(_ || _)
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1133:45: method supportsArithmetic in class TLMasterParameters is deprecated: Use supports.arithmetic instead of supportsArithmetic
[warn]   val anySupportArithmetic = masters.map(!_.supportsArithmetic.none).reduce(_ || _)
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1134:45: method supportsLogical in class TLMasterParameters is deprecated: Use supports.logical instead of supportsLogical
[warn]   val anySupportLogical    = masters.map(!_.supportsLogical.none)   .reduce(_ || _)
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1135:45: method supportsGet in class TLMasterParameters is deprecated: Use supports.get instead of supportsGet
[warn]   val anySupportGet        = masters.map(!_.supportsGet.none)       .reduce(_ || _)
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1136:45: method supportsPutFull in class TLMasterParameters is deprecated: Use supports.putFull instead of supportsPutFull
[warn]   val anySupportPutFull    = masters.map(!_.supportsPutFull.none)   .reduce(_ || _)
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1137:45: method supportsPutPartial in class TLMasterParameters is deprecated: Use supports.putPartial instead of supportsPutPartial
[warn]   val anySupportPutPartial = masters.map(!_.supportsPutPartial.none).reduce(_ || _)
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1138:45: method supportsHint in class TLMasterParameters is deprecated: Use supports.hint instead of supportsHint
[warn]   val anySupportHint       = masters.map(!_.supportsHint.none)      .reduce(_ || _)
[warn]                                             ^
[warn] /rocket-chip/src/main/scala/tilelink/Parameters.scala:1508:46: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     TLSourceIdMapEntry(c.sourceId, c.name, c.supportsProbe, c.requestFifo)
[warn]                                              ^
[warn] /rocket-chip/src/main/scala/tilelink/ToAXI4.scala:36:52: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     TLToAXI4IdMapEntry(m.id, c.sourceId, c.name, c.supportsProbe, c.requestFifo)
[warn]                                                    ^
[warn] /rocket-chip/src/main/scala/tilelink/ToAXI4.scala:281:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     if ( a.supportsProbe && !b.supportsProbe) return false
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/ToAXI4.scala:281:32: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     if ( a.supportsProbe && !b.supportsProbe) return false
[warn]                                ^
[warn] /rocket-chip/src/main/scala/tilelink/ToAXI4.scala:282:12: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     if (!a.supportsProbe &&  b.supportsProbe) return true
[warn]            ^
[warn] /rocket-chip/src/main/scala/tilelink/ToAXI4.scala:282:32: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     if (!a.supportsProbe &&  b.supportsProbe) return true
[warn]                                ^
```