### PR TITLE
Enable ResetAsynchronousFull in IDPool

### DIFF
--- a/src/main/scala/util/IDPool.scala
+++ b/src/main/scala/util/IDPool.scala
@@ -15,7 +15,7 @@ class IDPool(numIds: Int) extends Module {
   })
 
   // True indicates that the id is available
-  val bitmap = RegInit(~0.U(numIds.W))
+  val bitmap = RegInit(-1.S(numIds.W).asUInt)
   val select = RegInit(0.U(idWidth.W))
   val valid  = RegInit(true.B)
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Using SubsystemResetSchemesKey = ResetAsynchronousFull requires that the reset value of all registers be a constant.  FIRRTL was unable to determine that in this instance, necessitating this change.  No functional difference.