### PR TITLE
change monitor to not put diplomacy in error messages

### DIFF
--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -67,7 +67,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }.reduce(_ && _)
 
   def legalizeFormatA(bundle: TLBundleA, edge: TLEdge) {
-    def diplomacyInfo = "\nThe diplomacy information for the edge is as follows:\n" + edge.formatEdge + "\n"
+    //switch this flag to turn on diplomacy in error messages
+    def diplomacyInfo = if (true) "" else "\nThe diplomacy information for the edge is as follows:\n" + edge.formatEdge + "\n"
     monAssert (TLMessages.isA(bundle.opcode), "'A' channel has invalid opcode" + extra)
 
     // Reuse these subexpressions to save some firrtl lines


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
change monitor to not put diplomacy in error messages during normal run, but as an optional feature used for debugging