### PR TITLE
RVV 1.0: reorder fields in vtype

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -268,8 +268,8 @@ class VType(implicit p: Parameters) extends CoreBundle {
   val reserved = UInt((xLen - 9).W)
   val vma = Bool()
   val vta = Bool()
-  val vlmul_sign = Bool()
   val vsew = UInt(3.W)
+  val vlmul_sign = Bool()
   val vlmul_mag = UInt(2.W)
 
   def vlmul_signed: SInt = Cat(vlmul_sign, vlmul_mag).asSInt


### PR DESCRIPTION
This is a backwards-incompatible change to the layout of the RVV vtype CSR.

https://github.com/riscv/riscv-v-spec/commit/b8cd98bc9467617b6653583116b2dfe9eefb2f51

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
