### PR TITLE
Add OMVectorExtension.vstartALU field

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMISA.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMISA.scala
@@ -53,6 +53,7 @@ case class OMVectorExtension(
   vLen: Int,
   sLen: Int,
   eLen: Int,
+  vstartALU: Boolean, // whether non-memory/non-vsetvl instructions permit vstart != 0
   name: String = "V Standard Extension for Vector Operations",
   _types: Seq[String] = Seq("OMVectorExtension")
 )


### PR DESCRIPTION
This describes whether non-memory instructions support nonzero vstart values.

