### PR TITLE
CI: compile using wake 0.18.1

### DIFF
--- a/ci-tests/wake_scala_compilation
+++ b/ci-tests/wake_scala_compilation
@@ -3,8 +3,8 @@ set -ex
 
 echo "Installing Wake"
 
-wget https://github.com/sifive/wake/releases/download/v0.17.2/ubuntu-16-04-wake_0.17.2-1_amd64.deb
-sudo dpkg -i ubuntu-16-04-wake_0.17.2-1_amd64.deb
+wget https://github.com/sifive/wake/releases/download/v0.18.1/ubuntu-16-04-wake_0.18.1-1_amd64.deb
+sudo dpkg -i ubuntu-16-04-wake_0.18.1-1_amd64.deb
 
 
 echo "Installing Protobuf"
@@ -34,5 +34,5 @@ echo "Compile Scala"
 
 export WAKE_PATH=$PATH
 wake --init .
-wake --no-tty -p1 -dv 'compileScalaModule rocketchipScalaModule | getPathResult'
+wake -x 'compileScalaModule rocketchipScalaModule | getPathResult'
 cd ..


### PR DESCRIPTION
**Type of change**: other enhancement
**Impact**: no functional change
**Development Phase**:  implementation

Stop regressing on wake 0.18 support; compile using 0.18.1 instead of 0.17.2.