### PR TITLE
Remove hex symlink rule from test makefrag generation

### DIFF
--- a/src/main/scala/system/RocketTestSuite.scala
+++ b/src/main/scala/system/RocketTestSuite.scala
@@ -13,10 +13,6 @@ abstract class RocketTestSuite {
   def kind: String
   def postScript = s"""
 
-$$(addprefix $$(output_dir)/, $$(addsuffix .hex, $$($makeTargetName))): $$(output_dir)/%.hex: $dir/%.hex
-\tmkdir -p $$(output_dir)
-\tln -fs $$< $$@
-
 $$(addprefix $$(output_dir)/, $$($makeTargetName)): $$(output_dir)/%: $dir/%
 \tmkdir -p $$(output_dir)
 \tln -fs $$< $$@


### PR DESCRIPTION
riscv-tests hasn't built or installed the hex files this rule is trying to symlink for years.

This dead code is kind of a wart for a downstream rule in chipyard that also wants to generate this same file (obviously it is easily worked around by just naming it something different).

**Type of change**: dead code removal

**Impact**: no functional change

**Development Phase**: implementation