### PR TITLE
Debug: Add mcontext/scontext registers for breakpoint qualification

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -95,6 +95,8 @@ class RocketLogicalTreeNode(
       interruptLatency = 4,
       nLocalInterrupts = coreParams.nLocalInterrupts,
       nBreakpoints = coreParams.nBreakpoints,
+      mcontextWidth = coreParams.mcontextWidth,
+      scontextWidth = coreParams.scontextWidth,
       branchPredictor = rocketParams.btb.map(OMBTB.makeOMI),
       dcache = Some(omDCache),
       icache = Some(omICache),

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -23,6 +23,8 @@ case class OMRocketCore(
   interruptLatency: Int,
   nLocalInterrupts: Int,
   nBreakpoints: Int,
+  mcontextWidth: Int,
+  scontextWidth: Int,
   branchPredictor: Option[OMRocketBranchPredictor],
   dcache: Option[OMDCache],
   icache: Option[OMICache],

--- a/src/main/scala/rocket/Instructions.scala
+++ b/src/main/scala/rocket/Instructions.scala
@@ -911,6 +911,9 @@ object CSRs {
   val tdata1 = 0x7a1
   val tdata2 = 0x7a2
   val tdata3 = 0x7a3
+  val scontext = 0x5a8
+  val hcontext = 0x6a8
+  val mcontext = 0x7a8
   val dcsr = 0x7b0
   val dpc = 0x7b1
   val dscratch = 0x7b2
@@ -1167,6 +1170,9 @@ object CSRs {
     res += tdata1
     res += tdata2
     res += tdata3
+    res += scontext
+    res += hcontext
+    res += mcontext
     res += dcsr
     res += dpc
     res += dscratch

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -29,6 +29,8 @@ case class RocketCoreParams(
   nLocalInterrupts: Int = 0,
   nBreakpoints: Int = 1,
   useBPWatch: Boolean = false,
+  mcontextWidth: Int = 0,
+  scontextWidth: Int = 0,
   nPMPs: Int = 8,
   nPerfCounters: Int = 0,
   haveBasicCounters: Boolean = true,
@@ -319,6 +321,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   bpu.io.bp := csr.io.bp
   bpu.io.pc := ibuf.io.pc
   bpu.io.ea := mem_reg_wdata
+  bpu.io.mcontext := csr.io.mcontext
+  bpu.io.scontext := csr.io.scontext
 
   val id_xcpt0 = ibuf.io.inst(0).bits.xcpt0
   val id_xcpt1 = ibuf.io.inst(0).bits.xcpt1

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -35,6 +35,8 @@ trait CoreParams {
   val pmpGranularity: Int
   val nBreakpoints: Int
   val useBPWatch: Boolean
+  val mcontextWidth: Int
+  val scontextWidth: Int
   val nPerfCounters: Int
   val haveBasicCounters: Boolean
   val haveFSDirty: Boolean


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The Debug Spec defines `mcontext` and `scontext` as CSRs that M-mode and S-mode OSs can write to when switching tasks.  The OS writes a process ID or similar identifier to uniquely identify the incoming task or process.  A debugger may choose to qualify breakpoints by requiring that either `mcontext` or `scontext` (or both) match values programmed into the `textra` register of each breakpoint.  This allows triggering on a virtual address that might be used by more than one process.

`mcontext` and `scontext` have a secondary use as additional comparison registers that an M-mode or S-mode application can write to enable and disable breakpoints.  So even if a core doesn't have S-mode, `scontext` can still be a useful feature.

This feature is enabled with `rocketCoreParams.mcontextWidth > 0` and/or `rocketCoreParams.scontextWidth > 0`.  The default is disabled.