### PR TITLE
Change wrdata width to support xLen != fLen case

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -871,7 +871,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val icache_blocked = !(io.imem.resp.valid || RegNext(io.imem.resp.valid))
   csr.io.counters foreach { c => c.inc := RegNext(perfEvents.evaluate(c.eventSel)) }
 
-  val coreMonitorBundle = Wire(new CoreMonitorBundle(xLen))
+  val coreMonitorBundle = Wire(new CoreMonitorBundle(xLen, fLen))
 
   coreMonitorBundle.clock := clock
   coreMonitorBundle.reset := reset
@@ -934,7 +934,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   }
 
   // CoreMonitorBundle for late latency writes
-  val xrfWriteBundle = Wire(new CoreMonitorBundle(xLen))
+  val xrfWriteBundle = Wire(new CoreMonitorBundle(xLen, fLen))
 
   xrfWriteBundle.clock := clock
   xrfWriteBundle.reset := reset

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -732,7 +732,7 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
   val wb_ctrl = RegEnable(mem_ctrl, mem_reg_valid)
 
   // CoreMonitorBundle to monitor fp register file writes
-  val frfWriteBundle = Seq.fill(2)(WireInit(new CoreMonitorBundle(xLen), DontCare))
+  val frfWriteBundle = Seq.fill(2)(WireInit(new CoreMonitorBundle(xLen, fLen), DontCare))
   frfWriteBundle.foreach { i =>
     i.clock := clock
     i.reset := reset

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -15,7 +15,7 @@ class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
   val valid = Bool()
   val pc = UInt(width = xLen.W)
   val wrdst = UInt(width = 5.W)
-  val wrdata = UInt(width = xLen.W)
+  val wrdata = UInt(width = 64.W)
   val wrenx = Bool()
   val wrenf = Bool()
   @deprecated("replace wren with wrenx or wrenf to specify integer or floating point","Rocket Chip 2020.05")

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -7,7 +7,7 @@ import chisel3._
 
 // this bundle is used to expose some internal core signals
 // to verification monitors which sample instruction commits
-class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
+class CoreMonitorBundle(val xLen: Int, val fLen: Int) extends Bundle with Clocked {
   val excpt = Bool()
   val priv_mode = UInt(width = 3.W)
   val hartid = UInt(width = xLen.W)
@@ -15,7 +15,7 @@ class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
   val valid = Bool()
   val pc = UInt(width = xLen.W)
   val wrdst = UInt(width = 5.W)
-  val wrdata = UInt(width = 64.W)
+  val wrdata = UInt(width = (xLen max fLen).W)
   val wrenx = Bool()
   val wrenf = Bool()
   @deprecated("replace wren with wrenx or wrenf to specify integer or floating point","Rocket Chip 2020.05")


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
The wdata was collecting incomplete value for fp cases when xlen was different from flen for example xlen = 32 and flen = 64 because the data width was based on xlen.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
