### PR TITLE
testing removing putpartial diplomacy claims from DMI

### DIFF
--- a/src/main/scala/devices/debug/DMI.scala
+++ b/src/main/scala/devices/debug/DMI.scala
@@ -83,8 +83,7 @@ class DMIToTL(implicit p: Parameters) extends LazyModule {
     name = "debug",
     emits = TLMasterToSlaveTransferSizes(
       get = TransferSizes(4,4),
-      putFull = TransferSizes(4,4),
-      putPartial = TransferSizes(4,4)))))))
+      putFull = TransferSizes(4,4)))))))
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This is not meant for merging; This is a test to see if removing the DMI claim that it will emit putpartials will pass regressions. Since it failed regressions, that means the DMI emits putpartials.
