### PR TITLE
Add params for nTLBBasePageSectors and nTLBSuperpages for both I and D TLBs

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -112,8 +112,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     else ClockGate(clock, clock_en_reg, "dcache_clock_gate")
   @chiselName class DCacheModuleImpl extends NoChiselNamePrefix { // entering gated-clock domain
 
-  val tlb = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries, cacheParams.nTLB4KSectors, cacheParams.nTLBSuperpages)))
-  val pma_checker = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries, cacheParams.nTLB4KSectors, cacheParams.nTLBSuperpages)) with InlineInstance)
+  val tlb = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries, cacheParams.nTLBBasePageSectors, cacheParams.nTLBSuperpages)))
+  val pma_checker = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries, cacheParams.nTLBBasePageSectors, cacheParams.nTLBSuperpages)) with InlineInstance)
 
   // tags
   val replacer = cacheParams.replacement

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -112,8 +112,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     else ClockGate(clock, clock_en_reg, "dcache_clock_gate")
   @chiselName class DCacheModuleImpl extends NoChiselNamePrefix { // entering gated-clock domain
 
-  val tlb = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries)))
-  val pma_checker = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries)) with InlineInstance)
+  val tlb = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries, cacheParams.nTLB4KSectors, cacheParams.nTLBSuperpages)))
+  val pma_checker = Module(new TLB(false, log2Ceil(coreDataBytes), TLBConfig(nTLBEntries, cacheParams.nTLB4KSectors, cacheParams.nTLBSuperpages)) with InlineInstance)
 
   // tags
   val replacer = cacheParams.replacement

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -97,7 +97,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   icache.io.clock_enabled := clock_en
   withClock (gated_clock) { // entering gated-clock domain
 
-  val tlb = Module(new TLB(true, log2Ceil(fetchBytes), TLBConfig(nTLBEntries, outer.icacheParams.nTLB4KSectors, outer.icacheParams.nTLBSuperpages)))
+  val tlb = Module(new TLB(true, log2Ceil(fetchBytes), TLBConfig(nTLBEntries, outer.icacheParams.nTLBBasePageSectors, outer.icacheParams.nTLBSuperpages)))
 
   val s1_valid = Reg(Bool())
   val s2_valid = RegInit(false.B)

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -97,7 +97,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   icache.io.clock_enabled := clock_en
   withClock (gated_clock) { // entering gated-clock domain
 
-  val tlb = Module(new TLB(true, log2Ceil(fetchBytes), TLBConfig(nTLBEntries)))
+  val tlb = Module(new TLB(true, log2Ceil(fetchBytes), TLBConfig(nTLBEntries, outer.icacheParams.nTLB4KSectors, outer.icacheParams.nTLBSuperpages)))
 
   val s1_valid = Reg(Bool())
   val s2_valid = RegInit(false.B)

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -20,7 +20,7 @@ case class DCacheParams(
     nWays: Int = 4,
     rowBits: Int = 64,
     nTLBEntries: Int = 32,
-    nTLB4KSectors: Int = 4,
+    nTLBBasePageSectors: Int = 4,
     nTLBSuperpages: Int = 4,
     tagECC: Option[String] = None,
     dataECC: Option[String] = None,

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -20,6 +20,8 @@ case class DCacheParams(
     nWays: Int = 4,
     rowBits: Int = 64,
     nTLBEntries: Int = 32,
+    nTLB4KSectors: Int = 4,
+    nTLBSuperpages: Int = 4,
     tagECC: Option[String] = None,
     dataECC: Option[String] = None,
     dataECCBytes: Int = 1,

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -23,6 +23,8 @@ case class ICacheParams(
     nWays: Int = 4,
     rowBits: Int = 128,
     nTLBEntries: Int = 32,
+    nTLB4KSectors: Int = 4,
+    nTLBSuperpages: Int = 4,
     cacheIdBits: Int = 0,
     tagECC: Option[String] = None,
     dataECC: Option[String] = None,

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -23,7 +23,7 @@ case class ICacheParams(
     nWays: Int = 4,
     rowBits: Int = 128,
     nTLBEntries: Int = 32,
-    nTLB4KSectors: Int = 4,
+    nTLBBasePageSectors: Int = 4,
     nTLBSuperpages: Int = 4,
     cacheIdBits: Int = 0,
     tagECC: Option[String] = None,


### PR DESCRIPTION
**Type of change**: other enhancement
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation
**Release Notes**
The design also supports parametrization of both the sectoring and the number of superpages in the L1 TLBs. The code has always supported the different values, but the parameters to control it were not exposed up the hierarchy.