### PR TITLE
PTW clock_en l2_refill

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -107,8 +107,9 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   arb.io.out.ready := state === s_ready
 
   val resp_valid = Reg(next = Vec.fill(io.requestor.size)(Bool(false)))
+  val l2_refill_wire = Wire(Bool())
 
-  val clock_en = state =/= s_ready || arb.io.out.valid || io.dpath.sfence.valid || io.dpath.customCSRs.disableDCacheClockGate
+  val clock_en = state =/= s_ready || l2_refill_wire || arb.io.out.valid || io.dpath.sfence.valid || io.dpath.customCSRs.disableDCacheClockGate
   io.dpath.clock_enabled := usingVM && clock_en
   val gated_clock =
     if (!usingVM || !tileParams.dcache.get.clockGate) clock
@@ -187,6 +188,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   }
 
   val l2_refill = RegNext(false.B)
+  l2_refill_wire := l2_refill
   io.dpath.perf.l2miss := false
   val (l2_hit, l2_error, l2_pte, l2_tlb_ram) = if (coreParams.nL2TLBEntries == 0) (false.B, false.B, Wire(new PTE), None) else {
     val code = new ParityCode


### PR DESCRIPTION
**Type of change**: bug report

**Impact**: performance improvement, no functional change

**Development Phase**: implementation

**Release Notes**
This only affects designs with MMU and clock gating.

The bug is that an L2TLB write will almost always block the next L2TLB search, even many cycles later, because the `l2_refill` register doesn't clear until the next search enables the clock.  The fix is to add the `l2_refill` register to `ptw_clock_en`.

`customCSRs.disableDCacheClockGate` is a work-around to utilize the L2TLB at the cost of extra power.