### PR TITLE
configs: update BaseFPGAConfig and DefaultFPGAConfig

### DIFF
--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -83,5 +83,13 @@ class MMIOPortOnlyConfig extends Config(
   new DefaultConfig
 )
 
-class BaseFPGAConfig extends Config(new BaseConfig)
-class DefaultFPGAConfig extends Config(new WithNSmallCores(1) ++ new BaseFPGAConfig)
+class BaseFPGAConfig extends Config(
+  new WithoutTLMonitors ++
+  new BaseConfig
+)
+
+class DefaultFPGAConfig extends Config(
+  new WithNSmallCores(1) ++
+  new WithCoherentBusTopology ++
+  new BaseFPGAConfig
+)


### PR DESCRIPTION
`DefaultFPGAConfig` was broken by the configurable topology refactor, because it did not have a topology specified in its `Config`.

`DefaultFPGAConfig` is not protected by regression here, nor does it contain sufficient design material to actually make a working FPGA image for any particular FPGA board, as far as I know. Perhaps it should be retired entirely instead? Looks like neither https://github.com/sifive/freedom nor https://github.com/firesim/firesim use it vs `BaseConfig`...

I added `WithoutTLMonitors` alteration to `BaseFPGAConfig` since they are know to break most FPGA flows.

**Related issue**: Closes https://github.com/chipsalliance/rocket-chip/issues/2599

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**:  API addition 

<!-- choose one -->
**Development Phase**:implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
