### PR TITLE
Change tile outputs to initialize with async reset

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -1074,7 +1074,7 @@ class CSRFile(
 
   for (((t, insn), i) <- (io.trace zip io.inst).zipWithIndex) {
     t.exception := io.retire >= i && exception
-    t.valid := io.retire > i || t.exception
+    t.valid := (io.retire > i || t.exception) && !reset
     t.insn := insn
     t.iaddr := io.pc
     t.priv := Cat(reg_debug, reg_mstatus.prv)

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -348,6 +348,10 @@ trait CanAttachTile {
     domain {
       domain.clockSinkNode := crossingParams.injectClockNode(context) := domain.clockNode
     } := clockSource
+
+    domain {
+      domain.tile.externalClockSinkNode
+    } := clockSource
   }
 }
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.diplomaticobjectmodel.{HasLogicalTreeNode}
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{GenericLogicalTreeNode, LogicalTreeNode}
 
 import freechips.rocketchip.interrupts._
+import freechips.rocketchip.prci.{ClockSinkNode, ClockSinkParameters}
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -281,6 +282,10 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   /** Node for external consumers to source watchpoints to control trace. */
   val bpwatchNode: BundleBridgeOutwardNode[Vec[BPWatch]] =
     BundleBridgeNameNode("bpwatch") :*= bpwatchNexusNode := bpwatchSourceNode
+
+  /** Node to receive raw core_clock and core_reset */
+  val externalClockSinkNode = ClockSinkNode(Seq(ClockSinkParameters()))
+  def rawReset = externalClockSinkNode.in.head._1.reset
 
   /** Helper function for connecting MMIO devices inside the tile to an xbar that will make them visible to external masters. */
   def connectTLSlave(xbarNode: TLOutwardNode, node: TLNode, bytes: Int) {

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -82,7 +82,7 @@ trait SourcesExternalNotifications { this: BaseTile =>
 
   def reportHalt(could_halt: Option[Bool]) {
     val (halt_and_catch_fire, _) = haltNode.out(0)
-    halt_and_catch_fire(0) := could_halt.map(RegEnable(true.B, false.B, _)).getOrElse(false.B)
+    halt_and_catch_fire(0) := could_halt.map(h => RegEnable(true.B, false.B, BlockDuringReset(h))).getOrElse(false.B)
   }
 
   def reportHalt(errors: Seq[CanHaveErrors]) {
@@ -116,6 +116,6 @@ trait SourcesExternalNotifications { this: BaseTile =>
 
   def reportWFI(could_wfi: Option[Bool]) {
     val (wfi, _) = wfiNode.out(0)
-    wfi(0) := could_wfi.map(RegNext(_, init=false.B)).getOrElse(false.B)
+    wfi(0) := could_wfi.map(w => RegNext(BlockDuringReset(w), init=false.B)).getOrElse(false.B)
   }
 }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -4,6 +4,7 @@
 package freechips.rocketchip.tile
 
 import Chisel._
+import chisel3.withReset
 import freechips.rocketchip.config._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
@@ -136,17 +137,19 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   val core = Module(new Rocket(outer)(outer.p))
 
-  // Report unrecoverable error conditions; for now the only cause is cache ECC errors
-  outer.reportHalt(List(outer.dcache.module.io.errors))
+  withReset(outer.rawReset) {   // use unmodified reset for notification ports
+    // Report unrecoverable error conditions; for now the only cause is cache ECC errors
+    outer.reportHalt(List(outer.dcache.module.io.errors))
 
-  // Report when the tile has ceased to retire instructions; for now the only cause is clock gating
-  outer.reportCease(outer.rocketParams.core.clockGate.option(
-    !outer.dcache.module.io.cpu.clock_enabled &&
-    !outer.frontend.module.io.cpu.clock_enabled &&
-    !ptw.io.dpath.clock_enabled &&
-    core.io.cease))
+    // Report when the tile has ceased to retire instructions; for now the only cause is clock gating
+    outer.reportCease(outer.rocketParams.core.clockGate.option(
+      !outer.dcache.module.io.cpu.clock_enabled &&
+      !outer.frontend.module.io.cpu.clock_enabled &&
+      !ptw.io.dpath.clock_enabled &&
+      core.io.cease))
 
-  outer.reportWFI(Some(core.io.wfi))
+    outer.reportWFI(Some(core.io.wfi))
+  }
 
   outer.decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
 

--- a/src/main/scala/util/BlockDuringReset.scala
+++ b/src/main/scala/util/BlockDuringReset.scala
@@ -20,4 +20,9 @@ object BlockDuringReset
     }
     res
   }
+
+  def apply(enq: Bool): Bool = {
+    val out_of_reset = RegNext(true.B, false.B)
+    enq && out_of_reset
+  }
 }

--- a/src/main/scala/util/RationalCrossing.scala
+++ b/src/main/scala/util/RationalCrossing.scala
@@ -123,7 +123,7 @@ class RationalCrossingSink[T <: Data](gen: T, direction: RationalDirection = Sym
   enq.ready := deq.ready
   enq.sink  := count
   deq.bits  := Mux(equal, enq.bits0, enq.bits1)
-  deq.valid := Mux(equal, enq.valid, count(1) =/= enq.source(0))
+  deq.valid := BlockDuringReset(Mux(equal, enq.valid, count(1) =/= enq.source(0)))
 
   when (deq.fire()) { count := Cat(count(0), !count(1)) }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Tile notification output ports should be reset to 0 asynchronously when using `SubsystemResetKey = ResetAsynchronous`.  Since the module reset for the Tile is a stretched `Bool()` reset, bring a second reset into the Tile sourced from the original external IO.  When the notifications are placed in a `withReset` block, this resets the registers driving the outputs asynchronously.

@hcook, there's probably a cleaner way to connect the core_reset IO into the Tile...

Also changed the `RationalCrossing` so that the sink (which may be in an async reset domain) does not act on any output from the source (which may be synchronously reset some time later) until after the source has completed its reset at the first clock edge.
