### PR TITLE
Revise trace.valid gating method to relieve timing on reset

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -1074,7 +1074,7 @@ class CSRFile(
 
   for (((t, insn), i) <- (io.trace zip io.inst).zipWithIndex) {
     t.exception := io.retire >= i && exception
-    t.valid := (io.retire > i || t.exception) && !reset
+    t.valid := io.retire > i || t.exception
     t.insn := insn
     t.iaddr := io.pc
     t.priv := Cat(reg_debug, reg_mstatus.prv)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Per a review comment in another repository, change the method to ensure trace.valid signals are deasserted during and just after reset.  Now uses an async-reset delay to gate trace.valid in RocketTile rather than gating with core.reset.