### PR TITLE
Update to Chisel 3.4.0 and FIRRTL 1.4.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs-target/
 .addons-dont-touch
 /lib/
 /test_lib/
+rocketchip.jar

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,2 @@
+-Dsbt.sourcemode=true
+-Dsbt.workspace=$PWD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to Rocket Chip!
 + [Submitting a PR](#submitting)
 + [Conditions for Merging a PR](#merging)
 + [Bumping Submodules](#bumping)
++ [Bumping Chisel and FIRRTL](#bumping-chisel)
 
 ### <a name="submitting"></a> Submitting a PR
 
@@ -28,15 +29,13 @@ Currently, the requirements for merging a PR are:
 
 Several projects are managed as git submodules as well as [Wit](https://github.com/sifive/wit) dependencies.
 
-### When to bump
+#### When to bump
 
 Most projects will be bumped by developers as needed; however,
 sometimes users may wish to speed up the bumping process.
-For more stable projects like Chisel 3 and FIRRTL,
-please only bump to stable branches as defined by the specific subproject.
-As of March 2020 these branches are `3.2.x` in Chisel 3 and `1.2.x` in FIRRTL.
+For Chisel 3 and FIRRTL, please see the instructions in [Bumping Chisel and FIRRTL](#bumping-chisel).
 
-### How to bump
+#### How to bump
 
 1. Bump the Git submodule
 
@@ -72,3 +71,40 @@ major feature or performance improvements in your commit message.
 4. Open a Pull Request on Github
 
 Please see the Github documentation for [Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests)
+
+### <a name="bumping-chisel"></a> Bumping Chisel and FIRRTL
+
+Because Chisel and FIRRTL have mature release processes, Rocket Chip uses the published artifacts when possible.
+However, Rocket Chip maintains the ability to easily switch to building Chisel and FIRRTL from source.
+This support is useful for long-lived tapeout branches and forks that may stuck on old versions of Chisel or FIRRTL with tapeout-specific bugfixes or hacks.
+
+_Whether Rocket Chip is building Chisel and FIRRTL from published artifacts or from source is a property of a given commit_.
+Users should *not* be changing this behavior locally; it should only be changed as part of bumping the dependencies.
+
+In order to support switching between building against both source and published version of Chisel 3 and FIRRTL,
+Rocket Chip uses an SBT plugin that it configures via JVM system properties.
+This flow is described in the [Chisel README](https://github.com/freechipsproject/chisel3#building-chisel-with-firrtl-in-the-same-sbt-project).
+
+When a file named `.sbtopts` exists in the root of this repository, it means Rocket Chip is configured to build Chisel 3 and FIRRTL from source.
+When this file does not exist, Rocket Chip is configured to use published artifacts for Chisel 3 and FIRRTL.
+
+### How to bump
+
+Due to supporting both published artifacts and building from source, we must bump both approaches.
+To bump the source dependencies, bump the git submodules as described in the previous section: [Bumping Submodules](#bumping).
+To bump the published dependencies, bump the versions at the top of the SBT build file: [build.sbt](build.sbt).
+Typically, the SBT dependency will only list a version for Chisel 3 which itself depends on FIRRTL.
+
+Imporantly, the git submodule dependency and published dependency should be kept in sync.
+Each published version corresponds to a tag in the respective git repository.
+For example, Chisel version `"3.4.0"` in `build.sbt` corresponds to tag `v3.4.0` in the `chisel3` git submodule.
+Due to how Wit dependencies work, we do *not* want the submodules to point to release tags; rather, we want them to point to the merge-base with the stable release branch.
+
+For Chisel `v3.4.0`, the stable release branch is `3.4.x`.
+Thus, in bumping to Chisel `v3.4.0`, we would want to bump the submodule to the commit given by the command:
+
+```bash
+git merge-base v3.4.0 origin/3.4.x
+```
+
+Note that `origin/` is necessary for `3.4.x` because it is a branch so will not exist in your local clone by default.

--- a/Makefrag
+++ b/Makefrag
@@ -25,46 +25,38 @@ EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
 COMMA := ,
 
-SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -jar $(base_dir)/sbt-launch.jar
+# Running with sbt-launch.jar doesn't read .sbtopts by default
+# Set if the file exists (if it exists, we're building chisel3 and firrtl from source)
+sbtopts_file := $(base_dir)/.sbtopts
+ifneq (,$(wildcard $(sbtopts_file)))
+	SBT_OPTS ?= $(shell cat $(sbtopts_file))
+endif
+SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -jar $(base_dir)/sbt-launch.jar
 SHELL := /bin/bash
 
 FIRRTL_TRANSFORMS := \
 	firrtl.passes.InlineInstances \
 
-ROCKET_CLASS_DIRS ?= \
-	$(base_dir)/target/scala-2.12/classes \
-	$(base_dir)/chisel3/target/scala-2.12/classes \
-	$(base_dir)/chisel3/core/target/scala-2.12/classes \
-	$(base_dir)/chisel3/macros/target/scala-2.12/classes
-
-ROCKET_CLASSES ?= $(subst $(SPACE),:,$(ROCKET_CLASS_DIRS))
-FIRRTL_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl.jar
 FIRRTL_TEST_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl-test.jar
-FIRRTL ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -cp "$(FIRRTL_JAR)":"$(ROCKET_CLASSES)" firrtl.Driver
 
-# Build firrtl.jar and put it where chisel3 can find it.
-$(FIRRTL_JAR): $(shell find $(base_dir)/firrtl/src/main/scala -iname "*.scala")
-	$(MAKE) -C $(base_dir)/firrtl SBT="$(SBT)" root_dir=$(base_dir)/firrtl build-scala
-	cd $(base_dir)/firrtl && $(SBT) "Test / assembly"
-	touch $(FIRRTL_JAR)
-	mkdir -p $(base_dir)/lib
-	cp -p $(FIRRTL_JAR) $(base_dir)/lib
+JAVA ?= java -Xmx$(JVM_MEMORY) -Xss8M
+FIRRTL ?= $(JAVA) -cp $(ROCKET_CHIP_JAR) firrtl.stage.FirrtlMain
+GENERATOR ?= $(JAVA) -cp $(ROCKET_CHIP_JAR) $(PROJECT).Generator
 
-	mkdir -p $(base_dir)/test_lib
-	cp -p $(FIRRTL_JAR) $(base_dir)/test_lib
-	cp -p $(FIRRTL_TEST_JAR) $(base_dir)/test_lib
-# When chisel3 pr 448 is merged, the following extraneous copy may be removed.
-	mkdir -p $(base_dir)/chisel3/lib
-	cp -p $(FIRRTL_JAR) $(base_dir)/chisel3/lib
+# Extracting this information from SBT would be more robust
+# api-config-chipsalliance does not use standard SBT src/main/scala, but has no resources
+scala_srcs := $(shell find $(base_dir) -name "*.scala" -o -name "*.sbt")
+resource_dirs := $(shell find $(base_dir) -type d -path "*/src/main/resources")
+resources := $(foreach d,$(resource_dirs),$(shell find $(d) -type f))
+all_srcs := $(scala_srcs) $(resources)
 
-src_path := src/main/scala
-resources := $(base_dir)/src/main/resources
-csrc := $(resources)/csrc
-vsrc := $(resources)/vsrc
-default_submodules := . hardfloat chisel3
-default_submodule_src_paths := $(foreach submodule,$(default_submodules) $(ROCKETCHIP_ADDONS),$(base_dir)/$(submodule)/$(src_path))
-other_src_paths := $(base_dir)/api-config-chipsalliance/design/craft/src
-chisel_srcs := $(foreach path,$(default_submodule_src_paths) $(other_src_paths),$(shell find $(path) -name "*.scala"))
+ROCKET_CHIP_JAR := $(base_dir)/rocketchip.jar
+$(ROCKET_CHIP_JAR): $(all_srcs)
+	cd $(base_dir) && $(SBT) $(SBT_OPTS) assembly
+
+rc_resource_dir := $(base_dir)/src/main/resources
+csrc := $(rc_resource_dir)/csrc
+vsrc := $(rc_resource_dir)/vsrc
 
 disasm := 2>
 which_disasm := $(shell which spike-dasm 2> /dev/null)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ the RISC-V Rocket Core. For more information on Rocket Chip, please consult our 
     + [Pushing a Rocket core through the VLSI tools](#vlsi)
 + [How can I parameterize my Rocket chip?](#param)
 + [Debugging with GDB](#debug)
++ [Building Rocket Chip with an IDE](#ide)
 + [Contributors](#contributors)
 
 ## <a name="quick"></a> Quick Instructions
@@ -681,6 +682,25 @@ Now we can proceed as with Spike, debugging works in a similar way:
 	(gdb)
 
 Further information about GDB debugging is available [here](https://sourceware.org/gdb/onlinedocs/gdb/) and [here](https://sourceware.org/gdb/onlinedocs/gdb/Remote-Debugging.html#Remote-Debugging).
+
+## <a name="ide"></a> Building Rocket Chip with an IDE
+
+The Rocket Chip Scala build uses the standard Scala build tool SBT.
+IDEs like [IntelliJ](https://www.jetbrains.com/idea/) and [VSCode](https://code.visualstudio.com/)
+are popular in the Scala community and work with Rocket Chip.
+To use one of these IDEs, there is one minor peculiarity of the Rocket Chip build that must be addressed.
+
+If the file `.sbtopts` exists in the root of the repository, you need to expand the `$PWD` variable inside of the file to an absolute path pointing to the location of your Rocket Chip clone.
+You can do this in `bash` with:
+```bash
+sed -i "s|\$PWD|$PWD|" .sbtopts
+```
+
+_If the file `.sbtopts` does not exist, you do not need to do anything special._
+
+If `.sbtopts` does not exist or if you have expanded the `$PWD` variable inside of it, you can import Rocket Chip into your IDE of choice.
+
+For more information on what `.sbtopts` is for (when it exists), see [CONTRIBUTING.md](CONTRIBUTING.md#bumping-chisel).
 
 ## <a name="contributors"></a> Contributors
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,9 @@ import scala.sys.process._
 
 enablePlugins(PackPlugin)
 
+// This needs to stay in sync with the chisel3 and firrtl git submodules
+val chiselVersion = "3.4.0-RC3"
+
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
   version      := "1.2-SNAPSHOT",
@@ -14,7 +17,7 @@ lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-deprecation","-unchecked","-Xsource:2.11"),
   libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value),
   libraryDependencies ++= Seq("org.json4s" %% "json4s-jackson" % "3.6.1"),
-  libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.0.8" % "test"),
+  libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.0" % "test"),
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),
@@ -53,47 +56,40 @@ lazy val commonSettings = Seq(
   }
 )
 
-lazy val chisel = (project in file("chisel3")).settings(commonSettings)
-
-def dependOnChisel(prj: Project) = {
-  if (sys.props.contains("ROCKET_USE_MAVEN")) {
-    prj.settings(
-      libraryDependencies ++= Seq("edu.berkeley.cs" %% "chisel3" % "3.2-SNAPSHOT")
-    )
-  } else {
-    prj.dependsOn(chisel)
-  }
-}
+lazy val chiselRef = ProjectRef(workspaceDirectory / "chisel3", "chisel")
+lazy val chiselLib = "edu.berkeley.cs" %% "chisel3" % chiselVersion
+// While not built from source, *must* be in sync with the chisel3 git submodule
+// Building from source requires extending sbt-sriracha or a similar plugin and
+//   keeping scalaVersion in sync with chisel3 to the minor version
+lazy val chiselPluginLib = "edu.berkeley.cs" % "chisel3-plugin" % chiselVersion cross CrossVersion.full
 
 lazy val `api-config-chipsalliance` = (project in file("api-config-chipsalliance/build-rules/sbt"))
   .settings(commonSettings)
   .settings(publishArtifact := false)
-lazy val hardfloat  = dependOnChisel(project).settings(commonSettings)
+lazy val hardfloat  = (project in file("hardfloat"))
+  .sourceDependency(chiselRef, chiselLib)
+  .settings(addCompilerPlugin(chiselPluginLib))
+  .settings(commonSettings)
   .settings(publishArtifact := false)
 lazy val `rocket-macros` = (project in file("macros")).settings(commonSettings)
   .settings(publishArtifact := false)
-lazy val rocketchip = dependOnChisel(project in file("."))
+lazy val rocketchip = (project in file("."))
+  .sourceDependency(chiselRef, chiselLib)
+  .settings(addCompilerPlugin(chiselPluginLib))
   .settings(commonSettings, chipSettings)
-  .dependsOn(`api-config-chipsalliance` % "compile-internal;test-internal")
-  .dependsOn(hardfloat % "compile-internal;test-internal")
-  .dependsOn(`rocket-macros` % "compile-internal;test-internal")
-  .settings(
-      aggregate := false,
-      // Include macro classes, resources, and sources in main jar.
-      mappings in (Compile, packageBin) ++= (mappings in (`api-config-chipsalliance`, Compile, packageBin)).value,
-      mappings in (Compile, packageSrc) ++= (mappings in (`api-config-chipsalliance`, Compile, packageSrc)).value,
-      mappings in (Compile, packageBin) ++= (mappings in (hardfloat, Compile, packageBin)).value,
-      mappings in (Compile, packageSrc) ++= (mappings in (hardfloat, Compile, packageSrc)).value,
-      mappings in (Compile, packageBin) ++= (mappings in (`rocket-macros`, Compile, packageBin)).value,
-      mappings in (Compile, packageSrc) ++= (mappings in (`rocket-macros`, Compile, packageSrc)).value,
-      exportJars := true,
-      Test / unmanagedBase := baseDirectory.value / "test_lib",
-      // Settings for scalafix
-      semanticdbEnabled := true,
-      semanticdbVersion := scalafixSemanticdb.revision,
-      scalacOptions += "-Ywarn-unused-import"
+  .dependsOn(`api-config-chipsalliance`)
+  .dependsOn(hardfloat)
+  .dependsOn(`rocket-macros`)
+  .settings( // Assembly settings
+    assembly / test := {},
+    assembly / assemblyJarName := "rocketchip.jar",
+    assembly / assemblyOutputPath := baseDirectory.value / "rocketchip.jar"
   )
-
+  .settings( // Settings for scalafix
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalacOptions += "-Ywarn-unused-import"
+  )
 
 lazy val addons = settingKey[Seq[String]]("list of addons used for this build")
 lazy val make = inputKey[Unit]("trigger backend-specific makefile command")

--- a/build.wake
+++ b/build.wake
@@ -9,6 +9,7 @@ global def hardfloatScalaModule =
   | setScalaModuleRootDir hardfloatRoot
   | setScalaModuleDeps (chisel3ScalaModule, Nil)
   | setScalaModuleScalacOptions ("-Xsource:2.11", Nil)
+  | addChisel3CompilerPlugin
 
 global def rocketchipMacros =
   makeScalaModuleFromJSON here "rocketchipMacros"
@@ -27,6 +28,7 @@ global def rocketchipScalaModule =
   | setScalaModuleDeps deps
   | setScalaModuleScalacOptions ("-Xsource:2.11", Nil)
   | addMacrosParadiseCompilerPlugin
+  | addChisel3CompilerPlugin
 
 def vlsi_mem_gen = source "{rocketChipRoot}/scripts/vlsi_mem_gen"
 def vlsi_rom_gen = source "{rocketChipRoot}/scripts/vlsi_rom_gen"

--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -8,11 +8,11 @@ verilog = \
 
 .SECONDARY: $(firrtl) $(verilog)
 
-$(generated_dir)/%.fir $(generated_dir)/%.d: $(FIRRTL_JAR) $(chisel_srcs) $(bootrom_img)
+$(generated_dir)/%.fir $(generated_dir)/%.d: $(ROCKET_CHIP_JAR) $(bootrom_img)
 	mkdir -p $(dir $@)
-	cd $(base_dir) && $(SBT) "runMain $(PROJECT).Generator -td $(generated_dir) -T $(PROJECT).$(MODEL) -C $(CONFIG) $(CHISEL_OPTIONS)"
+	cd $(base_dir) && $(GENERATOR) -td $(generated_dir) -T $(PROJECT).$(MODEL) -C $(CONFIG) $(CHISEL_OPTIONS)
 
-%.v %.conf: %.fir $(FIRRTL_JAR)
+%.v %.conf: %.fir $(ROCKET_CHIP_JAR)
 	mkdir -p $(dir $@)
 	$(FIRRTL) $(patsubst %,-i %,$(filter %.fir,$^)) \
     -o $*.v \

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.9.3")
 
@@ -17,3 +17,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.5" )
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.21")
+
+addSbtPlugin("com.eed3si9n" % "sbt-sriracha" % "0.1.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -337,16 +337,16 @@ emulator-jtag-dtm-regression: emulator-jtag-dtm-tests-32 emulator-jtag-dtm-tests
 
 # Target to run Scalatest regressions 'sbt test'
 .PHONY: scalatest
-scalatest: stamps/other-submodules.stamp $(FIRRTL_JAR)
-	(cd $(abspath $(TOP)) && $(SBT) test)
+scalatest: stamps/other-submodules.stamp $(all_srcs)
+	(cd $(base_dir) && $(SBT) $(SBT_OPTS) test)
 
 # Target to run Scalafix 'sbt scalafix'
 .PHONY: scalafix
-scalafix: stamps/other-submodules.stamp $(FIRRTL_JAR)
-	(cd $(abspath $(TOP)) && $(SBT) scalafix)
+scalafix: stamps/other-submodules.stamp $(all_srcs)
+	(cd $(base_dir) && $(SBT) $(SBT_OPTS) scalafix)
 
 # Target to run Scalafix 'sbt scalafix --check', which will not actually modify
 # Scala files.
 .PHONY: scalafix-check
-scalafix-check: stamps/other-submodules.stamp $(FIRRTL_JAR)
-	(cd $(abspath $(TOP)) && $(SBT) 'scalafix --check')
+scalafix-check: stamps/other-submodules.stamp $(all_srcs)
+	(cd $(base_dir) && $(SBT) $(SBT_OPTS) 'scalafix --check')

--- a/regression/run-test-bucket
+++ b/regression/run-test-bucket
@@ -97,6 +97,10 @@ case "${bucket_number}" in
   9)
     make scalafix-check -C regression SUITE=foo JVM_MEMORY=8G
     ;;
+  10)
+    ./scripts/swap-sbt-build
+    make scalatest -C regression SUITE=foo JVM_MEMORY=8G
+    ;;
 
   -h|--help)
     print_usage

--- a/scripts/swap-sbt-build
+++ b/scripts/swap-sbt-build
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+# Switches between SBT building chisel3 and firrtl from source vs. published dependencies
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+root_dir="$(dirname "$script_dir")"
+sbt_opts="$root_dir/.sbtopts"
+
+if [ -f $sbt_opts ]; then
+  echo ".sbtopts exists so chisel3 and firrtl are currently built from source, swapping to build from published artifacts..."
+  rm -f $sbt_opts
+else
+  echo ".sbtopts does not exist so chisel3 and firrtl are currently built from published artifacts, swapping to build from source..."
+  echo "-Dsbt.sourcemode=true"  > $sbt_opts
+  echo "-Dsbt.workspace=\$PWD" >> $sbt_opts
+fi

--- a/src/main/scala/stage/phases/GenerateFirrtlAnnos.scala
+++ b/src/main/scala/stage/phases/GenerateFirrtlAnnos.scala
@@ -3,9 +3,9 @@
 package freechips.rocketchip.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.annotations.{Annotation, DeletedAnnotation, JsonProtocol}
+import firrtl.annotations.{DeletedAnnotation, JsonProtocol}
 import firrtl.options.Viewer.view
-import firrtl.options.{Dependency, Phase, PreservesAll, StageOptions, TargetDirAnnotation, Unserializable}
+import firrtl.options._
 import freechips.rocketchip.stage.RocketChipOptions
 import freechips.rocketchip.util.HasRocketChipStageUtils
 
@@ -18,18 +18,14 @@ class GenerateFirrtlAnnos extends Phase with PreservesAll[Phase] with HasRocketC
     val targetDir = view[StageOptions](annotations).targetDir
     val fileName = s"${view[RocketChipOptions](annotations).longName.get}.anno.json"
 
-    val annos = scala.collection.mutable.Buffer[Annotation]()
-    annotations.flatMap {
-      case a: Unserializable =>
-        Some(a)
-      case a: TargetDirAnnotation =>
-        /** Don't serialize, in case of downstream FIRRTL call */
-        Some(a)
-      case a @ DeletedAnnotation(_, _: Unserializable) =>
-        /** [[DeletedAnnotation]]s of unserializable annotations cannot be serialized */
-        Some(a)
+    val annos = annotations.view.flatMap {
+      // Remove TargetDirAnnotation so that we can pass as argument to FIRRTL
+      // Remove CustomFileEmission, those are serialized automatically by Stages
+      case (_: Unserializable | _: TargetDirAnnotation | _: CustomFileEmission) =>
+        None
+      case DeletedAnnotation(_, (_: Unserializable | _: CustomFileEmission)) =>
+        None
       case a =>
-        annos += a
         Some(a)
     }
 

--- a/src/test/scala/generatorTests/StageGeneratorSpec.scala
+++ b/src/test/scala/generatorTests/StageGeneratorSpec.scala
@@ -9,7 +9,7 @@ import chisel3._
 import firrtl.options.TargetDirAnnotation
 import freechips.rocketchip.stage.{ConfigsAnnotation, TopModuleAnnotation}
 import freechips.rocketchip.system.{RocketChipStage, TestHarness}
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 /** run via SBT with
  *    > testOnly generatorTests.StageGeneratorSpec
@@ -17,7 +17,7 @@ import org.scalatest.FlatSpec
  *  Output can be viewed in the testbuild directory. The wire named "hello" should show up in the generated
  *  *.anno.json file.
  */
-class StageGeneratorSpec extends FlatSpec {
+class StageGeneratorSpec extends AnyFlatSpec {
 
   val dummyAspect = InjectingAspect(
     {dut: TestHarness => Seq(dut.dut)},

--- a/src/test/scala/linting/rule/LintConflictingModuleNamesSpec.scala
+++ b/src/test/scala/linting/rule/LintConflictingModuleNamesSpec.scala
@@ -4,12 +4,13 @@ package freechips.rocketchip.linting.rule
 
 import firrtl._
 import firrtl.annotations._
-import firrtl.testutils.{FirrtlMatchers, FirrtlPropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 
 import freechips.rocketchip.linting.Violation
 import freechips.rocketchip.transforms.naming.{OverrideDesiredNameAnnotation, RenameDesiredNames}
 
-class LintConflictingModuleNamesSpec extends FirrtlPropSpec with FirrtlMatchers {
+class LintConflictingModuleNamesSpec extends AnyPropSpec with Matchers {
   val transform = new LintConflictingModuleNames
   def lint(input: String, annos: Seq[Annotation]): CircuitState = {
     val state = CircuitState(Parser.parse(input), UnknownForm, annos)

--- a/src/test/scala/transforms/naming/RenameDesiredNamesSpec.scala
+++ b/src/test/scala/transforms/naming/RenameDesiredNamesSpec.scala
@@ -4,7 +4,8 @@ package freechips.rocketchip.transforms.naming
 
 import firrtl._
 import firrtl.annotations._
-import firrtl.testutils.{FirrtlMatchers, FirrtlPropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 
 import freechips.rocketchip.linting.rule.DesiredNameAnnotation
 
@@ -16,7 +17,7 @@ case class UnstableNameAnnotation(target: IsModule) extends SingleTargetAnnotati
   def duplicate(newTarget: IsModule): UnstableNameAnnotation = this.copy(target = newTarget)
 }
 
-class RenameDesiredNamesSpec extends FirrtlPropSpec with FirrtlMatchers {
+class RenameDesiredNamesSpec extends AnyPropSpec with Matchers {
   val transform = new RenameDesiredNames
 
   case class TestCase(

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -8,11 +8,11 @@ verilog = $(generated_dir)/$(long_name).v
 # files.
 .SECONDARY: $(firrtl) $(verilog)
 
-$(generated_dir)/%.fir $(generated_dir)/%.d: $(FIRRTL_JAR) $(chisel_srcs) $(bootrom_img)
+$(generated_dir)/%.fir $(generated_dir)/%.d: $(ROCKET_CHIP_JAR) $(bootrom_img)
 	mkdir -p $(dir $@)
-	cd $(base_dir) && $(SBT) "runMain $(PROJECT).Generator -td $(generated_dir) -T $(PROJECT).$(MODEL) -C $(CONFIG)"
+	cd $(base_dir) && $(GENERATOR) -td $(generated_dir) -T $(PROJECT).$(MODEL) -C $(CONFIG)
 
-$(generated_dir)/%.v $(generated_dir)/%.conf: $(generated_dir)/%.fir $(FIRRTL_JAR)
+$(generated_dir)/%.v $(generated_dir)/%.conf: $(generated_dir)/%.fir $(ROCKET_CHIP_JAR)
 	mkdir -p $(dir $@)
 	$(FIRRTL) -i $< \
     -o $(generated_dir)/$*.v \

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -5,17 +5,17 @@
         "source": "git@github.com:ucb-bar/berkeley-hardfloat.git"
     },
     {
-        "commit": "dd3f744d72c45a606c4ed76da48fa44c1ee4de15",
+        "commit": "c1c87ba4899e53bfe09adf0f4631e2b6a0cca19a",
         "name": "api-chisel3-sifive",
         "source": "git@github.com:sifive/api-chisel3-sifive.git"
     },
     {
-        "commit": "cc2971feb15d4bc8cb4a8138b5a095ccbc92dcc3",
+        "commit": "d033d4123672b07a90afb5536b3e6cf83b7228ff",
         "name": "chisel3",
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "c07da8a581789b88f7e6ffc98c8e810565034ad9",
+        "commit": "4f92b94e0e8f35accb4fcc2f06390486d7144740",
         "name": "firrtl",
         "source": "git@github.com:freechipsproject/firrtl.git"
     },


### PR DESCRIPTION
This PR kills the FIRRTL fat jar, instead using https://github.com/freechipsproject/chisel3/pull/1563 to include FIRRTL as a managed dependency in SBT. It also supports toggling between source and published dependencies, if you delete `.sbtopts` it will use the published dependencies.

TODO
- [x] Add test for ability to toggle between source and published dependencies (this currently would not work because RC1 has a bug that breaks rocket-chip)
- [x] FIRRTL test utils

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification (to build API and Makefiles)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Change build flow to build FIRRTL as SBT-managed dependency and use rocket-chip fat jar in Makefiles