### PR TITLE
Expose control over take field for all ClockSinkParameters in system

### DIFF
--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -27,6 +27,7 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem.{TileCrossingParamsLike, CanAttachTile}
 import freechips.rocketchip.util._
+import freechips.rocketchip.prci.{ClockSinkParameters}
 
 // =======
 // Outline
@@ -75,6 +76,7 @@ case class TraceGenParams(
   val beuAddr = None
   val blockerCtrlAddr = None
   val name = None
+  val clockSinkParams = ClockSinkParameters()
 }
 
 trait HasTraceGenParams {

--- a/src/main/scala/subsystem/BankedL2Params.scala
+++ b/src/main/scala/subsystem/BankedL2Params.scala
@@ -37,12 +37,12 @@ case class CoherenceManagerWrapperParams(
     blockBytes: Int,
     beatBytes: Int,
     nBanks: Int,
+    dtsFrequency: Option[BigInt],
     name: String)
   (val coherenceManager: CoherenceManagerInstantiationFn)
   extends HasTLBusParams 
   with TLBusWrapperInstantiationLike
 {
-  val dtsFrequency = None
   def instantiate(context: HasTileLinkLocations, loc: Location[TLBusWrapper])(implicit p: Parameters): CoherenceManagerWrapper = {
     val cmWrapper = LazyModule(new CoherenceManagerWrapper(this, context))
     cmWrapper.suggestName(loc.name + "_wrapper")

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -79,7 +79,7 @@ case class CoherentBusTopologyParams(
 ) extends TLBusWrapperTopology(
   instantiations = (if (l2.nBanks == 0) Nil else List(
     (MBUS, mbus),
-    (L2, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, l2.nBanks, L2.name)(l2.coherenceManager)))),
+    (L2, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, l2.nBanks, sbus.dtsFrequency, L2.name)(l2.coherenceManager)))),
   connections = if (l2.nBanks == 0) Nil else List(
     (SBUS, L2,   TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_STAR)()),
     (L2,  MBUS,  TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_QUERY)())

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -229,7 +229,8 @@ trait CanAttachTile {
 
   /** Narrow waist through which all tiles are intended to pass while being instantiated. */
   def instantiate(implicit p: Parameters): TilePRCIDomain[TileType] = {
-    val tile_prci_domain = LazyModule(new TilePRCIDomain[TileType](tileParams.hartId) {
+    val clockSinkParams = tileParams.clockSinkParams.copy(name = Some(s"${tileParams.name.getOrElse("core")}_${tileParams.hartId}"))
+    val tile_prci_domain = LazyModule(new TilePRCIDomain[TileType](clockSinkParams) {
       val tile = LazyModule(tileParams.instantiate(crossingParams, lookup))
     })
     tile_prci_domain

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -14,6 +14,7 @@ import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
+import freechips.rocketchip.prci.{ClockSinkParameters}
 
 case object TileVisibilityNodeKey extends Field[TLEphemeralNode]
 case object TileKey extends Field[TileParams]
@@ -28,6 +29,7 @@ trait TileParams {
   val beuAddr: Option[BigInt]
   val blockerCtrlAddr: Option[BigInt]
   val name: Option[String]
+  val clockSinkParams: ClockSinkParameters
 }
 
 abstract class InstantiableTileParams[TileType <: BaseTile] extends TileParams {

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -13,6 +13,8 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.TileCrossingParamsLike
 import freechips.rocketchip.util._
+import freechips.rocketchip.prci.{ClockSinkParameters}
+
 
 case class RocketTileParams(
     core: RocketCoreParams = RocketCoreParams(),
@@ -24,6 +26,7 @@ case class RocketTileParams(
     hartId: Int = 0,
     beuAddr: Option[BigInt] = None,
     blockerCtrlAddr: Option[BigInt] = None,
+    clockSinkParams: ClockSinkParameters = ClockSinkParameters(),
     boundaryBuffers: Boolean = false // if synthesized with hierarchical PnR, cut feed-throughs?
     ) extends InstantiableTileParams[RocketTile] {
   require(icache.isDefined)

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -16,13 +16,13 @@ import freechips.rocketchip.tilelink._
   * hierarchical P&R boundary buffers, core-local interrupt handling,
   * and any other IOs related to PRCI control.
   */
-abstract class TilePRCIDomain[T <: BaseTile](id: Int)(implicit p: Parameters)
+abstract class TilePRCIDomain[T <: BaseTile](clockSinkParams: ClockSinkParameters)(implicit p: Parameters)
     extends ClockDomain
 {
   val tile: T
 
   val clockNode = ClockIdentityNode()
-  val clockSinkNode = ClockSinkNode(Seq(ClockSinkParameters(take = None, name = Some(s"core_$id"))))
+  val clockSinkNode = ClockSinkNode(Seq(clockSinkParams))
   def clockBundle = clockSinkNode.in.head._1
 
   /** External code looking to connect and clock-cross the interrupts driven into this tile can call this. */


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
This PR exposes control to set the `take` fields of all ClockSinks in the system. This lets us programmatically generate PLL models by inspecting all desired frequencies at a single `ClockGroupSourceNode`.

A `clockSinkParams` field is added to `TileParams`, and parameterizes the `ClockSinkNode` in the `TilePRCIDomain`.
Additionally, the `CoherenceManagerWrapper` is now set with the same `dtsFrequency` as the `SystemBus`, which drives its clocks

**Related issue**: https://github.com/ucb-bar/chipyard/pull/614

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
