### PR TITLE
PTW: wait for L2TLB refill before searching

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -104,13 +104,13 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
 
   val s_ready :: s_req :: s_wait1 :: s_dummy1 :: s_wait2 :: s_wait3 :: s_dummy2 :: s_fragment_superpage :: Nil = Enum(UInt(), 8)
   val state = Reg(init=s_ready)
+  val l2_refill_wire = Wire(Bool())
 
   val arb = Module(new Arbiter(Valid(new PTWReq), n))
   arb.io.in <> io.requestor.map(_.req)
-  arb.io.out.ready := state === s_ready
+  arb.io.out.ready := (state === s_ready) && !l2_refill_wire
 
   val resp_valid = Reg(next = Vec.fill(io.requestor.size)(Bool(false)))
-  val l2_refill_wire = Wire(Bool())
 
   val clock_en = state =/= s_ready || l2_refill_wire || arb.io.out.valid || io.dpath.sfence.valid || io.dpath.customCSRs.disableDCacheClockGate
   io.dpath.clock_enabled := usingVM && clock_en


### PR DESCRIPTION
**Related issue**: follow-on improvement to https://github.com/chipsalliance/rocket-chip/pull/2601

**Type of change**: performance enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Wait for L2TLB search to improve performance on back-to-back page table walks from L1DTLB then L1ITLB or vice versa.