### PR TITLE
readme: clarify example config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Then you can build as usual with `CONFIG=<MyConfigPackage>.MyConfig`.
 
 The objective of this section is to use GNU debugger to debug RISC-V programs running on the emulator in the same fashion as in [Spike](https://github.com/riscv/riscv-isa-sim#debugging-with-gdb).
 
-For that we need to add a Remote Bit-Bang client to the emulator. We can do so by extending our Config with JtagDTMSystem, which will add a DebugTransportModuleJTAG to the DUT and connect a SimJTAG module in the Test Harness. This will allow OpenOCD to interface with the emulator, and GDB can interface with OpenOCD. In the following example we added this Config extension to the Config.scala:
+For that we need to add a Remote Bit-Bang client to the emulator. We can do so by extending our Config with JtagDTMSystem, which will add a DebugTransportModuleJTAG to the DUT and connect a SimJTAG module in the Test Harness. This will allow OpenOCD to interface with the emulator, and GDB can interface with OpenOCD. In the following example we add this Config alteration to `src/main/scala/system/Configs.scala`:
 
     class DefaultConfigRBB extends Config(
     new WithJtagDTMSystem ++ new WithNBigCores(1) ++ new BaseConfig)


### PR DESCRIPTION
Clarify the location where example Config alterations should be added while working through one example in the Readme.

**Related issue**: https://github.com/chipsalliance/rocket-chip/issues/2600

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: no functional change (readme text only)

<!-- choose one -->
**Development Phase**: implementation
