### PR TITLE
Reduce common dependencies on the system implicit clock and reset

### DIFF
--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -74,7 +74,7 @@ object BootROM {
       rom.array() ++ subsystem.dtb.contents
     }
 
-    val bootrom = subsystem {
+    val bootrom = cbus {
       LazyModule(new TLROM(params.address, params.size, contents, true, cbus.beatBytes))
     }
 

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -106,7 +106,7 @@ class CLINT(params: CLINTParams, beatBytes: Int)(implicit p: Parameters) extends
 trait CanHavePeripheryCLINT { this: BaseSubsystem =>
   val clintOpt = p(CLINTKey).map { params =>
     val tlbus = locateTLBusWrapper(p(CLINTAttachKey).slaveWhere)
-    val clint = LazyModule(new CLINT(params, cbus.beatBytes))
+    val clint = tlbus { LazyModule(new CLINT(params, cbus.beatBytes)) }
     LogicalModuleTree.add(logicalTreeNode, clint.logicalTreeNode)
     clint.node := tlbus.coupleTo("clint") { TLFragmenter(tlbus) := _ }
     clint

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -349,7 +349,7 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val plicOpt  = p(PLICKey).map { params =>
     val tlbus = locateTLBusWrapper(p(PLICAttachKey).slaveWhere)
-    val plic = LazyModule(new TLPLIC(params, tlbus.beatBytes))
+    val plic = tlbus { LazyModule(new TLPLIC(params, tlbus.beatBytes)) }
     plic.node := tlbus.coupleTo("plic") { TLFragmenter(tlbus) := _ }
     plic.intnode :=* ibus.toPLIC
     plic

--- a/src/main/scala/subsystem/RTC.scala
+++ b/src/main/scala/subsystem/RTC.scala
@@ -3,24 +3,25 @@
 package freechips.rocketchip.subsystem
 
 import Chisel._
-import freechips.rocketchip.diplomacy.{LazyModuleImp, DTSTimebase}
-import freechips.rocketchip.devices.tilelink.CanHavePeripheryCLINT
+import freechips.rocketchip.diplomacy.{LazyModule, DTSTimebase, InModuleBody}
+import freechips.rocketchip.devices.tilelink.{CanHavePeripheryCLINT, CLINTAttachKey}
 
-trait HasRTCModuleImp extends LazyModuleImp {
-  val outer: BaseSubsystem with CanHavePeripheryCLINT
-  private val pbusFreq = outer.p(PeripheryBusKey).dtsFrequency.get
-  private val rtcFreq = outer.p(DTSTimebase)
+trait HasRTC extends LazyModule { this: BaseSubsystem with CanHavePeripheryCLINT =>
+  private val pbusFreq = p(PeripheryBusKey).dtsFrequency.get
+  private val rtcFreq = p(DTSTimebase)
   private val internalPeriod: BigInt = pbusFreq / rtcFreq
+  private val tlbus = locateTLBusWrapper(p(CLINTAttachKey).slaveWhere)
 
   // check whether pbusFreq >= rtcFreq
   require(internalPeriod > 0)
-  // check wehther the integer division is within 5% of the real division
+  // check whether the integer division is within 5% of the real division
   require((pbusFreq - rtcFreq * internalPeriod) * 100 / pbusFreq <= 5)
 
-  // Use the static period to toggle the RTC
-  val (_, int_rtc_tick) = Counter(true.B, internalPeriod.toInt)
-
-  outer.clintOpt.foreach { clint =>
-    clint.module.io.rtcTick := int_rtc_tick
+  clintOpt.foreach { clint =>
+    tlbus { InModuleBody {
+      // Use the static period to toggle the RTC
+      val (_, int_rtc_tick) = Counter(true.B, internalPeriod.toInt)
+      clint.module.io.rtcTick := int_rtc_tick
+    } }
   }
 }

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -15,6 +15,7 @@ class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
     with CanHaveMasterAXI4MemPort
     with CanHaveMasterAXI4MMIOPort
     with CanHaveSlaveAXI4Port
+    with HasRTC
 {
   // optionally add ROM devices
   // Note that setting BootROMLocated will override the reset_vector for all tiles
@@ -25,6 +26,5 @@ class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
 }
 
 class ExampleRocketSystemModuleImp[+L <: ExampleRocketSystem](_outer: L) extends RocketSubsystemModuleImp(_outer)
-    with HasRTCModuleImp
     with HasExtInterruptsModuleImp
     with DontTouch


### PR DESCRIPTION
This PR changes frequently used peripherals to acquire their clocks diplomatically.

The CLINT, Plic, and BootROM, are now instantiated as children of their attached buses. An alternative implementation could be to wrap these devices in their own `ClockDomains`, instead. 

The interrupt crossings into the tiles are now clocked by the clocks of their source and sink domains, instead of the implicit system clock.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
