### PR TITLE
Remove NA4 cover point for pmpGRanularity > 4

### DIFF
--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -165,8 +165,8 @@ class PMPChecker(lgMaxSize: Int)(implicit val p: Parameters) extends Module
     val ignore = default && !pmp.cfg.l
     val aligned = pmp.aligned(io.addr, io.size, lgMaxSize, prevPMP)
 
-    for ((name, idx) <- Seq("no", "TOR", "NA4", "NAPOT").zipWithIndex)
-      cover(pmp.cfg.a === idx, s"The cfg access is set to ${name} access ", "Cover PMP access mode setting")
+    for ((name, idx) <- Seq("no", "TOR", if (pmpGranularity <= 4) "NA4" else "", "NAPOT").zipWithIndex; if name.nonEmpty)
+        cover(pmp.cfg.a === idx, s"The cfg access is set to ${name} access ", "Cover PMP access mode setting")
 
     cover(pmp.cfg.l === 0x1, s"The cfg lock is set to high ", "Cover PMP lock mode setting")
    
@@ -174,9 +174,9 @@ class PMPChecker(lgMaxSize: Int)(implicit val p: Parameters) extends Module
     for ((name, idx) <- Seq("no", "RO", "", "RW", "X", "RX", "", "RWX").zipWithIndex; if name.nonEmpty)
       cover((Cat(pmp.cfg.x, pmp.cfg.w, pmp.cfg.r) === idx), s"The permission is set to ${name} access ", "Cover PMP access permission setting") 
 
-    for ((name, idx) <- Seq("", "TOR", "NA4", "NAPOT").zipWithIndex; if name.nonEmpty) {
-      cover(!ignore && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode ", "Cover PMP access")
-      cover(pmp.cfg.l && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode with lock bit high", "Cover PMP access with lock bit")
+    for ((name, idx) <- Seq("", "TOR", if (pmpGranularity <= 4) "NA4" else "", "NAPOT").zipWithIndex; if name.nonEmpty) {
+        cover(!ignore && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode ", "Cover PMP access")
+        cover(pmp.cfg.l && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode with lock bit high", "Cover PMP access with lock bit")
     }
 
     val cur = WireInit(pmp)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: PMP NA4 coverpoints generated in configs with pmpGranularity > 4

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Configs with pmpGranularity > 4 will not be able to create a PMP region Naturally Aligned to 4 (NA4). However NA4 coverpoints are generated in PMP and D$ TLB regardless. This means ~(2*nPMP*3) redundant coverpoints generated in configs with pmpGranularity > 4, where nPMP is the number of PMP regions in config.

<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
