### PR TITLE
Add maxTransactionsInFlight to IDMapEntry and OMIdMapEntry

### DIFF
--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -216,7 +216,7 @@ class AXI4IdMap(axi4: AXI4MasterPortParameters) extends IdMap[AXI4IdMapEntry] {
   }
 }
 
-case class AXI4IdMapEntry(axi4Id: IdRange, name: String, maxTransactionsInFlight: Option[Int]) extends IdMapEntry {
+case class AXI4IdMapEntry(axi4Id: IdRange, name: String, maxTransactionsInFlight: Option[Int] = None) extends IdMapEntry {
   val from = axi4Id
   val to = axi4Id
   val isCache = false

--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -210,11 +210,13 @@ class AXI4IdMap(axi4: AXI4MasterPortParameters) extends IdMap[AXI4IdMapEntry] {
   private val sorted = axi4.masters.sortBy(_.id)
 
   val mapping: Seq[AXI4IdMapEntry] = sorted.map { case c =>
-    AXI4IdMapEntry(c.id, c.name)
+    // to conservatively state max number of transactions, assume every id has up to c.maxFlight and reuses ids between AW and AR channels
+    val maxTransactionsInFlight = c.maxFlight.map(_ * c.id.size * 2)
+    AXI4IdMapEntry(c.id, c.name, maxTransactionsInFlight)
   }
 }
 
-case class AXI4IdMapEntry(axi4Id: IdRange, name: String) extends IdMapEntry {
+case class AXI4IdMapEntry(axi4Id: IdRange, name: String, maxTransactionsInFlight: Option[Int]) extends IdMapEntry {
   val from = axi4Id
   val to = axi4Id
   val isCache = false

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -16,6 +16,7 @@ case class AXI4ToTLIdMapEntry(tlId: IdRange, axi4Id: IdRange, name: String)
   val to = tlId
   val isCache = false
   val requestFifo = false
+  val maxTransactionsInFlight = Some(tlId.size)
 }
 
 case class AXI4ToTLNode(wcorrupt: Boolean)(implicit valName: ValName) extends MixedAdapterNode(AXI4Imp, TLImp)(

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -336,6 +336,7 @@ trait IdMapEntry {
   def to: IdRange
   def isCache: Boolean
   def requestFifo: Boolean
+  def maxTransactionsInFlight: Option[Int]
   def pretty(fmt: String) =
     if (from ne to) { // if the subclass uses the same reference for both from and to, assume its format string has an arity of 5
       fmt.format(to.start, to.end, from.start, from.end, s""""$name"""", if (isCache) " [CACHE]" else "", if (requestFifo) " [FIFO]" else "")

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -94,10 +94,11 @@ class OMIDMapEntry(val name: String,
                    val to: OMIDRange,
                    val isCache: Boolean,
                    val requestFifo: Boolean,
+                   val maxTransactionsInFlight: Option[Int],
                    val _types: Seq[String] = Seq("OMIDMapEntry", "OMCompoundType"))
 object OMIDMapEntry {
   def apply[T <: IdMapEntry](i: T): OMIDMapEntry = {
-    new OMIDMapEntry(i.name, OMIDRange(i.from), OMIDRange(i.to), i.isCache, i.requestFifo)
+    new OMIDMapEntry(i.name, OMIDRange(i.from), OMIDRange(i.to), i.isCache, i.requestFifo, i.maxTransactionsInFlight)
   }
 }
 

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -1565,4 +1565,5 @@ case class TLSourceIdMapEntry(tlId: IdRange, name: String, isCache: Boolean, req
 {
   val from = tlId
   val to = tlId
+  val maxTransactionsInFlight = Some(tlId.size)
 }

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -42,6 +42,7 @@ case class TLToAXI4IdMapEntry(axi4Id: IdRange, tlId: IdRange, name: String, isCa
 {
   val from = tlId
   val to = axi4Id
+  val maxTransactionsInFlight = Some(tlId.size)
 }
 
 case class TLToAXI4Node(stripBits: Int = 0, wcorrupt: Boolean = true)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AXI4Imp)(


### PR DESCRIPTION
This PR adds a `maxTransactionsInFlight` field to `IDMapEntry` and `OMIdMapEntry`. This field offers an upper-bound on the number of transactions possibly in flight from a given master associated with a range of ids. The calculation is protocol specific; while it is exactly the number of source ids for TileLink, for AXI4 incomplete information forces us to make a conservative overestimate: assume that every single ID could possibly generate the maximum number of transactions (which may or may not be true), and that each source could generate simultaneous read and write transactions using the same ID (which may or may not be true).

Related issue:

Type of change: feature request

Impact: API addition (no impact on existing code)

Development Phase: implementation

Release Notes