### PR TITLE
Make SimAXIMem start at expected memory base instead of zero

### DIFF
--- a/src/main/scala/system/SimAXIMem.scala
+++ b/src/main/scala/system/SimAXIMem.scala
@@ -5,14 +5,14 @@ package freechips.rocketchip.system // TODO this should really be in a testharne
 import chisel3._
 import freechips.rocketchip.amba._
 import freechips.rocketchip.amba.axi4._
-import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.subsystem.{CanHaveMasterAXI4MMIOPort, CanHaveMasterAXI4MemPort, ExtMem}
+import freechips.rocketchip.subsystem.{CanHaveMasterAXI4MMIOPort, CanHaveMasterAXI4MemPort, ExtBus, ExtMem}
 
 /** Memory with AXI port for use in elaboratable test harnesses. */
-class SimAXIMem(edge: AXI4EdgeParameters, size: BigInt)(implicit p: Parameters) extends SimpleLazyModule {
+class SimAXIMem(edge: AXI4EdgeParameters, size: BigInt, base: BigInt = 0)(implicit p: Parameters) extends SimpleLazyModule {
   val node = AXI4MasterNode(List(edge.master))
-  val srams = AddressSet.misaligned(0, size).map { aSet =>
+  val srams = AddressSet.misaligned(base, size).map { aSet =>
     LazyModule(new AXI4RAM(
       address = aSet,
       beatBytes = edge.bundle.dataBits/8,
@@ -28,7 +28,7 @@ object SimAXIMem {
   def connectMMIO(dut: CanHaveMasterAXI4MMIOPort)(implicit p: Parameters): Seq[SimAXIMem] = {
     dut.mmio_axi4.zip(dut.mmioAXI4Node.in).map { case (io, (_, edge)) =>
       // test harness size capped to 4KB (ignoring p(ExtMem).get.master.size)
-      val mmio_mem = LazyModule(new SimAXIMem(edge, size = 4096))
+      val mmio_mem = LazyModule(new SimAXIMem(edge, base = p(ExtBus).get.base, size = 4096))
       Module(mmio_mem.module).suggestName("mmio_mem")
       mmio_mem.io_axi4.head <> io
       mmio_mem
@@ -37,7 +37,7 @@ object SimAXIMem {
 
   def connectMem(dut: CanHaveMasterAXI4MemPort)(implicit p: Parameters): Seq[SimAXIMem] = {
     dut.mem_axi4.zip(dut.memAXI4Node.in).map { case (io, (_, edge)) =>
-      val mem = LazyModule(new SimAXIMem(edge, size = p(ExtMem).get.master.size))
+      val mem = LazyModule(new SimAXIMem(edge, base = p(ExtMem).get.master.base, size = p(ExtMem).get.master.size))
       Module(mem.module).suggestName("mem")
       mem.io_axi4.head <> io
       mem


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

`SimAXIMem` currently assumes physical memory always starts at zero; this is not the case as it is possible to modify `p(ExtMem).get.master.base` for scenarios where the memory does not actually start there (e.g. when instantiating on Zynq FPGA and using the upper half of DRAM).  This change adds support for this situation by reading the base of `ExtMem` and `ExtBus` from the parameters for instantiation.