### PR TITLE
Update BasicBusBlocker (chisel3, scala-doc, factory)

### DIFF
--- a/src/main/scala/devices/tilelink/ClockBlocker.scala
+++ b/src/main/scala/devices/tilelink/ClockBlocker.scala
@@ -16,7 +16,7 @@ import freechips.rocketchip.util._
   */
 
 class TLClockBlocker(params: BasicBusBlockerParams)(implicit p: Parameters)
-    extends TLBusBypassBase(params.deviceBeatBytes, params.deadlock)
+    extends TLBusBypassBase(params.blockedBeatBytes, params.deadlock)
 {
   val device = new SimpleDevice("clock-blocker", Seq("sifive,clock-blocker0"))
 


### PR DESCRIPTION
- convert to chisel3
- upstream factory helper from `sifive-blocks` (users might have to change import from `sifive.blocks.util` to `freechips.rocketchip.devices.tilelink`)
- improve detail of scaladoc comments

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:feature request

<!-- choose one -->
**Impact**:  API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
