### PR TITLE
Add built Verilator to $PATH in sbt test regression

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -338,4 +338,4 @@ emulator-jtag-dtm-regression: emulator-jtag-dtm-tests-32 emulator-jtag-dtm-tests
 # Target to run Scalatest regressionsk 'sbt test'
 .PHONY: scalatest
 scalatest: stamps/other-submodules.stamp $(FIRRTL_JAR)
-	(cd $(abspath $(TOP)) && $(SBT) test)
+	(cd $(abspath $(TOP)) && PATH=$(PATH):$(abspath $(TOP))/emulator/verilator/install/bin $(SBT) test)


### PR DESCRIPTION
Fixes a bug where running the `sbt test` regression can fail if a user adds tests that try to call Verilator (e.g., some Chisel testing library). This PR sets the `$PATH` to include the built Verilator before running `sbt test`.

_Note that no existing, upstream test actually uses Verilator._

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation
