### PR TITLE
User fields on C channel

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -734,6 +734,16 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   val newCoh = Wire(init = probeNewCoh)
   releaseWay := s2_probe_way
 
+  tl_out_c.bits.user.lift(AMBAProt).foreach { x =>
+    x.fetch       := false.B
+    x.secure      := true.B
+    x.privileged  := true.B
+    x.bufferable  := true.B
+    x.modifiable  := true.B
+    x.readalloc   := true.B
+    x.writealloc  := true.B
+  }
+
   if (!usingDataScratchpad) {
     when (s2_victimize) {
       assert(s2_valid_flush_line || s2_flush_valid || io.cpu.s2_nack)

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -212,6 +212,8 @@ final class TLBundleC(params: TLBundleParameters)
   val size    = UInt(width = params.sizeBits)
   val source  = UInt(width = params.sourceBits) // from
   val address = UInt(width = params.addressBits) // to
+  val user    = BundleMap(params.requestFields)
+  val echo    = BundleMap(params.echoFields)
   // variable fields during multibeat:
   val data    = UInt(width = params.dataBits)
   val corrupt = Bool() // only applies to *Data messages

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import freechips.rocketchip.amba.AMBAProt
 import scala.math.{min,max}
 import TLMessages._
 
@@ -92,15 +91,7 @@ class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Paramet
           lgSize     = in.c.bits.size,
           data       = in.c.bits.data,
           corrupt    = in.c.bits.corrupt)._2
-        c_a.bits.user.lift(AMBAProt).foreach { x =>
-          x.fetch       := false.B
-          x.secure      := true.B
-          x.privileged  := true.B
-          x.bufferable  := true.B
-          x.modifiable  := true.B
-          x.readalloc   := true.B
-          x.writealloc  := true.B
-        }
+        c_a.bits.user :<= in.c.bits.user
 
         // Releases without Data succeed instantly
         val c_d = Wire(in.d)


### PR DESCRIPTION
**Type of change**: other enhancement
**Impact**:  API modification
**Development Phase**:  implementation

**Release Notes**
C channel now has the same user bits A channel does.
This moves the responsibility for filling in AMBAProt on C-channel from the CacheCork to the caches.
However, it frees those caches to supply additional fields in their requests, which was previously impossible.
Time will tell if we need additional configuration flexibility between A- and C-channel fields.