### PR TITLE
wake: avoid hardcoded directory path for 'hardfloat' repository

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -2,9 +2,11 @@
 global def rocketChipRoot = here
 publish ivyDepLocations = rocketChipRoot, Nil
 
+def hardfloatRoot = findGitRepositoryWithFallback "hardfloat"
+
 global def hardfloatScalaModule =
   makeScalaModuleFromJSON here "hardfloat"
-  | setScalaModuleRootDir "hardfloat"
+  | setScalaModuleRootDir hardfloatRoot
   | setScalaModuleDeps (chisel3ScalaModule, Nil)
   | setScalaModuleScalacOptions ("-Xsource:2.11", Nil)
 

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -30,7 +30,7 @@
         "source": "git@github.com:chipsalliance/api-config-chipsalliance.git"
     },
     {
-        "commit": "e5d463cd9d131033396a9d8921440abb55f114cd",
+        "commit": "1c3539138f71d38f007e19870bcf5f69d9713307",
         "name": "api-scala-sifive",
         "source": "git@github.com:sifive/api-scala-sifive.git"
     }


### PR DESCRIPTION
This adds some indirection so that the hardfloat repository doesn't have to be at a fixed location

cc @jackkoenig @terpstra 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
