### PR TITLE
Relax master parameter of RocketCrossingParams

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -234,7 +234,10 @@ class WithBufferlessBroadcastHub extends Config((site, here, up) => {
  */
 class WithIncoherentTiles extends Config((site, here, up) => {
   case RocketCrossingKey => up(RocketCrossingKey, site) map { r =>
-    r.copy(master = r.master.copy(cork = Some(true)))
+    r.copy(master = r.master match {
+      case x: TileMasterPortParams => x.copy(cork = Some(true))
+      case _ => throw new Exception("Unrecognized type for RocketCrossingParams.master")
+    })
   }
   case BankedL2Key => up(BankedL2Key, site).copy(
     coherenceManager = CoherenceManagerWrapper.incoherentManager

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -15,7 +15,7 @@ import freechips.rocketchip.tile._
 
 case class RocketCrossingParams(
   crossingType: ClockCrossingType = SynchronousCrossing(),
-  master: TileMasterPortParams = TileMasterPortParams(),
+  master: TilePortParamsLike = TileMasterPortParams(),
   slave: TileSlavePortParams = TileSlavePortParams(),
   mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS,
   stretchResetCycles: Option[Int] = None


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This change is meant to allow for using more generic or even specialized implementations of the master parameter of RocketCrossingKey.

@hcook I'm a little bit more concerned about my change to subsystem/Configs.scala. Right now just TileMasterPortParams is used. If another subclass gets used then WithIncoherentTiles might not do the right thing.  I wasn't sure if this was the best approach.