### PR TITLE
Remove Verilog delay from DPI outputs and use falling edge instead

### DIFF
--- a/src/main/resources/vsrc/SimDTM.v
+++ b/src/main/resources/vsrc/SimDTM.v
@@ -35,10 +35,10 @@ module SimDTM(
 
   bit r_reset;
 
-  wire #0.1 __debug_req_ready = debug_req_ready;
-  wire #0.1 __debug_resp_valid = debug_resp_valid;
-  wire [31:0] #0.1 __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
-  wire [31:0] #0.1 __debug_resp_bits_data = debug_resp_bits_data;
+  wire __debug_req_ready = debug_req_ready;
+  wire __debug_resp_valid = debug_resp_valid;
+  wire [31:0] __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
+  wire [31:0] __debug_resp_bits_data = debug_resp_bits_data;
 
   bit __debug_req_valid;
   int __debug_req_bits_addr;
@@ -47,7 +47,6 @@ module SimDTM(
   bit __debug_resp_ready;
   int __exit;
 
-`ifdef VERILATOR
   reg        debug_req_valid_reg;
   reg [ 6:0] debug_req_bits_addr_reg;
   reg [ 1:0] debug_req_bits_op_reg;
@@ -72,17 +71,6 @@ module SimDTM(
   assign exit = exit_reg;
 
   always @(negedge clk)
-`else
-  assign #0.1 debug_req_valid = __debug_req_valid;
-  assign #0.1 debug_req_bits_addr = __debug_req_bits_addr[6:0];
-  assign #0.1 debug_req_bits_op = __debug_req_bits_op[1:0];
-  assign #0.1 debug_req_bits_data = __debug_req_bits_data[31:0];
-  assign #0.1 debug_resp_ready = __debug_resp_ready;
-  assign #0.1 exit = __exit;
-
-  always @(posedge clk)
-`endif
-
   begin
     r_reset <= reset;
     if (reset || r_reset)

--- a/src/main/resources/vsrc/SimDTM.v
+++ b/src/main/resources/vsrc/SimDTM.v
@@ -35,18 +35,10 @@ module SimDTM(
 
   bit r_reset;
 
-  reg __debug_req_ready;
-  reg __debug_resp_valid;
-  reg [31:0] __debug_resp_bits_resp;
-  reg [31:0]  __debug_resp_bits_data;
-
-//  // Delay sending inputs to DPI to avoid race condition failure in Verilator
-//  always @(negedge clk) begin
-  assign  __debug_req_ready = debug_req_ready;
-  assign  __debug_resp_valid = debug_resp_valid;
-  assign  __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
-  assign  __debug_resp_bits_data = debug_resp_bits_data;
-//  end
+  wire __debug_req_ready = debug_req_ready;
+  wire __debug_resp_valid = debug_resp_valid;
+  wire [31:0] __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
+  wire [31:0] __debug_resp_bits_data = debug_resp_bits_data;
 
   bit __debug_req_valid;
   int __debug_req_bits_addr;

--- a/src/main/resources/vsrc/SimDTM.v
+++ b/src/main/resources/vsrc/SimDTM.v
@@ -19,26 +19,26 @@ module SimDTM(
   input clk,
   input reset,
 
-  output reg        debug_req_valid,
-  input             debug_req_ready,
-  output reg [ 6:0] debug_req_bits_addr,
-  output reg [ 1:0] debug_req_bits_op,
-  output reg [31:0] debug_req_bits_data,
+  output        debug_req_valid,
+  input         debug_req_ready,
+  output [ 6:0] debug_req_bits_addr,
+  output [ 1:0] debug_req_bits_op,
+  output [31:0] debug_req_bits_data,
 
-  input             debug_resp_valid,
-  output reg        debug_resp_ready,
-  input      [ 1:0] debug_resp_bits_resp,
-  input      [31:0] debug_resp_bits_data,
+  input         debug_resp_valid,
+  output        debug_resp_ready,
+  input  [ 1:0] debug_resp_bits_resp,
+  input  [31:0] debug_resp_bits_data,
 
-  output reg [31:0] exit
+  output [31:0] exit
 );
 
   bit r_reset;
 
-  wire __debug_req_ready = debug_req_ready;
-  wire __debug_resp_valid = debug_resp_valid;
-  wire [31:0] __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
-  wire [31:0] __debug_resp_bits_data = debug_resp_bits_data;
+  wire #0.1 __debug_req_ready = debug_req_ready;
+  wire #0.1 __debug_resp_valid = debug_resp_valid;
+  wire [31:0] #0.1 __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
+  wire [31:0] #0.1 __debug_resp_bits_data = debug_resp_bits_data;
 
   bit __debug_req_valid;
   int __debug_req_bits_addr;
@@ -47,16 +47,42 @@ module SimDTM(
   bit __debug_resp_ready;
   int __exit;
 
-  always @(negedge clk) begin
-    debug_req_valid <= __debug_req_valid;
-    debug_req_bits_addr <= __debug_req_bits_addr[6:0];
-    debug_req_bits_op <= __debug_req_bits_op[1:0];
-    debug_req_bits_data <= __debug_req_bits_data[31:0];
-    debug_resp_ready <= __debug_resp_ready;
-    exit <= __exit;
+`ifdef VERILATOR
+  reg        debug_req_valid_reg;
+  reg [ 6:0] debug_req_bits_addr_reg;
+  reg [ 1:0] debug_req_bits_op_reg;
+  reg [31:0] debug_req_bits_data_reg;
+  reg        debug_resp_ready_reg;
+  reg [31:0] exit_reg;
+
+  always @(posedge clk) begin
+    debug_req_valid_reg <= __debug_req_valid;
+    debug_req_bits_addr_reg <= __debug_req_bits_addr[6:0];
+    debug_req_bits_op_reg <= __debug_req_bits_op[1:0];
+    debug_req_bits_data_reg <= __debug_req_bits_data[31:0];
+    debug_resp_ready_reg <= __debug_resp_ready;
+    exit_reg <= __exit;
   end
 
+  assign debug_req_valid = debug_req_valid_reg;
+  assign debug_req_bits_addr = debug_req_bits_addr_reg;
+  assign debug_req_bits_op = debug_req_bits_op_reg;
+  assign debug_req_bits_data = debug_req_bits_data_reg;
+  assign debug_resp_ready = debug_resp_ready_reg;
+  assign exit = exit_reg;
+
+  always @(negedge clk)
+`else
+  assign #0.1 debug_req_valid = __debug_req_valid;
+  assign #0.1 debug_req_bits_addr = __debug_req_bits_addr[6:0];
+  assign #0.1 debug_req_bits_op = __debug_req_bits_op[1:0];
+  assign #0.1 debug_req_bits_data = __debug_req_bits_data[31:0];
+  assign #0.1 debug_resp_ready = __debug_resp_ready;
+  assign #0.1 exit = __exit;
+
   always @(posedge clk)
+`endif
+
   begin
     r_reset <= reset;
     if (reset || r_reset)

--- a/src/main/resources/vsrc/SimDTM.v
+++ b/src/main/resources/vsrc/SimDTM.v
@@ -19,26 +19,34 @@ module SimDTM(
   input clk,
   input reset,
 
-  output        debug_req_valid,
-  input         debug_req_ready,
-  output [ 6:0] debug_req_bits_addr,
-  output [ 1:0] debug_req_bits_op,
-  output [31:0] debug_req_bits_data,
+  output reg        debug_req_valid,
+  input             debug_req_ready,
+  output reg [ 6:0] debug_req_bits_addr,
+  output reg [ 1:0] debug_req_bits_op,
+  output reg [31:0] debug_req_bits_data,
 
-  input         debug_resp_valid,
-  output        debug_resp_ready,
-  input  [ 1:0] debug_resp_bits_resp,
-  input  [31:0] debug_resp_bits_data,
+  input             debug_resp_valid,
+  output reg        debug_resp_ready,
+  input      [ 1:0] debug_resp_bits_resp,
+  input      [31:0] debug_resp_bits_data,
 
-  output [31:0] exit
+  output reg [31:0] exit
 );
 
   bit r_reset;
 
-  wire #0.1 __debug_req_ready = debug_req_ready;
-  wire #0.1 __debug_resp_valid = debug_resp_valid;
-  wire [31:0] #0.1 __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
-  wire [31:0] #0.1 __debug_resp_bits_data = debug_resp_bits_data;
+  reg __debug_req_ready;
+  reg __debug_resp_valid;
+  reg [31:0] __debug_resp_bits_resp;
+  reg [31:0]  __debug_resp_bits_data;
+
+//  // Delay sending inputs to DPI to avoid race condition failure in Verilator
+//  always @(negedge clk) begin
+  assign  __debug_req_ready = debug_req_ready;
+  assign  __debug_resp_valid = debug_resp_valid;
+  assign  __debug_resp_bits_resp = {30'b0, debug_resp_bits_resp};
+  assign  __debug_resp_bits_data = debug_resp_bits_data;
+//  end
 
   bit __debug_req_valid;
   int __debug_req_bits_addr;
@@ -47,12 +55,14 @@ module SimDTM(
   bit __debug_resp_ready;
   int __exit;
 
-  assign #0.1 debug_req_valid = __debug_req_valid;
-  assign #0.1 debug_req_bits_addr = __debug_req_bits_addr[6:0];
-  assign #0.1 debug_req_bits_op = __debug_req_bits_op[1:0];
-  assign #0.1 debug_req_bits_data = __debug_req_bits_data[31:0];
-  assign #0.1 debug_resp_ready = __debug_resp_ready;
-  assign #0.1 exit = __exit;
+  always @(negedge clk) begin
+    debug_req_valid <= __debug_req_valid;
+    debug_req_bits_addr <= __debug_req_bits_addr[6:0];
+    debug_req_bits_op <= __debug_req_bits_op[1:0];
+    debug_req_bits_data <= __debug_req_bits_data[31:0];
+    debug_resp_ready <= __debug_resp_ready;
+    exit <= __exit;
+  end
 
   always @(posedge clk)
   begin

--- a/src/main/resources/vsrc/SimJTAG.v
+++ b/src/main/resources/vsrc/SimJTAG.v
@@ -20,15 +20,15 @@ module SimJTAG #(
                    input         enable,
                    input         init_done,
 
-                   output reg    jtag_TCK,
-                   output reg    jtag_TMS,
-                   output reg    jtag_TDI,
-                   output reg    jtag_TRSTn,
+                   output        jtag_TCK,
+                   output        jtag_TMS,
+                   output        jtag_TDI,
+                   output        jtag_TRSTn,
  
                    input         jtag_TDO_data,
                    input         jtag_TDO_driven,
                           
-                   output reg [31:0] exit
+                   output [31:0] exit
                    );
 
    reg [31:0]                    tickCounterReg;
@@ -51,13 +51,12 @@ module SimJTAG #(
 
    reg          init_done_sticky;
    
-   always @(negedge clock) begin
-     jtag_TCK   <= __jtag_TCK;
-     jtag_TMS   <= __jtag_TMS;
-     jtag_TDI   <= __jtag_TDI;
-     jtag_TRSTn <= __jtag_TRSTn;
-     exit <= __exit;
-   end
+   assign #0.1 jtag_TCK   = __jtag_TCK;
+   assign #0.1 jtag_TMS   = __jtag_TMS;
+   assign #0.1 jtag_TDI   = __jtag_TDI;
+   assign #0.1 jtag_TRSTn = __jtag_TRSTn;
+   
+   assign #0.1 exit = __exit;
 
    always @(posedge clock) begin
       r_reset <= reset;

--- a/src/main/resources/vsrc/SimJTAG.v
+++ b/src/main/resources/vsrc/SimJTAG.v
@@ -20,15 +20,15 @@ module SimJTAG #(
                    input         enable,
                    input         init_done,
 
-                   output        jtag_TCK,
-                   output        jtag_TMS,
-                   output        jtag_TDI,
-                   output        jtag_TRSTn,
+                   output reg    jtag_TCK,
+                   output reg    jtag_TMS,
+                   output reg    jtag_TDI,
+                   output reg    jtag_TRSTn,
  
                    input         jtag_TDO_data,
                    input         jtag_TDO_driven,
                           
-                   output [31:0] exit
+                   output reg [31:0] exit
                    );
 
    reg [31:0]                    tickCounterReg;
@@ -51,12 +51,13 @@ module SimJTAG #(
 
    reg          init_done_sticky;
    
-   assign #0.1 jtag_TCK   = __jtag_TCK;
-   assign #0.1 jtag_TMS   = __jtag_TMS;
-   assign #0.1 jtag_TDI   = __jtag_TDI;
-   assign #0.1 jtag_TRSTn = __jtag_TRSTn;
-   
-   assign #0.1 exit = __exit;
+   always @(negedge clock) begin
+     jtag_TCK   <= __jtag_TCK;
+     jtag_TMS   <= __jtag_TMS;
+     jtag_TDI   <= __jtag_TDI;
+     jtag_TRSTn <= __jtag_TRSTn;
+     exit <= __exit;
+   end
 
    always @(posedge clock) begin
       r_reset <= reset;


### PR DESCRIPTION
Verilator ignores these delays (after warning the user), so they can
result in race conditions.

This fixes an issue visible on https://github.com/chipsalliance/rocket-chip/pull/2617 where some assertions fire erroneously due to some optimizations Verilator makes that are incorrect due to the race conditions.

Thank you to @ernie-sifive for doing this work 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Remove Verilog delay statements from SimJTAG.v and SimDTM.v
