### PR TITLE
axi4: remove <>s from metadata

### DIFF
--- a/src/main/scala/amba/axi4/IdIndexer.scala
+++ b/src/main/scala/amba/axi4/IdIndexer.scala
@@ -37,7 +37,7 @@ class AXI4IdIndexer(idBits: Int)(implicit p: Parameters) extends LazyModule
             maxFlight = old.maxFlight.flatMap { o => m.maxFlight.map { n => o+n } })
         }
       }
-      names.foreach { n => if (n.isEmpty) n += "<unused>" }
+      names.foreach { n => if (n.isEmpty) n += "(unused)" }
       val bits = log2Ceil(mp.endId) - idBits
       val field = if (bits > 0) Seq(AXI4ExtraIdField(bits)) else Nil
       mp.copy(


### PR DESCRIPTION
Any string that could potentially show up as metadata in the graphml cannot have text bracketed by `<...>` without that text being interpreted as a XML tag. Such a string was getting inserted in some cases for designs with AXIIdIndexers, a situation which was introduced by by me in https://github.com/chipsalliance/rocket-chip/pull/2483/ (though I don't think the data in question was being ingested into the graphml at that point?)

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**: implementation