### PR TITLE
Define ResetCrossingType and use with BlockDuringReset in TilePRCIDomain

### DIFF
--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -130,7 +130,7 @@ trait HasAXI4ControlRegMap { this: RegisterRouter =>
     executable = executable)
 
   // Externally, this helper should be used to connect the register control port to a bus
-  val controlXing: AXI4InwardCrossingHelper = this.crossIn(controlNode)
+  val controlXing: AXI4InwardClockCrossingHelper = this.crossIn(controlNode)
 
   // Internally, this function should be used to populate the control port with registers
   protected def regmap(mapping: RegField.Map*): Unit = { controlNode.regmap(mapping:_*) }

--- a/src/main/scala/amba/axi4/package.scala
+++ b/src/main/scala/amba/axi4/package.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba
 
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomacy.{HasClockDomainCrossing, _}
+import freechips.rocketchip.prci.{HasResetDomainCrossing}
 
 package object axi4
 {
@@ -11,8 +12,15 @@ package object axi4
   type AXI4InwardNode = InwardNodeHandle[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
 
   implicit class AXI4ClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
-    def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardCrossingHelper(valName.name, x, n)
-    def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardCrossingHelper(valName.name, x, n)
+    def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardClockCrossingHelper(valName.name, x, n)
+    def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardClockCrossingHelper(valName.name, x, n)
+    def cross(n: AXI4InwardNode) (implicit valName: ValName) = crossIn(n)
+    def cross(n: AXI4OutwardNode)(implicit valName: ValName) = crossOut(n)
+  }
+
+  implicit class AXI4ResetDomainCrossing(private val x: HasResetDomainCrossing) extends AnyVal {
+    def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardResetCrossingHelper(valName.name, x, n)
+    def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardResetCrossingHelper(valName.name, x, n)
     def cross(n: AXI4InwardNode) (implicit valName: ValName) = crossIn(n)
     def cross(n: AXI4OutwardNode)(implicit valName: ValName) = crossOut(n)
   }

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -109,6 +109,14 @@ trait CanHavePeripheryCLINT { this: BaseSubsystem =>
     val clint = LazyModule(new CLINT(params, cbus.beatBytes))
     LogicalModuleTree.add(logicalTreeNode, clint.logicalTreeNode)
     clint.node := tlbus.coupleTo("clint") { TLFragmenter(tlbus) := _ }
+
+    // Override the implicit clock and reset -- could instead include a clockNode in the clint, and make it a RawModuleImp?
+    InModuleBody {
+      clint.module.clock := tlbus.module.clock
+      clint.module.reset := tlbus.module.reset
+    }
+
     clint
+
   }
 }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -13,6 +13,7 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
+import freechips.rocketchip.prci.{ClockSinkDomain}
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.diplomaticobjectmodel.model._
 
@@ -349,9 +350,13 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val plicOpt  = p(PLICKey).map { params =>
     val tlbus = locateTLBusWrapper(p(PLICAttachKey).slaveWhere)
-    val plic = LazyModule(new TLPLIC(params, tlbus.beatBytes))
+    val plicDomainWrapper = LazyModule(new ClockSinkDomain(take = None))
+    plicDomainWrapper.clockNode := tlbus.fixedClockNode
+
+    val plic = plicDomainWrapper { LazyModule(new TLPLIC(params, tlbus.beatBytes)) }
     plic.node := tlbus.coupleTo("plic") { TLFragmenter(tlbus) := _ }
     plic.intnode :=* ibus.toPLIC
+
     plic
   }
 }

--- a/src/main/scala/diplomacy/ClockDomain.scala
+++ b/src/main/scala/diplomacy/ClockDomain.scala
@@ -1,5 +1,39 @@
 // See LICENSE.SiFive for license details.
 
 package freechips.rocketchip.diplomacy
+import freechips.rocketchip.util.{RationalDirection, FastToSlow, AsyncQueueParams, CreditedDelay}
 
-trait HasClockDomainCrossing extends LazyScope { this: LazyModule => }
+// TODO this should all be moved to package freechips.rocketchip.prci now that it exists
+
+trait CrossingType
+
+trait HasDomainCrossing extends LazyScope { this: LazyModule =>
+  type DomainCrossingType <: CrossingType
+}
+
+trait HasClockDomainCrossing extends HasDomainCrossing { this: LazyModule =>
+  type DomainCrossingType = ClockCrossingType
+}
+
+/** Enumerates the types of clock crossings generally supported by Diplomatic bus protocols  */
+sealed trait ClockCrossingType extends CrossingType
+{
+  def sameClock = this match {
+    case _: SynchronousCrossing | _: CreditedCrossing => true
+    case _ => false
+  }
+}
+
+case object NoCrossing // converts to SynchronousCrossing(BufferParams.none) via implicit def in package
+case class SynchronousCrossing(params: BufferParams = BufferParams.default) extends ClockCrossingType
+case class RationalCrossing(direction: RationalDirection = FastToSlow) extends ClockCrossingType
+case class AsynchronousCrossing(depth: Int = 8, sourceSync: Int = 3, sinkSync: Int = 3, safe: Boolean = true, narrow: Boolean = false) extends ClockCrossingType
+{
+  def asSinkParams = AsyncQueueParams(depth, sinkSync, safe, narrow)
+}
+case class CreditedCrossing(sourceDelay: CreditedDelay, sinkDelay: CreditedDelay) extends ClockCrossingType
+
+object CreditedCrossing {
+  def apply(delay: CreditedDelay): CreditedCrossing = CreditedCrossing(delay, delay.flip)
+  def apply(): CreditedCrossing = CreditedCrossing(CreditedDelay(1, 1))
+}

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.diplomacy
 
 import Chisel._
 import chisel3.util.ReadyValidIO
-import freechips.rocketchip.util.{ShiftQueue, RationalDirection, FastToSlow, AsyncQueueParams, CreditedDelay}
+import freechips.rocketchip.util.{ShiftQueue}
 
 /** Options for describing the attributes of memory regions */
 object RegionType {
@@ -298,29 +298,6 @@ object TriStateValue
 {
   implicit def apply(value: Boolean): TriStateValue = TriStateValue(value, true)
   def unset = TriStateValue(false, false)
-}
-
-/** Enumerates the types of clock crossings generally supported by Diplomatic bus protocols  */
-sealed trait ClockCrossingType
-{
-  def sameClock = this match {
-    case _: SynchronousCrossing | _: CreditedCrossing => true
-    case _ => false
-  }
-}
-
-case object NoCrossing // converts to SynchronousCrossing(BufferParams.none) via implicit def in package
-case class SynchronousCrossing(params: BufferParams = BufferParams.default) extends ClockCrossingType
-case class RationalCrossing(direction: RationalDirection = FastToSlow) extends ClockCrossingType
-case class AsynchronousCrossing(depth: Int = 8, sourceSync: Int = 3, sinkSync: Int = 3, safe: Boolean = true, narrow: Boolean = false) extends ClockCrossingType
-{
-  def asSinkParams = AsyncQueueParams(depth, sinkSync, safe, narrow)
-}
-case class CreditedCrossing(sourceDelay: CreditedDelay, sinkDelay: CreditedDelay) extends ClockCrossingType
-
-object CreditedCrossing {
-  def apply(delay: CreditedDelay): CreditedCrossing = CreditedCrossing(delay, delay.flip)
-  def apply(): CreditedCrossing = CreditedCrossing(CreditedDelay(1, 1))
 }
 
 trait DirectedBuffers[T] {

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -304,7 +304,7 @@ object TriStateValue
 sealed trait ClockCrossingType
 {
   def sameClock = this match {
-    case _: SynchronousCrossing => true
+    case _: SynchronousCrossing | _: CreditedCrossing => true
     case _ => false
   }
 }

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -27,6 +27,7 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem.{TileCrossingParamsLike, CanAttachTile}
 import freechips.rocketchip.util._
+import freechips.rocketchip.prci.{ClockSinkParameters}
 
 // =======
 // Outline
@@ -75,6 +76,7 @@ case class TraceGenParams(
   val beuAddr = None
   val blockerCtrlAddr = None
   val name = None
+  val clockSinkParams = ClockSinkParameters()
 }
 
 trait HasTraceGenParams {

--- a/src/main/scala/interrupts/BlockDuringReset.scala
+++ b/src/main/scala/interrupts/BlockDuringReset.scala
@@ -2,9 +2,8 @@
 
 package freechips.rocketchip.interrupts
 
-import chisel3._
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.util.BlockDuringReset
 
 /** BlockDuringReset ensures that no interrupt is raised while reset is raised. */

--- a/src/main/scala/interrupts/BlockDuringReset.scala
+++ b/src/main/scala/interrupts/BlockDuringReset.scala
@@ -1,0 +1,27 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.interrupts
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.util.BlockDuringReset
+
+/** BlockDuringReset ensures that no interrupt is raised while reset is raised. */
+class IntBlockDuringReset()(implicit p: Parameters) extends LazyModule
+{
+  val intnode = IntAdapterNode()
+
+  lazy val module = new LazyModuleImp(this) {
+    intnode.in.zip(intnode.out).foreach { case ((in, _), (out, _)) =>
+      in.zip(out).foreach { case (i, o) => o := BlockDuringReset(i) }
+    }
+  }
+}
+
+object IntBlockDuringReset {
+  def apply()(implicit p: Parameters): IntNode = {
+    val block_during_reset = LazyModule(new IntBlockDuringReset)
+    block_during_reset.intnode
+  }
+}

--- a/src/main/scala/interrupts/BlockDuringReset.scala
+++ b/src/main/scala/interrupts/BlockDuringReset.scala
@@ -8,20 +8,22 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.BlockDuringReset
 
 /** BlockDuringReset ensures that no interrupt is raised while reset is raised. */
-class IntBlockDuringReset()(implicit p: Parameters) extends LazyModule
+class IntBlockDuringReset(stretchResetCycles: Int = 0)(implicit p: Parameters) extends LazyModule
 {
   val intnode = IntAdapterNode()
   override def shouldBeInlined = true
   lazy val module = new LazyModuleImp(this) {
     intnode.in.zip(intnode.out).foreach { case ((in, _), (out, _)) =>
-      in.zip(out).foreach { case (i, o) => o := BlockDuringReset(i) }
+      in.zip(out).foreach { case (i, o) => o := BlockDuringReset(i, stretchResetCycles) }
     }
   }
 }
 
 object IntBlockDuringReset {
-  def apply()(implicit p: Parameters): IntNode = {
-    val block_during_reset = LazyModule(new IntBlockDuringReset)
-    block_during_reset.intnode
+  def apply(shouldBlockAndStretch: Option[Int] = Some(0))(implicit p: Parameters): IntNode = {
+    shouldBlockAndStretch.map { c =>
+      val block_during_reset = LazyModule(new IntBlockDuringReset(c))
+      block_during_reset.intnode
+    } .getOrElse(IntTempNode())
   }
 }

--- a/src/main/scala/interrupts/BlockDuringReset.scala
+++ b/src/main/scala/interrupts/BlockDuringReset.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.util.BlockDuringReset
 class IntBlockDuringReset()(implicit p: Parameters) extends LazyModule
 {
   val intnode = IntAdapterNode()
-
+  override def shouldBeInlined = true
   lazy val module = new LazyModuleImp(this) {
     intnode.in.zip(intnode.out).foreach { case ((in, _), (out, _)) =>
       in.zip(out).foreach { case (i, o) => o := BlockDuringReset(i) }

--- a/src/main/scala/interrupts/BlockDuringReset.scala
+++ b/src/main/scala/interrupts/BlockDuringReset.scala
@@ -20,10 +20,8 @@ class IntBlockDuringReset(stretchResetCycles: Int = 0)(implicit p: Parameters) e
 }
 
 object IntBlockDuringReset {
-  def apply(shouldBlockAndStretch: Option[Int] = Some(0))(implicit p: Parameters): IntNode = {
-    shouldBlockAndStretch.map { c =>
-      val block_during_reset = LazyModule(new IntBlockDuringReset(c))
-      block_during_reset.intnode
-    } .getOrElse(IntTempNode())
+  def apply(stretchResetCycles: Int = 0)(implicit p: Parameters): IntNode = {
+    val block_during_reset = LazyModule(new IntBlockDuringReset(stretchResetCycles))
+    block_during_reset.intnode
   }
 }

--- a/src/main/scala/interrupts/Nodes.scala
+++ b/src/main/scala/interrupts/Nodes.scala
@@ -40,6 +40,10 @@ object IntNameNode {
   def apply(name: String): IntIdentityNode = apply(Some(name))
 }
 
+object IntTempNode {
+  def apply(): IntEphemeralNode = IntEphemeralNode()(ValName("temp"))
+}
+
 case class IntNexusNode(
   sourceFn:       Seq[IntSourcePortParameters] => IntSourcePortParameters,
   sinkFn:         Seq[IntSinkPortParameters]   => IntSinkPortParameters,

--- a/src/main/scala/interrupts/RegisterRouter.scala
+++ b/src/main/scala/interrupts/RegisterRouter.scala
@@ -12,7 +12,7 @@ trait HasInterruptSources { this: RegisterRouter =>
   protected val intnode = IntSourceNode(IntSourcePortSimple(num = nInterrupts, resources = Seq(Resource(device, "int"))))
 
   // Externally, this helper should be used to connect the interrupts to a bus
-  val intXing: IntOutwardCrossingHelper = this.crossOut(intnode)
+  val intXing: IntOutwardClockCrossingHelper = this.crossOut(intnode)
 
   // Internally, this wire should be used to drive interrupt values
   val interrupts: ModuleValue[Vec[Bool]] = InModuleBody { if (intnode.out.isEmpty) Vec(0, Bool()) else intnode.out(0)._1 }

--- a/src/main/scala/interrupts/package.scala
+++ b/src/main/scala/interrupts/package.scala
@@ -2,8 +2,9 @@
 
 package freechips.rocketchip
 
-import Chisel._
-import freechips.rocketchip.diplomacy._
+import chisel3.{Bool, Vec}
+import freechips.rocketchip.diplomacy.{HasClockDomainCrossing, _}
+import freechips.rocketchip.prci.{HasResetDomainCrossing}
 
 package object interrupts
 {
@@ -12,8 +13,15 @@ package object interrupts
   type IntNode = SimpleNodeHandle[IntSourcePortParameters, IntSinkPortParameters, IntEdge, Vec[Bool]]
 
   implicit class IntClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
-    def crossIn (n: IntInwardNode) (implicit valName: ValName) = IntInwardCrossingHelper(valName.name, x, n)
-    def crossOut(n: IntOutwardNode)(implicit valName: ValName) = IntOutwardCrossingHelper(valName.name, x, n)
+    def crossIn (n: IntInwardNode) (implicit valName: ValName) = IntInwardClockCrossingHelper(valName.name, x, n)
+    def crossOut(n: IntOutwardNode)(implicit valName: ValName) = IntOutwardClockCrossingHelper(valName.name, x, n)
+    def cross(n: IntInwardNode) (implicit valName: ValName) = crossIn(n)
+    def cross(n: IntOutwardNode)(implicit valName: ValName) = crossOut(n)
+  }
+
+  implicit class IntResetDomainCrossing(private val x: HasResetDomainCrossing) extends AnyVal {
+    def crossIn (n: IntInwardNode) (implicit valName: ValName) = IntInwardResetCrossingHelper(valName.name, x, n)
+    def crossOut(n: IntOutwardNode)(implicit valName: ValName) = IntOutwardResetCrossingHelper(valName.name, x, n)
     def cross(n: IntInwardNode) (implicit valName: ValName) = crossIn(n)
     def cross(n: IntOutwardNode)(implicit valName: ValName) = crossOut(n)
   }

--- a/src/main/scala/prci/BundleBridgeBlockDuringReset.scala
+++ b/src/main/scala/prci/BundleBridgeBlockDuringReset.scala
@@ -1,0 +1,36 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.prci
+
+import chisel3._
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomacy.BundleBridgeNexus.fillN
+import freechips.rocketchip.util.{BlockDuringReset, Blockable}
+
+object BundleBridgeBlockDuringReset {
+  def apply[T <: Data : Blockable](
+    resetCrossingType: ResetCrossingType,
+    name: Option[String] = None,
+    registered: Boolean = false,
+    default: Option[() => T] = None,
+    inputRequiresOutput: Boolean = false,
+    shouldBeInlined: Boolean = true
+  )(implicit p: Parameters): BundleBridgeNexusNode[T] = {
+    val nexus = LazyModule(new BundleBridgeNexus[T](
+      inputFn = (s: Seq[T]) => {
+        val data = BundleBridgeNexus.requireOne[T](registered)(s)
+        resetCrossingType match {
+          case _: NoResetCrossing => data
+          case s: StretchedResetCrossing => BlockDuringReset(data, s.cycles)
+        }
+      },
+      outputFn = fillN[T](registered) _,
+      default = default,
+      inputRequiresOutput = inputRequiresOutput,
+      shouldBeInlined = shouldBeInlined
+    ))
+    name.foreach(nexus.suggestName(_))
+    nexus.node
+  }
+}

--- a/src/main/scala/prci/ClockDomain.scala
+++ b/src/main/scala/prci/ClockDomain.scala
@@ -23,20 +23,16 @@ abstract class ClockDomain(implicit p: Parameters) extends LazyModule
   }
 }
 
-class ClockSinkDomain(
-  take: Option[ClockParameters] = None,
-  name: Option[String] = None)
-  (implicit p: Parameters) extends ClockDomain
+class ClockSinkDomain(val clockSinkParams: ClockSinkParameters)(implicit p: Parameters) extends ClockDomain
 {
-  val clockNode = ClockSinkNode(Seq(ClockSinkParameters(take = take, name = name)))
+  def this(take: Option[ClockParameters] = None, name: Option[String] = None)(implicit p: Parameters) = this(ClockSinkParameters(take = take, name = name))
+  val clockNode = ClockSinkNode(Seq(clockSinkParams))
   def clockBundle = clockNode.in.head._1
 }
 
-class ClockSourceDomain(
-  give: Option[ClockParameters] = None,
-  name: Option[String] = None)
-  (implicit p: Parameters) extends ClockDomain
+class ClockSourceDomain(val clockSourceParams: ClockSourceParameters)(implicit p: Parameters) extends ClockDomain
 {
-  val clockNode = ClockSourceNode(Seq(ClockSourceParameters(give = give, name = name)))
+  def this(give: Option[ClockParameters] = None, name: Option[String] = None)(implicit p: Parameters) = this(ClockSourceParameters(give = give, name = name))
+  val clockNode = ClockSourceNode(Seq(clockSourceParams))
   def clockBundle = clockNode.out.head._1
 }

--- a/src/main/scala/prci/ClockDomain.scala
+++ b/src/main/scala/prci/ClockDomain.scala
@@ -4,10 +4,7 @@ import chisel3._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 
-abstract class ClockDomain(implicit p: Parameters) extends LazyModule
-  with LazyScope
-  with HasClockDomainCrossing
-{
+abstract class Domain(implicit p: Parameters) extends LazyModule with HasDomainCrossing {
   def clockBundle: ClockBundle
 
   lazy val module = new LazyRawModuleImp(this) {
@@ -23,6 +20,8 @@ abstract class ClockDomain(implicit p: Parameters) extends LazyModule
   }
 }
 
+abstract class ClockDomain(implicit p: Parameters) extends Domain with HasClockDomainCrossing
+
 class ClockSinkDomain(val clockSinkParams: ClockSinkParameters)(implicit p: Parameters) extends ClockDomain
 {
   def this(take: Option[ClockParameters] = None, name: Option[String] = None)(implicit p: Parameters) = this(ClockSinkParameters(take = take, name = name))
@@ -36,3 +35,5 @@ class ClockSourceDomain(val clockSourceParams: ClockSourceParameters)(implicit p
   val clockNode = ClockSourceNode(Seq(clockSourceParams))
   def clockBundle = clockNode.out.head._1
 }
+
+abstract class ResetDomain(implicit p: Parameters) extends Domain with HasResetDomainCrossing

--- a/src/main/scala/prci/ClockGroup.scala
+++ b/src/main/scala/prci/ClockGroup.scala
@@ -49,7 +49,7 @@ class ClockGroupAggregator(groupName: String)(implicit p: Parameters) extends La
     val (out, _) = node.out.unzip
     val outputs = out.flatMap(_.member.data)
 
-    require (node.in.size == 1)
+    require (node.in.size == 1, s"Aggregator for groupName: ${groupName} had ${node.in.size} inward edges instead of 1")
     require (in.head.member.size == outputs.size)
     in.head.member.data.zip(outputs).foreach { case (i, o) => o := i }
   }

--- a/src/main/scala/prci/ResetCrossingType.scala
+++ b/src/main/scala/prci/ResetCrossingType.scala
@@ -1,0 +1,24 @@
+// See LICENSE.SiFive for license details.
+package freechips.rocketchip.prci
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy.{CrossingType, HasDomainCrossing, LazyModule}
+
+trait HasResetDomainCrossing extends HasDomainCrossing { this: LazyModule =>
+  type DomainCrossingType = ResetCrossingType
+}
+
+sealed trait ResetCrossingType extends CrossingType {
+  def injectClockNode(implicit p: Parameters): ClockNode
+}
+
+case class NoResetCrossing() extends ResetCrossingType {
+  def injectClockNode(implicit p: Parameters): ClockNode = ClockTempNode()
+}
+
+case class StretchedResetCrossing(cycles: Int) extends ResetCrossingType {
+  def injectClockNode(implicit p: Parameters): ClockNode = {
+    val rs = LazyModule(new ResetStretcher(cycles))
+    rs.node
+  }
+}

--- a/src/main/scala/prci/ResetStretcher.scala
+++ b/src/main/scala/prci/ResetStretcher.scala
@@ -5,6 +5,22 @@ import chisel3._
 import chisel3.util.log2Ceil
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.subsystem.Attachable
+
+sealed trait ResetCrossingType {
+  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode
+}
+
+case class NoResetCrossing() extends ResetCrossingType {
+  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = ClockTempNode()
+}
+
+case class StretchedResetCrossing(cycles: Int) extends ResetCrossingType {
+  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = {
+    val rs = LazyModule(new ResetStretcher(cycles))
+    rs.node
+  }
+}
 
 /* Stretch async reset
 */

--- a/src/main/scala/prci/ResetStretcher.scala
+++ b/src/main/scala/prci/ResetStretcher.scala
@@ -4,26 +4,12 @@ package freechips.rocketchip.prci
 import chisel3._
 import chisel3.util.log2Ceil
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.subsystem.Attachable
+import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp, ValName}
 
-sealed trait ResetCrossingType {
-  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode
-}
-
-case class NoResetCrossing() extends ResetCrossingType {
-  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = ClockTempNode()
-}
-
-case class StretchedResetCrossing(cycles: Int) extends ResetCrossingType {
-  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = {
-    val rs = LazyModule(new ResetStretcher(cycles))
-    rs.node
-  }
-}
-
-/* Stretch async reset
-*/
+/** This adapter takes an input reset and stretches it.
+  *
+  * If the reset was asynchronous, it becomes synchronous.
+  */
 class ResetStretcher(cycles: Int)(implicit p: Parameters) extends LazyModule {
   val node = ClockAdapterNode()(ValName("reset_stretcher"))
   require(cycles > 1, s"ResetStretcher only supports cycles > 1 but got ${cycles}")

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -1159,7 +1159,7 @@ class CSRFile(
 
   for (((t, insn), i) <- (io.trace zip io.inst).zipWithIndex) {
     t.exception := io.retire >= i && exception
-    t.valid := io.retire > i || t.exception
+    t.valid := (io.retire > i || t.exception) && !reset
     t.insn := insn
     t.iaddr := io.pc
     t.priv := Cat(reg_debug, reg_mstatus.prv)

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -1159,7 +1159,7 @@ class CSRFile(
 
   for (((t, insn), i) <- (io.trace zip io.inst).zipWithIndex) {
     t.exception := io.retire >= i && exception
-    t.valid := (io.retire > i || t.exception) && !reset
+    t.valid := io.retire > i || t.exception
     t.insn := insn
     t.iaddr := io.pc
     t.priv := Cat(reg_debug, reg_mstatus.prv)

--- a/src/main/scala/subsystem/BankedL2Params.scala
+++ b/src/main/scala/subsystem/BankedL2Params.scala
@@ -37,12 +37,12 @@ case class CoherenceManagerWrapperParams(
     blockBytes: Int,
     beatBytes: Int,
     nBanks: Int,
-    name: String)
+    name: String,
+    dtsFrequency: Option[BigInt] = None)
   (val coherenceManager: CoherenceManagerInstantiationFn)
   extends HasTLBusParams 
   with TLBusWrapperInstantiationLike
 {
-  val dtsFrequency = None
   def instantiate(context: HasTileLinkLocations, loc: Location[TLBusWrapper])(implicit p: Parameters): CoherenceManagerWrapper = {
     val cmWrapper = LazyModule(new CoherenceManagerWrapper(this, context))
     cmWrapper.suggestName(loc.name + "_wrapper")

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -82,6 +82,10 @@ abstract class BaseSubsystem(val location: HierarchicalLocation = InSubsystem)
   val sbus = tlBusWrapperLocationMap(SBUS)
   tlBusWrapperLocationMap.lift(SBUS).map { _.clockGroupNode := asyncClockGroupsNode }
 
+  // TODO: Preserve legacy implicit-clock behavior for IBUS for now. If binding
+  // a PLIC to the CBUS, ensure it is synchronously coupled to the SBUS.
+  ibus.clockNode := sbus.fixedClockNode
+
   // TODO deprecate these public members to see where users are manually hardcoding a particular bus that might actually not exist in a certain dynamic topology
   val pbus = tlBusWrapperLocationMap.lift(PBUS).getOrElse(sbus)
   val fbus = tlBusWrapperLocationMap.lift(FBUS).getOrElse(sbus)

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -97,7 +97,7 @@ case class CoherentBusTopologyParams(
 ) extends TLBusWrapperTopology(
   instantiations = (if (l2.nBanks == 0) Nil else List(
     (MBUS, mbus),
-    (L2, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, l2.nBanks, L2.name)(l2.coherenceManager)))),
+    (L2, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, l2.nBanks, L2.name, sbus.dtsFrequency)(l2.coherenceManager)))),
   connections = if (l2.nBanks == 0) Nil else List(
     (SBUS, L2,   TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_STAR)()),
     (L2,  MBUS,  TLBusWrapperConnection.crossTo(

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -7,25 +7,24 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.interrupts._
-
+import freechips.rocketchip.prci.{HasResetDomainCrossing, ResetCrossingType}
 
 @deprecated("Only use this trait if you are confident you island will only ever be crossed to a single clock", "rocket-chip 1.3")
 trait HasCrossing extends CrossesToOnlyOneClockDomain { this: LazyModule => }
 
-/** Given a constant crossing type, define a bunch of helper methods for
+/** Given a constant clock crossing type, define a bunch of helper methods for
   * crossing to all the procotols.
   * Note: only use this if you don't care that all signals of a given protocol
   *       type will have the same name prefixes (e.g. "tl_in_xing_*").
   */
 trait CrossesToOnlyOneClockDomain extends HasClockDomainCrossing { this: LazyModule =>
-
   def crossing: ClockCrossingType
 
   def crossTLIn(n: TLInwardNode)(implicit p: Parameters): TLInwardNode = {
     val tlInXing = this.crossIn(n)
     tlInXing(crossing)
   }
-  
+
   def crossTLOut(n: TLOutwardNode)(implicit p: Parameters): TLOutwardNode = {
     val tlOutXing = this.crossOut(n)
     tlOutXing(crossing)
@@ -36,6 +35,44 @@ trait CrossesToOnlyOneClockDomain extends HasClockDomainCrossing { this: LazyMod
     axi4InXing(crossing)
   }
 
+  def crossAXI4Out(n: AXI4OutwardNode)(implicit p: Parameters): AXI4OutwardNode = {
+    val axi4OutXing = this.crossOut(n)
+    axi4OutXing(crossing)
+  }
+
+  def crossIntIn(n: IntInwardNode)(implicit p: Parameters): IntInwardNode = {
+    val intInXing = this.crossIn(n)
+    intInXing(crossing)
+  }
+
+  def crossIntOut(n: IntOutwardNode)(implicit p: Parameters): IntOutwardNode = {
+    val intOutXing = this.crossOut(n)
+    intOutXing(crossing)
+  }
+}
+
+/** Given a constant reset crossing type, define a bunch of helper methods for
+  * crossing to all the procotols.
+  * Note: only use this if you don't care that all signals of a given protocol
+  *       type will have the same name prefixes (e.g. "tl_in_xing_*").
+  */
+trait CrossesToOnlyOneResetDomain extends HasResetDomainCrossing { this: LazyModule =>
+  def crossing: ResetCrossingType
+
+  def crossTLIn(n: TLInwardNode)(implicit p: Parameters): TLInwardNode = {
+    val tlInXing = this.crossIn(n)
+    tlInXing(crossing)
+  }
+
+  def crossTLOut(n: TLOutwardNode)(implicit p: Parameters): TLOutwardNode = {
+    val tlOutXing = this.crossOut(n)
+    tlOutXing(crossing)
+  }
+
+  def crossAXI4In(n: AXI4InwardNode)(implicit p: Parameters): AXI4InwardNode = {
+    val axi4InXing = this.crossIn(n)
+    axi4InXing(crossing)
+  }
   def crossAXI4Out(n: AXI4OutwardNode)(implicit p: Parameters): AXI4OutwardNode = {
     val axi4OutXing = this.crossOut(n)
     axi4OutXing(crossing)

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalModuleTree
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tile.{BaseTile, LookupByHartIdImpl, TileParams, InstantiableTileParams, MaxHartIdBits, TilePRCIDomain, NMI}
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.prci.{ClockGroup, ClockNode, ResetCrossingType}
+import freechips.rocketchip.prci.{ClockGroup, ResetCrossingType}
 import freechips.rocketchip.util._
 
 /** Entry point for Config-uring the presence of Tiles */

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -248,7 +248,8 @@ trait CanAttachTile {
 
   /** Narrow waist through which all tiles are intended to pass while being instantiated. */
   def instantiate(implicit p: Parameters): TilePRCIDomain[TileType] = {
-    val tile_prci_domain = LazyModule(new TilePRCIDomain[TileType](tileParams.hartId) { self =>
+    val clockSinkParams = tileParams.clockSinkParams.copy(name = Some(s"${tileParams.name.getOrElse("core")}_${tileParams.hartId}"))
+    val tile_prci_domain = LazyModule(new TilePRCIDomain[TileType](clockSinkParams) { self =>
       val tile = self.tile_reset_domain { LazyModule(tileParams.instantiate(crossingParams, lookup)) }
     })
     tile_prci_domain

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -371,7 +371,7 @@ trait CanAttachTile {
     })
 
     domain {
-      domain.tile_reset_domain.clockNode := crossingParams.resetCrossingType.injectClockNode(context) := domain.clockNode
+      domain.tile_reset_domain.clockNode := crossingParams.resetCrossingType.injectClockNode := domain.clockNode
     } := clockSource
   }
 }

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -369,10 +369,6 @@ trait CanAttachTile {
     domain {
       domain.clockSinkNode := crossingParams.injectClockNode(context) := domain.clockNode
     } := clockSource
-
-    domain {
-      domain.tile.externalClockSinkNode
-    } := clockSource
   }
 }
 

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -340,9 +340,9 @@ trait CanAttachTile {
     context.tileHaltXbarNode  :=* domain.crossIntOut(NoCrossing, domain.tile.haltNode)
     context.tileWFIXbarNode   :=* domain.crossIntOut(NoCrossing, domain.tile.wfiNode)
     context.tileCeaseXbarNode :=* domain.crossIntOut(NoCrossing, domain.tile.ceaseNode)
-    // TODO should context be forced to have a trace sink connected here,
-    //      or the below trace wiring just legacy support that should be deprecated?
-    domain.traceNexusNode := domain.tile.traceNode
+    // TODO should context be forced to have a trace sink connected here?
+    //      for now this just ensures domain.trace[Core]Node has been crossed without connecting it externally
+    domain.crossTracesOut()
   }
 
   /** Connect inputs to the tile that are assumed to be constant during normal operation, and so are not clock-crossed. */

--- a/src/main/scala/subsystem/InterruptBus.scala
+++ b/src/main/scala/subsystem/InterruptBus.scala
@@ -6,12 +6,13 @@ import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
+import freechips.rocketchip.prci.{ClockSinkDomain}
 
 /** Collects interrupts from internal and external devices and feeds them into the PLIC */ 
-class InterruptBusWrapper(implicit p: Parameters) extends SimpleLazyModule with LazyScope with HasClockDomainCrossing {
+class InterruptBusWrapper(implicit p: Parameters) extends ClockSinkDomain {
   override def shouldBeInlined = true
-  val int_bus = LazyModule(new IntXbar)
-  private val int_in_xing = this.crossIn(int_bus.intnode)
+  val int_bus = LazyModule(new IntXbar)   // Interrupt crossbar
+  private val int_in_xing  = this.crossIn(int_bus.intnode)
   private val int_out_xing = this.crossOut(int_bus.intnode)
   def from(name: Option[String])(xing: ClockCrossingType) = int_in_xing(xing) :=* IntNameNode(name)
   def to(name: Option[String])(xing: ClockCrossingType) = IntNameNode(name) :*= int_out_xing(xing)

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.subsystem
 
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.prci.{ClockNode, ClockTempNode, ResetStretcher}
+import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing}
 import freechips.rocketchip.tile._
 
 case class RocketCrossingParams(
@@ -12,16 +12,8 @@ case class RocketCrossingParams(
   master: TilePortParamsLike = TileMasterPortParams(),
   slave: TileSlavePortParams = TileSlavePortParams(),
   mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS,
-  stretchResetCycles: Option[Int] = None
+  resetCrossingType: ResetCrossingType = NoResetCrossing()
 ) extends TileCrossingParamsLike {
-  def injectClockNode(context: Attachable)(implicit p: Parameters): ClockNode = {
-    if (stretchResetCycles.isDefined) {
-      val rs = LazyModule(new ResetStretcher(stretchResetCycles.get))
-      rs.node
-    } else {
-      ClockTempNode()
-    }
-  }
   def forceSeparateClockReset: Boolean = false
 }
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -14,6 +14,7 @@ import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
+import freechips.rocketchip.prci.{ClockSinkParameters}
 
 case object TileVisibilityNodeKey extends Field[TLEphemeralNode]
 case object TileKey extends Field[TileParams]
@@ -28,6 +29,7 @@ trait TileParams {
   val beuAddr: Option[BigInt]
   val blockerCtrlAddr: Option[BigInt]
   val name: Option[String]
+  val clockSinkParams: ClockSinkParameters
 }
 
 abstract class InstantiableTileParams[TileType <: BaseTile] extends TileParams {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -88,8 +88,6 @@ trait HasNonDiplomaticTileParameters {
   //                  Core   PTW                DTIM                    coprocessors           
   def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + p(BuildRoCC).size + tileParams.core.useVector.toInt
 
-  def intOutwardNodeAlreadyRegistered: Boolean = false
-
   // TODO merge with isaString in CSR.scala
   def isaDTS: String = {
     val ie = if (tileParams.core.useRVE) "e" else "i"

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -11,7 +11,6 @@ import freechips.rocketchip.diplomaticobjectmodel.{HasLogicalTreeNode}
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{GenericLogicalTreeNode, LogicalTreeNode}
 
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.prci.{ClockSinkNode, ClockSinkParameters}
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -291,10 +290,6 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   /** Node for external consumers to source watchpoints to control trace. */
   val bpwatchNode: BundleBridgeOutwardNode[Vec[BPWatch]] =
     BundleBridgeNameNode("bpwatch") :*= bpwatchNexusNode := bpwatchSourceNode
-
-  /** Node to receive raw core_clock and core_reset */
-  val externalClockSinkNode = ClockSinkNode(Seq(ClockSinkParameters()))
-  def rawReset = externalClockSinkNode.in.head._1.reset
 
   /** Helper function for connecting MMIO devices inside the tile to an xbar that will make them visible to external masters. */
   def connectTLSlave(xbarNode: TLOutwardNode, node: TLNode, bytes: Int): Unit = {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -256,11 +256,9 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
 
   /** Node for the core to drive legacy "raw" instruction trace. */
   val traceSourceNode = BundleBridgeSource(() => Vec(traceRetireWidth, new TracedInstruction()))
-  /** Node to broadcast legacy "raw" instruction trace. */
-  val traceNexusNode = BundleBroadcast[Vec[TracedInstruction]]()
   /** Node for external consumers to source a legacy instruction trace from the core. */
   val traceNode: BundleBridgeOutwardNode[Vec[TracedInstruction]] =
-    BundleBridgeNameNode("trace") :*= traceNexusNode := traceSourceNode
+    BundleBridgeNameNode("trace") := traceSourceNode
 
   /** Node to broadcast collected trace sideband signals into the tile. */
   val traceAuxNexusNode = BundleBridgeNexus[TraceAux](default = Some(() => {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -88,6 +88,8 @@ trait HasNonDiplomaticTileParameters {
   //                  Core   PTW                DTIM                    coprocessors           
   def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + p(BuildRoCC).size + tileParams.core.useVector.toInt
 
+  def intOutwardNodeAlreadyRegistered: Boolean = false
+
   // TODO merge with isaString in CSR.scala
   def isaDTS: String = {
     val ie = if (tileParams.core.useRVE) "e" else "i"

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -256,8 +256,9 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   protected def traceRetireWidth = tileParams.core.retireWidth
   /** Node for the core to drive legacy "raw" instruction trace. */
   val traceSourceNode = BundleBridgeSource(() => Vec(traceRetireWidth, new TracedInstruction()))
+  private val traceNexus = BundleBroadcast[Vec[TracedInstruction]]() // backwards compatiblity; not blocked during stretched reset
   /** Node for external consumers to source a legacy instruction trace from the core. */
-  val traceNode: BundleBridgeOutwardNode[Vec[TracedInstruction]] = traceSourceNode
+  val traceNode: BundleBridgeOutwardNode[Vec[TracedInstruction]] = traceNexus := traceSourceNode
 
   protected def traceCoreParams = new TraceCoreParams()
   /** Node for core to drive instruction trace conforming to RISC-V Processor Trace spec V1.0 */

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -92,7 +92,7 @@ trait SourcesExternalNotifications { this: BaseTile =>
 
   def reportHalt(could_halt: Option[Bool]): Unit = {
     val (halt_and_catch_fire, _) = haltNode.out(0)
-    halt_and_catch_fire(0) := could_halt.map(h => RegEnable(true.B, false.B, BlockDuringReset(h))).getOrElse(false.B)
+    halt_and_catch_fire(0) := could_halt.map(RegEnable(true.B, false.B, _)).getOrElse(false.B)
   }
 
   def reportHalt(errors: Seq[CanHaveErrors]): Unit = {
@@ -126,6 +126,6 @@ trait SourcesExternalNotifications { this: BaseTile =>
 
   def reportWFI(could_wfi: Option[Bool]): Unit = {
     val (wfi, _) = wfiNode.out(0)
-    wfi(0) := could_wfi.map(w => RegNext(BlockDuringReset(w), init=false.B)).getOrElse(false.B)
+    wfi(0) := could_wfi.map(RegNext(_, init=false.B)).getOrElse(false.B)
   }
 }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -51,6 +51,7 @@ class RocketTile private(
     this(params, crossing.crossingType, lookup, p)
 
   val intOutwardNode = IntIdentityNode()
+  override def intOutwardNodeAlreadyRegistered: Boolean = true
   val slaveNode = TLIdentityNode()
   val masterNode = visibilityNode
 
@@ -63,9 +64,14 @@ class RocketTile private(
 
   val bus_error_unit = rocketParams.beuAddr map { a =>
     val beu = LazyModule(new BusErrorUnit(new L1BusErrors, BusErrorUnitParams(a), logicalTreeNode))
-    intOutwardNode := beu.intNode
     connectTLSlave(beu.node, xBytes)
     beu
+  }
+
+  val beuIntNode = bus_error_unit.map { beu =>
+    val node = IntAdapterNode()
+    intOutwardNode := node := beu.intNode
+    node
   }
 
   val tile_master_blocker =
@@ -162,6 +168,11 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
     core.io.interrupts.buserror.get := beu.module.io.interrupt
     beu.module.io.errors.dcache := outer.dcache.module.io.errors
     beu.module.io.errors.icache := outer.frontend.module.io.errors
+
+    // register beu interrupt with rawReset async reset flop
+    val (int_in, _) = outer.beuIntNode.get.in(0)
+    val (int_out, _) = outer.beuIntNode.get.out(0)
+    int_out(0) := withReset(outer.rawReset.asAsyncReset)(RegNext(int_in(0), false.B))
   }
 
   core.io.interrupts.nmi.foreach { nmi => nmi := outer.nmiSinkNode.bundle }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -137,7 +137,6 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   val core = Module(new Rocket(outer)(outer.p))
 
-  val traceValidEnable = Wire(Bool())
   withReset(outer.rawReset) {   // use unmodified reset for notification ports
     // Report unrecoverable error conditions; for now the only cause is cache ECC errors
     outer.reportHalt(List(outer.dcache.module.io.errors))
@@ -150,10 +149,6 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
       core.io.cease))
 
     outer.reportWFI(Some(core.io.wfi))
-
-    val outOfReset = RegInit(0.U(2.W))
-    when (!traceValidEnable) { outOfReset := outOfReset + 1.U }
-    traceValidEnable := outOfReset.andR      // force trace.valid to 0 during and just after async reset without adding any loads to core.reset
   }
 
   outer.decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
@@ -168,7 +163,6 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   // Pass through various external constants and reports that were bundle-bridged into the tile
   outer.traceSourceNode.bundle <> core.io.trace
-  outer.traceSourceNode.bundle.zip(core.io.trace).foreach { case(tb, t) => tb.valid := t.valid && traceValidEnable }
   core.io.traceStall := outer.traceAuxSinkNode.bundle.stall
   outer.bpwatchSourceNode.bundle <> core.io.bpwatch
   core.io.hartid := outer.hartIdSinkNode.bundle

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -51,7 +51,6 @@ class RocketTile private(
     this(params, crossing.crossingType, lookup, p)
 
   val intOutwardNode = IntIdentityNode()
-  override def intOutwardNodeAlreadyRegistered: Boolean = true
   val slaveNode = TLIdentityNode()
   val masterNode = visibilityNode
 
@@ -64,14 +63,9 @@ class RocketTile private(
 
   val bus_error_unit = rocketParams.beuAddr map { a =>
     val beu = LazyModule(new BusErrorUnit(new L1BusErrors, BusErrorUnitParams(a), logicalTreeNode))
+    intOutwardNode := beu.intNode
     connectTLSlave(beu.node, xBytes)
     beu
-  }
-
-  val beuIntNode = bus_error_unit.map { beu =>
-    val node = IntAdapterNode()
-    intOutwardNode := node := beu.intNode
-    node
   }
 
   val tile_master_blocker =
@@ -168,11 +162,6 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
     core.io.interrupts.buserror.get := beu.module.io.interrupt
     beu.module.io.errors.dcache := outer.dcache.module.io.errors
     beu.module.io.errors.icache := outer.frontend.module.io.errors
-
-    // register beu interrupt with rawReset async reset flop
-    val (int_in, _) = outer.beuIntNode.get.in(0)
-    val (int_out, _) = outer.beuIntNode.get.out(0)
-    int_out(0) := withReset(outer.rawReset.asAsyncReset)(RegNext(int_in(0), false.B))
   }
 
   core.io.interrupts.nmi.foreach { nmi => nmi := outer.nmiSinkNode.bundle }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -13,6 +13,8 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.TileCrossingParamsLike
 import freechips.rocketchip.util._
+import freechips.rocketchip.prci.{ClockSinkParameters}
+
 
 case class RocketTileParams(
     core: RocketCoreParams = RocketCoreParams(),
@@ -24,6 +26,7 @@ case class RocketTileParams(
     hartId: Int = 0,
     beuAddr: Option[BigInt] = None,
     blockerCtrlAddr: Option[BigInt] = None,
+    clockSinkParams: ClockSinkParameters = ClockSinkParameters(),
     boundaryBuffers: Boolean = false // if synthesized with hierarchical PnR, cut feed-throughs?
     ) extends InstantiableTileParams[RocketTile] {
   require(icache.isDefined)

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -4,7 +4,6 @@
 package freechips.rocketchip.tile
 
 import Chisel._
-import chisel3.withReset
 import freechips.rocketchip.config._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
@@ -137,19 +136,17 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   val core = Module(new Rocket(outer)(outer.p))
 
-  withReset(outer.rawReset) {   // use unmodified reset for notification ports
-    // Report unrecoverable error conditions; for now the only cause is cache ECC errors
-    outer.reportHalt(List(outer.dcache.module.io.errors))
+  // Report unrecoverable error conditions; for now the only cause is cache ECC errors
+  outer.reportHalt(List(outer.dcache.module.io.errors))
 
-    // Report when the tile has ceased to retire instructions; for now the only cause is clock gating
-    outer.reportCease(outer.rocketParams.core.clockGate.option(
-      !outer.dcache.module.io.cpu.clock_enabled &&
-      !outer.frontend.module.io.cpu.clock_enabled &&
-      !ptw.io.dpath.clock_enabled &&
-      core.io.cease))
+  // Report when the tile has ceased to retire instructions; for now the only cause is clock gating
+  outer.reportCease(outer.rocketParams.core.clockGate.option(
+    !outer.dcache.module.io.cpu.clock_enabled &&
+    !outer.frontend.module.io.cpu.clock_enabled &&
+    !ptw.io.dpath.clock_enabled &&
+    core.io.cease))
 
-    outer.reportWFI(Some(core.io.wfi))
-  }
+  outer.reportWFI(Some(core.io.wfi))
 
   outer.decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
 

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -26,7 +26,7 @@ abstract class TilePRCIDomain[T <: BaseTile](clockSinkParams: ClockSinkParameter
 
   val tapClockNode = ClockIdentityNode()
   val clockNode = FixedClockBroadcast(None) :=* tapClockNode
-  val tile_reset_domain = LazyModule(new ClockSinkDomain(clockSinkParams))
+  val tile_reset_domain = LazyModule(new ClockSinkDomain(clockSinkParams) { override def shouldBeInlined = true })
   lazy val clockBundle = tapClockNode.in.head._1
 
   /** Node to broadcast legacy "raw" instruction trace while surpressing it during (async) reset. */

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -34,7 +34,7 @@ abstract class TilePRCIDomain[T <: BaseTile](id: Int)(implicit p: Parameters)
   /** External code looking to connect and clock-cross the interrupts raised by devices inside this tile can call this. */
   def crossIntOut(crossing: ClockCrossingType): IntOutwardNode = {
     val intOutXing = this.crossOut(tile.intOutwardNode)
-    intOutXing(crossing)
+    intOutXing(crossing, tile.intOutwardNodeAlreadyRegistered)
   }
 
   /** External code looking to connect the ports where this tile is slaved to an interconnect

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -19,14 +19,14 @@ import freechips.rocketchip.util.{BlockDuringReset}
   * hierarchical P&R boundary buffers, core-local interrupt handling,
   * and any other IOs related to PRCI control.
   */
-abstract class TilePRCIDomain[T <: BaseTile](id: Int)(implicit p: Parameters)
+abstract class TilePRCIDomain[T <: BaseTile](clockSinkParams: ClockSinkParameters)(implicit p: Parameters)
     extends ClockDomain
 {
   val tile: T
 
   val tapClockNode = ClockIdentityNode()
   val clockNode = FixedClockBroadcast(None) :=* tapClockNode
-  val tile_reset_domain = LazyModule(new ClockSinkDomain(take = None, name = Some(s"core_$id")))
+  val tile_reset_domain = LazyModule(new ClockSinkDomain(clockSinkParams))
   lazy val clockBundle = tapClockNode.in.head._1
 
   /** Node to broadcast legacy "raw" instruction trace while surpressing it during (async) reset. */

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -34,7 +34,7 @@ abstract class TilePRCIDomain[T <: BaseTile](id: Int)(implicit p: Parameters)
   /** External code looking to connect and clock-cross the interrupts raised by devices inside this tile can call this. */
   def crossIntOut(crossing: ClockCrossingType): IntOutwardNode = {
     val intOutXing = this.crossOut(tile.intOutwardNode)
-    intOutXing(crossing, tile.intOutwardNodeAlreadyRegistered)
+    intOutXing(crossing)
   }
 
   /** External code looking to connect the ports where this tile is slaved to an interconnect

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -95,7 +95,7 @@ abstract class TilePRCIDomain[T <: BaseTile](
     */
   def crossSlavePort(crossingType: ClockCrossingType): TLInwardNode = { DisableMonitors { implicit p => FlipRendering { implicit p =>
     val tlSlaveResetXing = this {
-      tile_reset_domain.crossTLIn(tile.slaveNode) :=
+      tile_reset_domain.crossTLIn(tile.slaveNode) :*=
         tile.makeSlaveBoundaryBuffers(crossingType)
     }
     val tlSlaveClockXing = this.crossIn(tlSlaveResetXing)

--- a/src/main/scala/tilelink/BlockDuringReset.scala
+++ b/src/main/scala/tilelink/BlockDuringReset.scala
@@ -34,10 +34,8 @@ class TLBlockDuringReset(stretchResetCycles: Int = 0)
 }
 
 object TLBlockDuringReset {
-  def apply(shouldBlockAndStretch: Option[Int] = Some(0))(implicit p: Parameters): TLNode = {
-    shouldBlockAndStretch.map { c =>
-      val block_during_reset = LazyModule(new TLBlockDuringReset(c))
-      block_during_reset.node
-    } .getOrElse(TLTempNode())
+  def apply(stretchCycles: Int = 0)(implicit p: Parameters): TLNode = {
+    val block_during_reset = LazyModule(new TLBlockDuringReset(stretchCycles))
+    block_during_reset.node
   }
 }

--- a/src/main/scala/tilelink/BlockDuringReset.scala
+++ b/src/main/scala/tilelink/BlockDuringReset.scala
@@ -8,18 +8,19 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.{BlockDuringReset, EnhancedChisel3Assign}
 
 /** BlockDuringReset ensures that no channel admits to be ready or valid while reset is raised. */
-class TLBlockDuringReset()(implicit p: Parameters) extends LazyModule
+class TLBlockDuringReset(stretchResetCycles: Int = 0)
+                        (implicit p: Parameters) extends LazyModule
 {
   val node = TLAdapterNode()
   override def shouldBeInlined = true
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      out.a :<> BlockDuringReset(in .a)
-      in .d :<> BlockDuringReset(out.d)
+      out.a :<> BlockDuringReset(in .a, stretchResetCycles)
+      in .d :<> BlockDuringReset(out.d, stretchResetCycles)
       if (edgeOut.manager.anySupportAcquireB && edgeOut.client.anySupportProbe) {
-        in .b :<> BlockDuringReset(out.b)
-        out.c :<> BlockDuringReset(in .c)
-        out.e :<> BlockDuringReset(in .e)
+        in .b :<> BlockDuringReset(out.b, stretchResetCycles)
+        out.c :<> BlockDuringReset(in .c, stretchResetCycles)
+        out.e :<> BlockDuringReset(in .e, stretchResetCycles)
       } else {
         in.b.valid  := false.B
         in.c.ready  := true.B
@@ -33,8 +34,10 @@ class TLBlockDuringReset()(implicit p: Parameters) extends LazyModule
 }
 
 object TLBlockDuringReset {
-  def apply()(implicit p: Parameters): TLAdapterNode = {
-    val block_during_reset = LazyModule(new TLBlockDuringReset)
-    block_during_reset.node
+  def apply(shouldBlockAndStretch: Option[Int] = Some(0))(implicit p: Parameters): TLNode = {
+    shouldBlockAndStretch.map { c =>
+      val block_during_reset = LazyModule(new TLBlockDuringReset(c))
+      block_during_reset.node
+    } .getOrElse(TLTempNode())
   }
 }

--- a/src/main/scala/tilelink/BlockDuringReset.scala
+++ b/src/main/scala/tilelink/BlockDuringReset.scala
@@ -1,0 +1,39 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tilelink
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.util.{BlockDuringReset, EnhancedChisel3Assign}
+
+/** BlockDuringReset ensures that no channel admits to be ready or valid while reset is raised. */
+class TLBlockDuringReset()(implicit p: Parameters) extends LazyModule
+{
+  val node = TLAdapterNode()
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      out.a :<> BlockDuringReset(in .a)
+      in .d :<> BlockDuringReset(out.d)
+      if (edgeOut.manager.anySupportAcquireB && edgeOut.client.anySupportProbe) {
+        in .b :<> BlockDuringReset(out.b)
+        out.c :<> BlockDuringReset(in .c)
+        out.e :<> BlockDuringReset(in .e)
+      } else {
+        in.b.valid  := false.B
+        in.c.ready  := true.B
+        in.e.ready  := true.B
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
+      }
+    }
+  }
+}
+
+object TLBlockDuringReset {
+  def apply()(implicit p: Parameters): TLAdapterNode = {
+    val block_during_reset = LazyModule(new TLBlockDuringReset)
+    block_during_reset.node
+  }
+}

--- a/src/main/scala/tilelink/BlockDuringReset.scala
+++ b/src/main/scala/tilelink/BlockDuringReset.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.util.{BlockDuringReset, EnhancedChisel3Assign}
 class TLBlockDuringReset()(implicit p: Parameters) extends LazyModule
 {
   val node = TLAdapterNode()
+  override def shouldBeInlined = true
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out.a :<> BlockDuringReset(in .a)

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -37,8 +37,8 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
     with CanAttachTLSlaves
     with CanAttachTLMasters
 {
-  private val clockGroupAggregator = LazyModule(new ClockGroupAggregator(busName)).suggestName(busName + "_clock_groups")
-  private val clockGroup = LazyModule(new ClockGroup(busName))
+  private val clockGroupAggregator = LazyModule(new ClockGroupAggregator(busName){ override def shouldBeInlined = true }).suggestName(busName + "_clock_groups")
+  private val clockGroup = LazyModule(new ClockGroup(busName){ override def shouldBeInlined = true })
   val clockGroupNode = clockGroupAggregator.node // other bus clock groups attach here
   val clockNode = clockGroup.node
   val fixedClockNode = FixedClockBroadcast(fixedClockOpt) // device clocks attach here

--- a/src/main/scala/tilelink/CrossingHelper.scala
+++ b/src/main/scala/tilelink/CrossingHelper.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.tilelink
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.prci._
-import freechips.rocketchip.util.RationalDirection
 
 trait TLOutwardCrossingHelper {
   type HelperCrossingType <: CrossingType

--- a/src/main/scala/tilelink/CrossingHelper.scala
+++ b/src/main/scala/tilelink/CrossingHelper.scala
@@ -7,7 +7,20 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.util.RationalDirection
 
-case class TLInwardCrossingHelper(name: String, scope: LazyScope, node: TLInwardNode) {
+trait TLOutwardCrossingHelper {
+  type HelperCrossingType <: CrossingType
+  def apply(xing: HelperCrossingType)(implicit p: Parameters): TLOutwardNode
+}
+
+trait TLInwardCrossingHelper {
+  type HelperCrossingType <: CrossingType
+  def apply(xing: HelperCrossingType)(implicit p: Parameters): TLInwardNode
+}
+
+case class TLInwardClockCrossingHelper(name: String, scope: LazyScope, node: TLInwardNode)
+    extends TLInwardCrossingHelper
+{
+  type HelperCrossingType = ClockCrossingType
   def apply(xing: ClockCrossingType = NoCrossing)(implicit p: Parameters): TLInwardNode = {
     xing match {
       case x: AsynchronousCrossing =>
@@ -20,7 +33,12 @@ case class TLInwardCrossingHelper(name: String, scope: LazyScope, node: TLInward
         node :*=* scope { TLCreditedSink(sinkDelay) :*=* TLCreditedNameNode(name) } :*=* TLCreditedNameNode(name) :*=* TLCreditedSource(sourceDelay)
     }
   }
+}
 
+case class TLInwardResetCrossingHelper(name: String, scope: LazyScope, node: TLInwardNode)
+    extends TLInwardCrossingHelper
+{
+  type HelperCrossingType = ResetCrossingType
   def apply(xing: ResetCrossingType)(implicit p: Parameters): TLInwardNode = {
     xing match {
       case _: NoResetCrossing => node
@@ -30,7 +48,10 @@ case class TLInwardCrossingHelper(name: String, scope: LazyScope, node: TLInward
   }
 }
 
-case class TLOutwardCrossingHelper(name: String, scope: LazyScope, node: TLOutwardNode) {
+case class TLOutwardClockCrossingHelper(name: String, scope: LazyScope, node: TLOutwardNode)
+    extends TLOutwardCrossingHelper
+{
+  type HelperCrossingType = ClockCrossingType
   def apply(xing: ClockCrossingType = NoCrossing)(implicit p: Parameters): TLOutwardNode = {
     xing match {
       case x: AsynchronousCrossing =>
@@ -43,7 +64,12 @@ case class TLOutwardCrossingHelper(name: String, scope: LazyScope, node: TLOutwa
         TLCreditedSink(sinkDelay) :*=* TLCreditedNameNode(name) :*=* scope { TLCreditedNameNode(name) :*=* TLCreditedSource(sourceDelay) } :*=* node
     }
   }
+}
 
+case class TLOutwardResetCrossingHelper(name: String, scope: LazyScope, node: TLOutwardNode)
+    extends TLOutwardCrossingHelper
+{
+  type HelperCrossingType = ResetCrossingType
   def apply(xing: ResetCrossingType)(implicit p: Parameters): TLOutwardNode = {
     xing match {
       case _: NoResetCrossing => node

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -196,7 +196,7 @@ trait HasTLControlRegMap { this: RegisterRouter =>
     executable = executable)
 
   // Externally, this helper should be used to connect the register control port to a bus
-  val controlXing: TLInwardCrossingHelper = this.crossIn(controlNode)
+  val controlXing: TLInwardClockCrossingHelper = this.crossIn(controlNode)
 
   // Internally, this function should be used to populate the control port with registers
   protected def regmap(mapping: RegField.Map*): Unit = { controlNode.regmap(mapping:_*) }

--- a/src/main/scala/tilelink/package.scala
+++ b/src/main/scala/tilelink/package.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip
 
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.diplomacy.{HasClockDomainCrossing, _}
+import freechips.rocketchip.prci.{HasResetDomainCrossing}
 
 package object tilelink
 {
@@ -17,8 +18,15 @@ package object tilelink
   type TLClientPortParameters = TLMasterPortParameters
 
   implicit class TLClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
-    def crossIn (n: TLInwardNode) (implicit valName: ValName) = TLInwardCrossingHelper (valName.name, x, n)
-    def crossOut(n: TLOutwardNode)(implicit valName: ValName) = TLOutwardCrossingHelper(valName.name, x, n)
+    def crossIn (n: TLInwardNode) (implicit valName: ValName) = TLInwardClockCrossingHelper (valName.name, x, n)
+    def crossOut(n: TLOutwardNode)(implicit valName: ValName) = TLOutwardClockCrossingHelper(valName.name, x, n)
+    def cross(n: TLInwardNode) (implicit valName: ValName) = crossIn(n)
+    def cross(n: TLOutwardNode)(implicit valName: ValName) = crossOut(n)
+  }
+
+  implicit class TLResetDomainCrossing(private val x: HasResetDomainCrossing) extends AnyVal {
+    def crossIn (n: TLInwardNode) (implicit valName: ValName) = TLInwardResetCrossingHelper (valName.name, x, n)
+    def crossOut(n: TLOutwardNode)(implicit valName: ValName) = TLOutwardResetCrossingHelper(valName.name, x, n)
     def cross(n: TLInwardNode) (implicit valName: ValName) = crossIn(n)
     def cross(n: TLOutwardNode)(implicit valName: ValName) = crossOut(n)
   }

--- a/src/main/scala/util/BlockDuringReset.scala
+++ b/src/main/scala/util/BlockDuringReset.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.util
 
 import chisel3._
-import chisel3.util.{Counter, DecoupledIO, RegEnable}
+import chisel3.util.{Counter, RegEnable}
 
 /** Blocks transactions until the cycle after reset. */
 object BlockDuringReset
@@ -13,39 +13,7 @@ object BlockDuringReset
     case i => RegEnable(true.B, false.B, Counter(true.B, i)._2)
   }
 
-  def apply[T <: Data](enq: DecoupledIO[T], stretchCycles: Int = 0): DecoupledIO[T] = {
-    val out_of_reset = outOfReset(stretchCycles)
-    val res = Wire(enq.cloneType)
-    res.valid := enq.valid
-    enq.ready := res.ready
-    res.bits := enq.bits
-    when (!out_of_reset) {
-      res.valid := false.B
-      enq.ready := false.B
-    }
-    res
-  }
-
-  def apply(valid: Bool, stretchCycles: Int): Bool = {
-    val out_of_reset = outOfReset(stretchCycles)
-    valid && out_of_reset
-  }
-
-  def apply[T <: DataCanBeValid](data: T, stretchCycles: Int): T = {
-    val out_of_reset = outOfReset(stretchCycles)
-    val res = Wire(data.cloneType)
-    res := data
-    res.valid := data.valid && out_of_reset
-    res
-  }
-
-  def apply[T <: DataCanBeValid](data: Vec[T], stretchCycles: Int): Vec[T] = {
-    val out_of_reset = outOfReset(stretchCycles)
-    val res = Wire(data.cloneType)
-    res.zip(data)foreach { case (r, d) =>
-      r := d
-      r.valid := d.valid && out_of_reset
-    }
-    res
+  def apply[T <: Data : Blockable](data: T, stretchCycles: Int = 0): T = {
+    implicitly[Blockable[T]].blockWhile(!outOfReset(stretchCycles), data)
   }
 }

--- a/src/main/scala/util/BlockDuringReset.scala
+++ b/src/main/scala/util/BlockDuringReset.scala
@@ -3,14 +3,14 @@
 package freechips.rocketchip.util
 
 import chisel3._
-import chisel3.util.{Counter, DecoupledIO}
+import chisel3.util.{Counter, DecoupledIO, RegEnable}
 
 /** Blocks transactions until the cycle after reset. */
 object BlockDuringReset
 {
   private def outOfReset(stretchCycles: Int): Bool = stretchCycles match {
     case 0 => RegNext(true.B, false.B)
-    case i => Counter(true.B, i)._2
+    case i => RegEnable(true.B, false.B, Counter(true.B, i)._2)
   }
 
   def apply[T <: Data](enq: DecoupledIO[T], stretchCycles: Int = 0): DecoupledIO[T] = {

--- a/src/main/scala/util/BlockDuringReset.scala
+++ b/src/main/scala/util/BlockDuringReset.scala
@@ -21,8 +21,26 @@ object BlockDuringReset
     res
   }
 
-  def apply(enq: Bool): Bool = {
+  def apply(valid: Bool): Bool = {
     val out_of_reset = RegNext(true.B, false.B)
-    enq && out_of_reset
+    valid && out_of_reset
+  }
+
+  def apply[T <: DataCanBeValid](data: T): T = {
+    val out_of_reset = RegNext(true.B, false.B)
+    val res = Wire(data.cloneType)
+    res := data
+    res.valid := data.valid && out_of_reset
+    res
+  }
+
+  def apply[T <: DataCanBeValid](data: Vec[T]): Vec[T] = {
+    val out_of_reset = RegNext(true.B, false.B)
+    val res = Wire(data.cloneType)
+    res.zip(data)foreach { case (r, d) =>
+      r := d
+      r.valid := d.valid && out_of_reset
+    }
+    res
   }
 }

--- a/src/main/scala/util/BlockDuringReset.scala
+++ b/src/main/scala/util/BlockDuringReset.scala
@@ -3,13 +3,18 @@
 package freechips.rocketchip.util
 
 import chisel3._
-import chisel3.util.DecoupledIO
+import chisel3.util.{Counter, DecoupledIO}
 
 /** Blocks transactions until the cycle after reset. */
 object BlockDuringReset
 {
-  def apply[T <: Data](enq: DecoupledIO[T]): DecoupledIO[T] = {
-    val out_of_reset = RegNext(true.B, false.B)
+  private def outOfReset(stretchCycles: Int): Bool = stretchCycles match {
+    case 0 => RegNext(true.B, false.B)
+    case i => Counter(true.B, i)._2
+  }
+
+  def apply[T <: Data](enq: DecoupledIO[T], stretchCycles: Int = 0): DecoupledIO[T] = {
+    val out_of_reset = outOfReset(stretchCycles)
     val res = Wire(enq.cloneType)
     res.valid := enq.valid
     enq.ready := res.ready
@@ -21,21 +26,21 @@ object BlockDuringReset
     res
   }
 
-  def apply(valid: Bool): Bool = {
-    val out_of_reset = RegNext(true.B, false.B)
+  def apply(valid: Bool, stretchCycles: Int): Bool = {
+    val out_of_reset = outOfReset(stretchCycles)
     valid && out_of_reset
   }
 
-  def apply[T <: DataCanBeValid](data: T): T = {
-    val out_of_reset = RegNext(true.B, false.B)
+  def apply[T <: DataCanBeValid](data: T, stretchCycles: Int): T = {
+    val out_of_reset = outOfReset(stretchCycles)
     val res = Wire(data.cloneType)
     res := data
     res.valid := data.valid && out_of_reset
     res
   }
 
-  def apply[T <: DataCanBeValid](data: Vec[T]): Vec[T] = {
-    val out_of_reset = RegNext(true.B, false.B)
+  def apply[T <: DataCanBeValid](data: Vec[T], stretchCycles: Int): Vec[T] = {
+    val out_of_reset = outOfReset(stretchCycles)
     val res = Wire(data.cloneType)
     res.zip(data)foreach { case (r, d) =>
       r := d

--- a/src/main/scala/util/Blockable.scala
+++ b/src/main/scala/util/Blockable.scala
@@ -45,4 +45,18 @@ object Blockable {
       VecInit(data.map(x => implicitly[Blockable[T]].blockWhile(enable_blocking, x)))
     }
   }
+
+  implicit object BlockableTraceCoreInterface extends Blockable[TraceCoreInterface] {
+    def blockWhile(enable_blocking: Bool, data: TraceCoreInterface): TraceCoreInterface = {
+      val blocked: TraceCoreInterface = Wire(chiselTypeOf(data))
+      blocked := data
+      when (enable_blocking) {
+        blocked.group.foreach { g =>
+          g.iretire := 0.U
+          g.itype := TraceItype.ITNothing
+        }
+      }
+      blocked
+    }
+  }
 }

--- a/src/main/scala/util/Blockable.scala
+++ b/src/main/scala/util/Blockable.scala
@@ -1,0 +1,48 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import chisel3._
+import chisel3.util.DecoupledIO
+
+/** A trait supplying a function allowing the contents of data
+  * to be supressed for a time period, i.e. be blocked.
+  */
+trait Blockable[T <: Data] {
+  def blockWhile(enable_blocking: Bool, data: T): T
+}
+
+object Blockable {
+  implicit object BlockableBool extends Blockable[Bool] {
+    def blockWhile(enable_blocking: Bool, x: Bool): Bool = x && !enable_blocking
+  }
+
+  implicit def BlockableDataCanBeValid[T <: DataCanBeValid]: Blockable[T] = new Blockable[T] {
+    def blockWhile(enable_blocking: Bool, data: T): T = {
+      val blocked: T = Wire(chiselTypeOf(data))
+      blocked := data
+      when (enable_blocking) { blocked.valid := false.B }
+      blocked
+    }
+  }
+
+  implicit def BlockableDecoupled[T <: Data]: Blockable[DecoupledIO[T]] = new Blockable[DecoupledIO[T]] {
+    def blockWhile(enable_blocking: Bool, data: DecoupledIO[T]): DecoupledIO[T] = {
+      val res = Wire(chiselTypeOf(data))
+      res.valid  := data.valid
+      data.ready := res.ready
+      res.bits   := data.bits
+      when (enable_blocking) {
+        res.valid  := false.B
+        data.ready := false.B
+      }
+      res
+    }
+  }
+
+  implicit def BlockableVec[T <: Data : Blockable]: Blockable[Vec[T]] = new Blockable[Vec[T]] {
+    def blockWhile(enable_blocking: Bool, data: Vec[T]): Vec[T] = {
+      VecInit(data.map(x => implicitly[Blockable[T]].blockWhile(enable_blocking, x)))
+    }
+  }
+}

--- a/src/main/scala/util/RationalCrossing.scala
+++ b/src/main/scala/util/RationalCrossing.scala
@@ -123,7 +123,7 @@ class RationalCrossingSink[T <: Data](gen: T, direction: RationalDirection = Sym
   enq.ready := deq.ready
   enq.sink  := count
   deq.bits  := Mux(equal, enq.bits0, enq.bits1)
-  deq.valid := BlockDuringReset(Mux(equal, enq.valid, count(1) =/= enq.source(0)))
+  deq.valid := Mux(equal, enq.valid, count(1) =/= enq.source(0))
 
   when (deq.fire()) { count := Cat(count(0), !count(1)) }
 

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -84,6 +84,9 @@ package object util {
     }
   }
 
+  /** Any Data subtype that has a Bool member named valid. */
+  type DataCanBeValid = Data { val valid: Bool }
+
   implicit class SeqMemToAugmentedSeqMem[T <: Data](private val x: SeqMem[T]) extends AnyVal {
     def readAndHold(addr: UInt, enable: Bool): T = x.read(addr, enable) holdUnless RegNext(enable)
   }


### PR DESCRIPTION
This PR combines and merges the effects of #2618 and #2623 while also partially reverting #2611. The overall goals are:
- Avoid tunneling the "raw" subsystem reset into `RocketTile`, instead, move all logic requiring raw reset into the `TilePRCIWrapper` 
- Said logic largely takes the form of registers that block tile outputs from appearing valid while the tile is being held in an extended reset, in which case those registers need to be asynchronously reset for certain `ResetSchemes` (when a `ResetStretcher` is injected) and then they need to maintain the blockage for the duration of any stretched reset.
-  `TileResetDomain` is added to manage diplomatic control of the Tile's `reset` input. All other clock crossing logic in `TilePRCIDomain` goes back to being on the raw subsystem reset (but still on the tile clock domain). `TileResetDomain` is inlined by firrtl to prevent further disruption to the module hierarchy.
- `ResetCrossingType` is defined to be analogous to `ClockCrossingType`, the two defined reset crossing types are currently `NoResetCrossing` and `StretchedResetCrossing(cycles: Int)`
- The diplomatic `CrossingHelper` functionality for TL and Interrupts are extended to also deal with `ResetCrossingType`
- Specifically, for `StretchedResetCrossing` they will inject `BlockDuringReset` logic in the scope where the helper is invoked; in this specific case, that scope is `TilePRCIDomain`, ensuring the logic gets the raw reset.
- Various other minor parameterization cleanups and helper nodes.

@aswaterman, @ernie-sifive can you double check that my changes to the actual `BlockDuringReset` logics look kosher?

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
