### PR TITLE
Support subbanking the D$ to save power for narrow accesses

### DIFF
--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -19,6 +19,7 @@ case class DCacheParams(
     nSets: Int = 64,
     nWays: Int = 4,
     rowBits: Int = 64,
+    subWordBits: Option[Int] = None,
     nTLBSets: Int = 1,
     nTLBWays: Int = 32,
     nTLBBasePageSectors: Int = 4,
@@ -58,6 +59,8 @@ trait HasL1HellaCacheParameters extends HasL1CacheParameters with HasCoreParamet
 
   def wordBits = coreDataBits
   def wordBytes = coreDataBytes
+  def subWordBits = cacheParams.subWordBits.getOrElse(wordBits)
+  def subWordBytes = subWordBits / 8
   def wordOffBits = log2Up(wordBytes)
   def beatBytes = cacheBlockBytes / cacheDataBeats
   def beatWords = beatBytes / wordBytes


### PR DESCRIPTION
This is particularly useful for reducing energy per scalar access when attaching a coprocessor that requires a very wide D$ port.

Enabled with optional parameter DCacheParams.subWordBits.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

