### PR TITLE
Public accessors for SRAM modules

### DIFF
--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -116,4 +116,6 @@ class AHBRAM(
     in.hresp     := Mux(!d_request || d_legal || !in.hreadyout, AHBParameters.RESP_OKAY, AHBParameters.RESP_ERROR)
     in.hrdata    := Mux(in.hreadyout, muxdata.asUInt, UInt(0))
   }
+
+  def mem = module.mem
 }

--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -36,15 +36,13 @@ class AHBRAM(
 
   lazy val module = new LazyModuleImp(this) with HasJustOneSeqMem {
     val (in, _) = node.in(0)
-    val lanes = beatBytes
     val laneDataBits = 8
     val (mem, omSRAM, omMem) = makeSinglePortedByteWriteSeqMem(
       size = BigInt(1) << mask.filter(b=>b).size,
-      lanes = lanes,
+      lanes = beatBytes,
       bits = laneDataBits)
     val eccCode = None
     val address = outer.address
-    val laneECCBits = 0
 
     parentLogicalTreeNode.map {
       case parentLTN =>

--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -36,15 +36,13 @@ class APBRAM(
 
   lazy val module = new LazyModuleImp(this) with HasJustOneSeqMem {
     val (in, _) = node.in(0)
-    val lanes = beatBytes
     val laneDataBits = 8
     val (mem, omSRAM, omMem) = makeSinglePortedByteWriteSeqMem(
       size = BigInt(1) << mask.filter(b=>b).size,
-      lanes = lanes,
+      lanes = beatBytes,
       bits = laneDataBits)
     val eccCode = None
     val address = outer.address
-    val laneECCBits = 0
 
     parentLogicalTreeNode.map {
       case parentLTN =>

--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -60,4 +60,6 @@ class APBRAM(
     in.pslverr := RegEnable(!legal, !in.penable) || (Bool(fuzzError) && LFSRNoiseMaker(1)(0))
     in.prdata  := mem.readAndHold(paddr, read).asUInt
   }
+
+  def mem = module.mem
 }

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -114,6 +114,8 @@ class AXI4RAM(
     in.r.bits.echo :<= r_echo
     in.r.bits.last := Bool(true)
   }
+
+  def mem = module.mem
 }
 
 object AXI4RAM

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -40,15 +40,13 @@ class AXI4RAM(
 
   lazy val module = new LazyModuleImp(this) with HasJustOneSeqMem {
     val (in, edgeIn) = node.in(0)
-    val lanes = beatBytes
     val laneDataBits = 8
     val (mem, omSRAM, omMem) = makeSinglePortedByteWriteSeqMem(
       size = BigInt(1) << mask.filter(b=>b).size,
-      lanes = lanes,
+      lanes = beatBytes,
       bits = laneDataBits)
     val eccCode = None
     val address = outer.address
-    val laneECCBits = 0
 
     parentLogicalTreeNode.map {
       case parentLTN =>

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -3,10 +3,11 @@
 package freechips.rocketchip.diplomacy
 
 import Chisel._
+import chisel3.SyncReadMem
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model._
-import freechips.rocketchip.util.DescribedSRAM
+import freechips.rocketchip.util.{DescribedSRAM, Code}
 
 abstract class DiplomaticSRAM(
     val address: AddressSet,
@@ -49,4 +50,37 @@ abstract class DiplomaticSRAM(
 
     (mem, omSRAM, Seq(omMem))
   }
+}
+
+/** Represents a single seq mem mapped to a single, contiguous address space
+  */
+trait HasJustOneSeqMem {
+
+  /** A reference to the chisel memory mapped to this address
+    */
+  def mem: SyncReadMem[Vec[UInt]]
+
+  /** The number of lanes the mem has i.e. the length of the mem's Vec type
+    */
+  def lanes: Int
+
+  /** The number of bits use for data in a single lane
+    *
+    * laneDataBits + laneECCBits should equal the total width of a lane
+    */
+  def laneDataBits: Int
+
+  /** The number of bits use for ECC in a single lane
+    *
+    * laneDataBits + laneECCBits should equal the total width of a lane
+    */
+  def laneECCBits: Int
+
+  /** The ecc code used by this memory
+    */
+  def eccCode: Option[Code]
+
+  /** The address set this memory is mapped to
+    */
+  def address: AddressSet
 }

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -57,26 +57,18 @@ abstract class DiplomaticSRAM(
 trait HasJustOneSeqMem {
 
   /** A reference to the chisel memory mapped to this address
+    *
+    * Each element of the Vec type is a lane
     */
   def mem: SyncReadMem[Vec[UInt]]
 
-  /** The number of lanes the mem has i.e. the length of the mem's Vec type
-    */
-  def lanes: Int
-
-  /** The number of bits use for data in a single lane
+  /** The number of bits used for data in a single lane
     *
     * laneDataBits + laneECCBits should equal the total width of a lane
     */
   def laneDataBits: Int
 
-  /** The number of bits use for ECC in a single lane
-    *
-    * laneDataBits + laneECCBits should equal the total width of a lane
-    */
-  def laneECCBits: Int
-
-  /** The ecc code used by this memory
+    /** The ecc code used by this memory
     */
   def eccCode: Option[Code]
 

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomaticobjectmodel.model._
 import freechips.rocketchip.util.DescribedSRAM
 
 abstract class DiplomaticSRAM(
-    address: AddressSet,
+    val address: AddressSet,
     beatBytes: Int,
     devName: Option[String],
     dtsCompat: Option[Seq[String]] = None)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -67,7 +67,6 @@ class TLRAM(
     val eccCode = Some(ecc.code)
     val address = outer.address
     val laneDataBits = eccBytes * 8
-    val laneECCBits = width - laneDataBits
 
     parentLogicalTreeNode.map {
       case parentLTN =>

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -17,7 +17,7 @@ class TLRAMErrors(val params: ECCParams, val addrBits: Int) extends Bundle with 
 }
 
 class TLRAM(
-    address: AddressSet,
+    val address: AddressSet,
     parentLogicalTreeNode: Option[LogicalTreeNode] = None,
     cacheable: Boolean = true,
     executable: Boolean = true,
@@ -321,6 +321,7 @@ class TLRAM(
     in.c.ready := true.B
     in.e.ready := true.B
   }
+  def mem = module.mem
 }
 
 object TLRAM

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -17,7 +17,7 @@ class TLRAMErrors(val params: ECCParams, val addrBits: Int) extends Bundle with 
 }
 
 class TLRAM(
-    val address: AddressSet,
+    address: AddressSet,
     parentLogicalTreeNode: Option[LogicalTreeNode] = None,
     cacheable: Boolean = true,
     executable: Boolean = true,


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
Add public accessors for addresses and chisel memories of `AXI4/ABP/AHB/TLRAM` so they may be used to record metadata in downstream passes.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
