### PR TITLE
Add scalafix and remove unused imports

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bucket: [1, 2, 3, 4, 5, 6, 7, 8]
+        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v2
 

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,6 @@
+rules = [
+  RemoveUnused,
+  DisableSyntax,
+  NoAutoTupling,
+  NoValInForComprehension,
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,3 +104,7 @@ jobs:
       name: Scala tests
       script:
         - ./regression/run-test-bucket 8
+    - <<: *test*
+      name: Scala tests
+      script:
+        - ./regression/run-test-bucket 9

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ To generate FPGA- or VLSI-synthesizable Verilog (output will be in `vsim/generat
     $ cd vsim
     $ make verilog
 
+To run the Scala tests (`sbt test`) or linter (`sbt scalafix`):
+
+    $ cd regression
+
+    # Scala tests
+    $ make scalatest SUITE=foo
+
+    # Scala linter, automatically modifying files to correct issues
+    $ make scalafix SUITE=foo
+
+    # Scala linter, only printing out issues
+    $ make scalafix-check SUITE=foo
+
 
 ### Keeping Your Repo Up-to-Date
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,11 @@ lazy val rocketchip = dependOnChisel(project in file("."))
       mappings in (Compile, packageBin) ++= (mappings in (`rocket-macros`, Compile, packageBin)).value,
       mappings in (Compile, packageSrc) ++= (mappings in (`rocket-macros`, Compile, packageSrc)).value,
       exportJars := true,
-      Test / unmanagedBase := baseDirectory.value / "test_lib"
+      Test / unmanagedBase := baseDirectory.value / "test_lib",
+      // Settings for scalafix
+      semanticdbEnabled := true,
+      semanticdbVersion := scalafixSemanticdb.revision,
+      scalacOptions += "-Ywarn-unused-import"
   )
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.5" )
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.21")

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -335,7 +335,18 @@ emulator-jtag-dtm-tests-64 : $(EMULATOR_JTAG_DTM_64_TEST_STAMPS)
 vsim-jtag-dtm-regression: vsim-jtag-dtm-tests-32 vsim-jtag-dtm-tests-64
 emulator-jtag-dtm-regression: emulator-jtag-dtm-tests-32 emulator-jtag-dtm-tests-64
 
-# Target to run Scalatest regressionsk 'sbt test'
+# Target to run Scalatest regressions 'sbt test'
 .PHONY: scalatest
 scalatest: stamps/other-submodules.stamp $(FIRRTL_JAR)
 	(cd $(abspath $(TOP)) && $(SBT) test)
+
+# Target to run Scalafix 'sbt scalafix'
+.PHONY: scalafix
+scalafix: stamps/other-submodules.stamp $(FIRRTL_JAR)
+	(cd $(abspath $(TOP)) && $(SBT) scalafix)
+
+# Target to run Scalafix 'sbt scalafix --check', which will not actually modify
+# Scala files.
+.PHONY: scalafix-check
+scalafix-check: stamps/other-submodules.stamp $(FIRRTL_JAR)
+	(cd $(abspath $(TOP)) && $(SBT) 'scalafix --check')

--- a/regression/run-test-bucket
+++ b/regression/run-test-bucket
@@ -94,6 +94,9 @@ case "${bucket_number}" in
   8)
     make scalatest -C regression SUITE=foo JVM_MEMORY=8G
     ;;
+  9)
+    make scalafix-check -C regression SUITE=foo JVM_MEMORY=8G
+    ;;
 
   -h|--help)
     print_usage

--- a/src/main/scala/amba/ahb/AHBLite.scala
+++ b/src/main/scala/amba/ahb/AHBLite.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.amba.ahb
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
 
 class AHBLite()(implicit p: Parameters) extends LazyModule {
   val node = AHBMasterAdapterNode(

--- a/src/main/scala/amba/ahb/Monitor.scala
+++ b/src/main/scala/amba/ahb/Monitor.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.amba.ahb
 
 import chisel3._
-import freechips.rocketchip.config.Parameters
 
 case class AHBSlaveMonitorArgs(edge: AHBEdgeParameters)
 

--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 import freechips.rocketchip.util._
-import scala.math.{min,max}
+import scala.math.min
 
 case class AHBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
   extends SinkNode(AHBImpSlave)(Seq(AHBSlavePortParameters(

--- a/src/main/scala/amba/ahb/Xbar.scala
+++ b/src/main/scala/amba/ahb/Xbar.scala
@@ -5,9 +5,7 @@ package freechips.rocketchip.amba.ahb
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
 import freechips.rocketchip.util._
-import scala.math.{min,max}
 
 class AHBFanout()(implicit p: Parameters) extends LazyModule {
   val node = new AHBFanoutNode(

--- a/src/main/scala/amba/ahb/package.scala
+++ b/src/main/scala/amba/ahb/package.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.amba
 
-import Chisel._
 import freechips.rocketchip.diplomacy._
 
 package object ahb

--- a/src/main/scala/amba/apb/Monitor.scala
+++ b/src/main/scala/amba/apb/Monitor.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.amba.apb
 
 import chisel3._
-import freechips.rocketchip.config.Parameters
 
 case class APBMonitorArgs(edge: APBEdgeParameters)
 

--- a/src/main/scala/amba/apb/RegisterRouter.scala
+++ b/src/main/scala/amba/apb/RegisterRouter.scala
@@ -7,8 +7,6 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
-import freechips.rocketchip.util._
-import scala.math.{min,max}
 
 case class APBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
   extends SinkNode(APBImp)(Seq(APBSlavePortParameters(

--- a/src/main/scala/amba/apb/Xbar.scala
+++ b/src/main/scala/amba/apb/Xbar.scala
@@ -6,8 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import freechips.rocketchip.regmapper._
-import scala.math.{min,max}
 
 class APBFanout()(implicit p: Parameters) extends LazyModule {
   val node = new APBNexusNode(

--- a/src/main/scala/amba/apb/package.scala
+++ b/src/main/scala/amba/apb/package.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.amba
 
-import Chisel._
 import freechips.rocketchip.diplomacy._
 
 package object apb

--- a/src/main/scala/amba/axi4/Buffer.scala
+++ b/src/main/scala/amba/axi4/Buffer.scala
@@ -6,7 +6,7 @@ import Chisel._
 import chisel3.util.IrrevocableIO
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import scala.math.{min,max}
+import scala.math.min
 
 // pipe is only used if a queue has depth = 1
 class AXI4Buffer(

--- a/src/main/scala/amba/axi4/Deinterleaver.scala
+++ b/src/main/scala/amba/axi4/Deinterleaver.scala
@@ -3,12 +3,11 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util.{Cat, IrrevocableIO, isPow2, log2Ceil,
+import chisel3.util.{Cat, isPow2, log2Ceil,
   log2Up, OHToUInt, Queue, QueueIO, UIntToOH}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util.{leftOR, rightOR, UIntToOH1, OH1ToOH}
-import scala.math.{min,max}
+import freechips.rocketchip.util.leftOR
 
 class AXI4Deinterleaver(maxReadBytes: Int, buffer: BufferParams = BufferParams.default)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/amba/axi4/Filter.scala
+++ b/src/main/scala/amba/axi4/Filter.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.amba.axi4
 
-import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 

--- a/src/main/scala/amba/axi4/Fragmenter.scala
+++ b/src/main/scala/amba/axi4/Fragmenter.scala
@@ -7,7 +7,6 @@ import chisel3.util.IrrevocableIO
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.math.{min,max}
 
 case object AXI4FragLast extends ControlKey[Bool]("real_last")
 case class AXI4FragLastField() extends SimpleBundleField(AXI4FragLast)(Output(Bool()), false.B)

--- a/src/main/scala/amba/axi4/IdIndexer.scala
+++ b/src/main/scala/amba/axi4/IdIndexer.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.math.{min,max}
 
 case object AXI4ExtraId extends ControlKey[UInt]("extra_id")
 case class AXI4ExtraIdField(width: Int) extends SimpleBundleField(AXI4ExtraId)(UInt(OUTPUT, width = width), UInt(0))

--- a/src/main/scala/amba/axi4/Monitor.scala
+++ b/src/main/scala/amba/axi4/Monitor.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import freechips.rocketchip.config.Parameters
 
 case class AXI4MonitorArgs(edge: AXI4EdgeParameters)
 

--- a/src/main/scala/amba/axi4/Protocol.scala
+++ b/src/main/scala/amba/axi4/Protocol.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.amba.axi4
 
 import Chisel._
-import chisel3.util.{Irrevocable, IrrevocableIO}
 
 object AXI4Parameters
 {

--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -8,7 +8,6 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 import freechips.rocketchip.util._
-import scala.math.{min,max}
 
 case object AXI4RRId extends ControlKey[UInt]("extra_id")
 case class AXI4RRIdField(width: Int) extends SimpleBundleField(AXI4RRId)(UInt(OUTPUT, width = 1 max width), UInt(0))

--- a/src/main/scala/amba/axi4/package.scala
+++ b/src/main/scala/amba/axi4/package.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.amba
 
-import Chisel._
 import freechips.rocketchip.diplomacy._
 
 package object axi4

--- a/src/main/scala/amba/axis/Buffer.scala
+++ b/src/main/scala/amba/axis/Buffer.scala
@@ -2,12 +2,9 @@
 
 package freechips.rocketchip.amba.axis
 
-import chisel3._
-import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.util._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
 
 class AXISBuffer(val params: BufferParams)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/amba/axis/Nodes.scala
+++ b/src/main/scala/amba/axis/Nodes.scala
@@ -2,8 +2,6 @@
 
 package freechips.rocketchip.amba.axis
 
-import chisel3._
-import chisel3.util._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/amba/axis/Parameters.scala
+++ b/src/main/scala/amba/axis/Parameters.scala
@@ -1,7 +1,6 @@
 // See LICENSE.SiFive for license details.
 package freechips.rocketchip.amba.axis
 
-import chisel3._
 import chisel3.util._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters

--- a/src/main/scala/amba/axis/package.scala
+++ b/src/main/scala/amba/axis/package.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.amba
 
-import chisel3._
 import freechips.rocketchip.diplomacy._
 
 package object axis

--- a/src/main/scala/devices/debug/APB.scala
+++ b/src/main/scala/devices/debug/APB.scala
@@ -1,8 +1,6 @@
 // See LICENSE.SiFive for license details.
 
 package freechips.rocketchip.devices.debug
-import chisel3._
-import chisel3.experimental._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._

--- a/src/main/scala/devices/debug/DMI.scala
+++ b/src/main/scala/devices/debug/DMI.scala
@@ -6,7 +6,6 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -15,11 +15,9 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink.{DevNullParams, TLError}
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
 import freechips.rocketchip.devices.debug.systembusaccess._
 import freechips.rocketchip.devices.tilelink.TLBusBypass
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{DebugLogicalTreeNode, LogicalModuleTree}
-import freechips.rocketchip.diplomaticobjectmodel.model._
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.DebugLogicalTreeNode
 import freechips.rocketchip.amba.apb.{APBToTL, APBFanout}
 import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
@@ -72,19 +70,16 @@ object DebugModuleAccessType extends scala.Enumeration {
   type DebugModuleAccessType = Value
   val Access8Bit, Access16Bit, Access32Bit, Access64Bit, Access128Bit = Value
 }
-import DebugModuleAccessType._
 
 object DebugAbstractCommandError extends scala.Enumeration {
   type DebugAbstractCommandError = Value
   val Success, ErrBusy, ErrNotSupported, ErrException, ErrHaltResume = Value
 }
-import DebugAbstractCommandError._
 
 object DebugAbstractCommandType extends scala.Enumeration {
   type DebugAbstractCommandType = Value
   val AccessRegister, QuickAccess  = Value
 }
-import DebugAbstractCommandType._
 
 /** Parameters exposed to the top-level design, set based on
   * external requirements, etc.
@@ -762,7 +757,6 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     import DMI_RegAddrs._
     import DsbRegAddrs._
     import DsbBusConsts._
-    import DMIConsts._
 
     //--------------------------------------------------------------
     // Sanity Check Configuration For this implementation.

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -9,7 +9,6 @@ import chisel3.experimental.chiselName
 
 import freechips.rocketchip.config._
 import freechips.rocketchip.jtag._
-import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
 
 

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -8,11 +8,9 @@ import chisel3.util._
 import chisel3.util.HasBlackBoxResource
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.amba.apb._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalModuleTree
-import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 import freechips.rocketchip.jtag._
 import freechips.rocketchip.util._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -9,15 +9,13 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
 import freechips.rocketchip.devices.debug._
 
 object SystemBusAccessState extends scala.Enumeration {
    type SystemBusAccessState = Value
    val Idle, SBReadRequest, SBWriteRequest, SBReadResponse, SBWriteResponse = Value
-}
-import SystemBusAccessState._ 
+} 
 
 object SBErrorCode extends scala.Enumeration {
   type SBErrorCode = Value
@@ -28,7 +26,6 @@ object SBErrorCode extends scala.Enumeration {
   val BadAccess  = Value(4)
   val OtherError = Value(7)
 }
-import SBErrorCode._
 
 object SystemBusAccessModule
 {
@@ -36,7 +33,6 @@ object SystemBusAccessModule
     (Seq[RegField], Seq[Seq[RegField]], Seq[Seq[RegField]]) =
   {
     import SBErrorCode._
-    import DMI_RegAddrs._
 
     val cfg = p(DebugModuleKey).get
 

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -4,12 +4,11 @@ package freechips.rocketchip.devices.tilelink
 
 import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
-import freechips.rocketchip.subsystem.{BaseSubsystem, HierarchicalLocation, HasTiles, TLBusWrapperLocation, CBUS}
+import freechips.rocketchip.subsystem.{BaseSubsystem, HierarchicalLocation, HasTiles, TLBusWrapperLocation}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
 
-import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
 
 /** Size, location and contents of the boot rom. */

--- a/src/main/scala/devices/tilelink/BusBypass.scala
+++ b/src/main/scala/devices/tilelink/BusBypass.scala
@@ -3,12 +3,9 @@
 package freechips.rocketchip.devices.tilelink
 
 import Chisel._
-import chisel3.experimental.withReset
-import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
-import scala.math.min
 
 abstract class TLBusBypassBase(beatBytes: Int, deadlock: Boolean = false, bufferError: Boolean = true, maxAtomic: Int = 16, maxTransfer: Int = 4096)
   (implicit p: Parameters) extends LazyModule

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -6,8 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
-import scala.math.min
 
 import freechips.rocketchip.diplomaticobjectmodel.{DiplomaticObjectModelAddressing, HasLogicalTreeNode}
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.devices.tilelink
 import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.subsystem.{Attachable, HierarchicalLocation, TLBusWrapperLocation, CBUS}
+import freechips.rocketchip.subsystem.{Attachable, HierarchicalLocation, TLBusWrapperLocation}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/tilelink/MasterMux.scala
+++ b/src/main/scala/devices/tilelink/MasterMux.scala
@@ -3,10 +3,9 @@
 package freechips.rocketchip.devices.tilelink
 
 import Chisel._
-import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
 
 class MasterMuxNode(uFn: Seq[TLMasterPortParameters] => TLMasterPortParameters)(implicit valName: ValName) extends TLCustomNode
 {

--- a/src/main/scala/devices/tilelink/TestRAM.scala
+++ b/src/main/scala/devices/tilelink/TestRAM.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
 
 // Do not use this for synthesis! Only for simulation.
 class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4, trackCorruption: Boolean = true)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/diplomacy/AddressDecoder.scala
+++ b/src/main/scala/diplomacy/AddressDecoder.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.diplomacy
 
 import Chisel.log2Ceil
-import scala.math.{max,min}
 
 object AddressDecoder
 {

--- a/src/main/scala/diplomacy/AddressRange.scala
+++ b/src/main/scala/diplomacy/AddressRange.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel._
 
 // Use AddressSet instead -- this is just for pretty printing
 case class AddressRange(base: BigInt, size: BigInt) extends Ordered[AddressRange]

--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.experimental.{DataMirror,IO}
 import chisel3.experimental.DataMirror.internal.chiselTypeClone
-import freechips.rocketchip.config.{Parameters,Field}
+import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util.DataToAugmentedData
 
 case class BundleBridgeParams[T <: Data](genOpt: Option[() => T])

--- a/src/main/scala/diplomacy/CloneModule.scala
+++ b/src/main/scala/diplomacy/CloneModule.scala
@@ -23,7 +23,6 @@ class ClonePorts protected[shim](elts: Data*) extends Record
 
 class CloneModule private (model: RawModule) extends BlackBox
 {
-  import CloneModule._
   override def desiredName = model.name
   val io = IO(new ClonePorts(model.getPorts.map(_.id): _*))
 }

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -3,9 +3,8 @@
 package freechips.rocketchip.diplomacy
 
 import Chisel._
-import chisel3.util.{IrrevocableIO,ReadyValidIO}
+import chisel3.util.ReadyValidIO
 import freechips.rocketchip.util.{ShiftQueue, RationalDirection, FastToSlow, AsyncQueueParams, CreditedDelay}
-import scala.reflect.ClassTag
 
 /** Options for describing the attributes of memory regions */
 object RegionType {

--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -3,8 +3,6 @@
 package freechips.rocketchip.diplomacy
 
 import Chisel.log2Ceil
-import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
-import freechips.rocketchip.diplomaticobjectmodel.model._
 
 import scala.collection.immutable.{ListMap, SortedMap}
 import scala.collection.mutable.HashMap

--- a/src/main/scala/diplomacy/ValName.scala
+++ b/src/main/scala/diplomacy/ValName.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.diplomacy
 
-import scala.language.experimental.macros
 import freechips.rocketchip.macros.ValNameImpl
 
 case class ValName(name: String)

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip
 
-import chisel3.internal.sourceinfo.{SourceInfo, SourceLine, UnlocatableSourceInfo}
+import chisel3.internal.sourceinfo.{SourceInfo, SourceLine}
 import chisel3.Data
 import freechips.rocketchip.config.Parameters
 import scala.language.implicitConversions

--- a/src/main/scala/diplomaticobjectmodel/ConstructOM.scala
+++ b/src/main/scala/diplomaticobjectmodel/ConstructOM.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.diplomaticobjectmodel
 
-import freechips.rocketchip.diplomacy.ResourceBindingsMap
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
 import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 import freechips.rocketchip.util.ElaborationArtefacts

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -5,9 +5,8 @@ package freechips.rocketchip.diplomaticobjectmodel
 import java.io.{File, FileWriter}
 
 import Chisel.{Data, Vec, log2Ceil}
-import freechips.rocketchip.diplomacy.{ AddressSet, Binding, Device, DiplomacyUtils, ResourceAddress, ResourceBindings, ResourceBindingsMap, ResourceInt, ResourceMapping, ResourcePermissions, ResourceValue, SimpleDevice}
+import freechips.rocketchip.diplomacy.{ AddressSet, Binding, Device, DiplomacyUtils, ResourceAddress, ResourceBindings, ResourceInt, ResourceMapping, ResourcePermissions, ResourceValue, SimpleDevice}
 import freechips.rocketchip.diplomaticobjectmodel.model._
-import freechips.rocketchip.util.Code
 import org.json4s.jackson.JsonMethods.pretty
 import org.json4s.jackson.Serialization
 import org.json4s.{CustomSerializer, Extraction, NoTypeHints}

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.logicaltree
 
-import freechips.rocketchip.diplomacy.BindingScope.bindingScopes
 import freechips.rocketchip.diplomacy.{BindingScope, Device, ResourceBindings, ResourceBindingsMap, SimpleDevice}
 import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -6,7 +6,7 @@ import freechips.rocketchip.diplomacy.{ResourceBindings, SimpleDevice}
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model._
 import freechips.rocketchip.rocket.{DCacheParams, HellaCache, ICache, ICacheParams}
-import freechips.rocketchip.tile.{CoreParams, RocketTile, XLen}
+import freechips.rocketchip.tile.{CoreParams, RocketTile}
 
 
 /**

--- a/src/main/scala/diplomaticobjectmodel/model/CustomISAExtensions.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/CustomISAExtensions.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.diplomaticobjectmodel.model
 
 
-import scala.collection.mutable
 
 trait OMCustomExtensionSpecification{
   def name: String

--- a/src/main/scala/diplomaticobjectmodel/model/ISASpecifications.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/ISASpecifications.scala
@@ -2,8 +2,6 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.model
 
-import freechips.rocketchip.util.BooleanToAugmentedBoolean
-import freechips.rocketchip.tile.CoreParams
 
 sealed trait PrivilegedArchitectureExtension extends OMEnum
 case object MachineLevelISA extends PrivilegedArchitectureExtension

--- a/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 
 
 import freechips.rocketchip.config._
-import freechips.rocketchip.devices.debug.{DebugModuleParams, ExportDebug}
+import freechips.rocketchip.devices.debug.ExportDebug
 
 sealed trait OMDebugInterfaceType extends OMEnum
 case object JTAG extends OMDebugInterfaceType

--- a/src/main/scala/diplomaticobjectmodel/model/OMISA.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMISA.scala
@@ -3,8 +3,7 @@
 package freechips.rocketchip.diplomaticobjectmodel.model
 
 
-import freechips.rocketchip.rocket.RocketCoreParams
-import freechips.rocketchip.tile.{CoreParams, RocketTile}
+import freechips.rocketchip.tile.RocketTile
 import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
 trait OMExtensionType extends OMEnum

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -2,9 +2,8 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.model
 
-import freechips.rocketchip.diplomacy.{ResourceBindings, ResourceBindingsMap, IdRange, IdMapEntry, IdMap}
+import freechips.rocketchip.diplomacy.{ResourceBindings, IdRange, IdMapEntry}
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
-import freechips.rocketchip.diplomaticobjectmodel.model._
 
 sealed trait PortType extends OMEnum
 case object SystemPortType extends PortType

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -3,7 +3,6 @@
 
 package freechips.rocketchip.groundtest
 
-import Chisel._
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.devices.tilelink.{CLINTKey, PLICKey}
 import freechips.rocketchip.devices.debug.{DebugModuleKey}

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -6,12 +6,10 @@ package freechips.rocketchip.groundtest
 import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.subsystem._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket.{DCache, ICacheParams, NonBlockingDCache, RocketCoreParams}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
-import scala.collection.mutable.ListBuffer
 
 trait GroundTestTileParams extends TileParams {
   val memStart: BigInt

--- a/src/main/scala/interrupts/Bundles.scala
+++ b/src/main/scala/interrupts/Bundles.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.interrupts
 
 import Chisel._
-import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 
 class SyncInterrupts(params: IntEdge) extends GenericParameterizedBundle(params)

--- a/src/main/scala/interrupts/Parameters.scala
+++ b/src/main/scala/interrupts/Parameters.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.interrupts
 
-import Chisel._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.jtag
 import scala.collection.SortedMap
 
 import chisel3._
-import chisel3.util._
 import freechips.rocketchip.config.Parameters
 
 /** JTAG signals, viewed from the master side

--- a/src/main/scala/jtag/JtagUtils.scala
+++ b/src/main/scala/jtag/JtagUtils.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.jtag
 
 import chisel3._
-import chisel3.util._
 
 class JTAGIdcodeBundle extends Bundle {
   val version = UInt(4.W)

--- a/src/main/scala/linting/LintException.scala
+++ b/src/main/scala/linting/LintException.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.linting
 
 import firrtl.FirrtlUserException
-import firrtl.ir.FileInfo
 
 /** Thrown to report all linting rule violations, according to the display options */
 case class LintException(seq: Seq[Violation], lintDisplayOptions: DisplayOptions) extends FirrtlUserException(

--- a/src/main/scala/linting/LintReporter.scala
+++ b/src/main/scala/linting/LintReporter.scala
@@ -3,13 +3,8 @@
 package freechips.rocketchip.linting
 
 import firrtl._
-import firrtl.ir._
-import firrtl.traversals.Foreachers._
-import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.{OptionsException, RegisteredLibrary, ShellOption, PreservesAll, Dependency}
+import firrtl.options.{RegisteredLibrary, ShellOption, PreservesAll, Dependency}
 import firrtl.stage.RunFirrtlTransformAnnotation
-import chisel3.experimental.ChiselAnnotation
-import scala.collection.mutable
 
 /** The final transform for all linting
   * Collects all computer lint violations and displays them

--- a/src/main/scala/linting/Linter.scala
+++ b/src/main/scala/linting/Linter.scala
@@ -2,8 +2,6 @@
 
 package freechips.rocketchip.linting
 
-import firrtl._
-import firrtl.ir._
 import chisel3.experimental.annotate
 
 /** Chisel users: Use to whitelist files

--- a/src/main/scala/prci/ClockBundles.scala
+++ b/src/main/scala/prci/ClockBundles.scala
@@ -3,7 +3,6 @@ package freechips.rocketchip.prci
 
 import chisel3._
 import freechips.rocketchip.util.RecordMap
-import scala.collection.immutable.ListMap
 
 
 class ClockBundle(val params: ClockBundleParameters) extends Bundle

--- a/src/main/scala/prci/ClockGroup.scala
+++ b/src/main/scala/prci/ClockGroup.scala
@@ -1,8 +1,6 @@
 // See LICENSE.SiFive for license details.
 package freechips.rocketchip.prci
 
-import chisel3._
-import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 

--- a/src/main/scala/prci/ClockNodes.scala
+++ b/src/main/scala/prci/ClockNodes.scala
@@ -1,7 +1,6 @@
 // See LICENSE.SiFive for license details.
 package freechips.rocketchip.prci
 
-import chisel3._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/prci/ClockParameters.scala
+++ b/src/main/scala/prci/ClockParameters.scala
@@ -1,10 +1,8 @@
 // See LICENSE.SiFive for license details.
 package freechips.rocketchip.prci
 
-import chisel3._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
-import scala.math.max
 import scala.collection.immutable.ListMap
 
 // All Clock parameters specify only the PLL values required at power-on

--- a/src/main/scala/regmapper/Annotation.scala
+++ b/src/main/scala/regmapper/Annotation.scala
@@ -2,10 +2,6 @@
 
 package freechips.rocketchip.regmapper
 
-import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
-import chisel3.RawModule
-import firrtl.annotations._
-import firrtl.{CircuitForm, CircuitState, LowForm, Transform}
 
 case class RegFieldDescSer(
   byteOffset: String,

--- a/src/main/scala/regmapper/DescribedReg.scala
+++ b/src/main/scala/regmapper/DescribedReg.scala
@@ -2,8 +2,6 @@
 package freechips.rocketchip.regmapper
 
 import Chisel._
-import chisel3.experimental._
-import chisel3.{Input, Output}
 import freechips.rocketchip.util.{AsyncResetRegVec, SimpleRegIO}
 
 object DescribedReg {

--- a/src/main/scala/regmapper/RegField.scala
+++ b/src/main/scala/regmapper/RegField.scala
@@ -7,7 +7,6 @@ import chisel3.util.{ReadyValidIO}
 
 import org.json4s.JsonDSL._
 import org.json4s.JsonAST.JValue
-import org.json4s.jackson.JsonMethods.{pretty, render}
 
 import freechips.rocketchip.util.{SimpleRegIO}
 

--- a/src/main/scala/regmapper/RegMapper.scala
+++ b/src/main/scala/regmapper/RegMapper.scala
@@ -7,7 +7,7 @@ import Chisel._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
-import chisel3.internal.sourceinfo.{SourceInfo, SourceLine}
+import chisel3.internal.sourceinfo.SourceInfo
 
 // A bus agnostic register interface to a register-based device
 

--- a/src/main/scala/regmapper/RegisterRouter.scala
+++ b/src/main/scala/regmapper/RegisterRouter.scala
@@ -5,8 +5,6 @@ package freechips.rocketchip.regmapper
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tilelink._
 
 case class RegisterRouterParams(
   name: String,

--- a/src/main/scala/rocket/ALU.scala
+++ b/src/main/scala/rocket/ALU.scala
@@ -45,7 +45,6 @@ object ALU
 }
 
 import ALU._
-import Instructions._
 
 class ALU(implicit p: Parameters) extends CoreModule()(p) {
   val io = new Bundle {

--- a/src/main/scala/rocket/Breakpoint.scala
+++ b/src/main/scala/rocket/Breakpoint.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.util.{Cat}
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.tile.{CoreModule, CoreBundle, HasCoreParameters}
+import freechips.rocketchip.tile.{CoreBundle, HasCoreParameters}
 import freechips.rocketchip.util._
 
 class BPControl(implicit p: Parameters) extends CoreBundle()(p) {

--- a/src/main/scala/rocket/Consts.scala
+++ b/src/main/scala/rocket/Consts.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.rocket.constants
 
 import Chisel._
 import freechips.rocketchip.util._
-import scala.math._
 
 trait ScalarOpConstants {
   val SZ_BR = 3

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -9,9 +9,7 @@ import chisel3.{withClock,withReset}
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.experimental.chiselName
 import freechips.rocketchip.config._
-import freechips.rocketchip.subsystem._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -7,7 +7,6 @@ import Chisel._
 import chisel3.dontTouch
 import freechips.rocketchip.amba._
 import freechips.rocketchip.config.{Parameters, Field}
-import freechips.rocketchip.subsystem._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.model.OMSRAM
 import freechips.rocketchip.tile._

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -15,8 +15,6 @@ import freechips.rocketchip.util.property._
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.dontTouch
 import chisel3.util.random.LFSR
-import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
-import freechips.rocketchip.diplomaticobjectmodel.model._
 
 case class ICacheParams(
     nSets: Int = 64,

--- a/src/main/scala/rocket/IDecode.scala
+++ b/src/main/scala/rocket/IDecode.scala
@@ -4,7 +4,6 @@
 package freechips.rocketchip.rocket
 
 import Chisel._
-import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.tile.HasCoreParameters
 import freechips.rocketchip.util._

--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.rocket
 
 import chisel3._
 import chisel3.util._
-import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -12,7 +12,6 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
 import freechips.rocketchip.scie._
-import scala.collection.immutable.ListMap
 import scala.collection.mutable.ArrayBuffer
 
 case class RocketCoreParams(

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -6,8 +6,6 @@ import Chisel._
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.subsystem.RocketTilesKey
-import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/rocket/SimpleHellaCacheIF.scala
+++ b/src/main/scala/rocket/SimpleHellaCacheIF.scala
@@ -4,7 +4,6 @@
 package freechips.rocketchip.rocket
 
 import Chisel._
-import Chisel.ImplicitConversions._
 
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util._

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -9,7 +9,7 @@ import Chisel.ImplicitConversions._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.subsystem.CacheBlockBytes
 import freechips.rocketchip.diplomacy.RegionType
-import freechips.rocketchip.tile.{XLen, CoreModule, CoreBundle}
+import freechips.rocketchip.tile.{CoreModule, CoreBundle}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._

--- a/src/main/scala/scie/SCIE.scala
+++ b/src/main/scala/scie/SCIE.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.scie
 
 import chisel3._
 import chisel3.util.{BitPat, HasBlackBoxInline}
-import chisel3.experimental.{IntParam, fromIntToIntParam}
+import chisel3.experimental.fromIntToIntParam
 
 object SCIE {
   val opcode = BitPat("b?????????????????????????0?01011")

--- a/src/main/scala/stage/phases/AddDefaultTests.scala
+++ b/src/main/scala/stage/phases/AddDefaultTests.scala
@@ -4,14 +4,13 @@ package freechips.rocketchip.stage.phases
 
 
 import chipsalliance.rocketchip.config.Parameters
-import chisel3.stage.phases.Elaborate
 import firrtl.AnnotationSeq
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.{Dependency, Phase, PreservesAll, Unserializable}
 import firrtl.options.Viewer.view
 import freechips.rocketchip.stage.RocketChipOptions
 import freechips.rocketchip.subsystem.RocketTilesKey
-import freechips.rocketchip.system.{DefaultTestSuites, RegressionTestSuite, RocketTestSuite, TestGeneration}
+import freechips.rocketchip.system.{DefaultTestSuites, RegressionTestSuite, RocketTestSuite}
 import freechips.rocketchip.tile.XLen
 import freechips.rocketchip.util.HasRocketChipStageUtils
 import freechips.rocketchip.system.DefaultTestSuites._

--- a/src/main/scala/stage/phases/GenerateArtefacts.scala
+++ b/src/main/scala/stage/phases/GenerateArtefacts.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.stage.phases
 
-import chisel3.stage.phases.Elaborate
 import firrtl.AnnotationSeq
 import firrtl.options.{Dependency, Phase, PreservesAll, StageOptions}
 import firrtl.options.Viewer.view

--- a/src/main/scala/stage/phases/GenerateFirrtlAnnos.scala
+++ b/src/main/scala/stage/phases/GenerateFirrtlAnnos.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.stage.phases
 
-import chisel3.stage.phases.{Convert, Elaborate, MaybeAspectPhase}
 import firrtl.AnnotationSeq
 import firrtl.annotations.{Annotation, DeletedAnnotation, JsonProtocol}
 import firrtl.options.Viewer.view

--- a/src/main/scala/stage/phases/GenerateTestSuiteMakefrags.scala
+++ b/src/main/scala/stage/phases/GenerateTestSuiteMakefrags.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.stage.phases
 
-import chisel3.stage.phases.Elaborate
 import firrtl.AnnotationSeq
 import firrtl.options.{Dependency, Phase, PreservesAll, StageOptions}
 import firrtl.options.Viewer.view

--- a/src/main/scala/subsystem/Attachable.scala
+++ b/src/main/scala/subsystem/Attachable.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.subsystem
 
-import scala.language.dynamics
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{LazyModule, LazyScope}
 import freechips.rocketchip.diplomaticobjectmodel.HasLogicalTreeNode

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.subsystem
 import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.HasLogicalTreeNode
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.tilelink.TLBusWrapper

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.subsystem
 
-import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.Location

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -10,7 +10,6 @@ import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tile._
-import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
 class BaseSubsystemConfig extends Config ((site, here, up) => {

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -2,11 +2,9 @@
 
 package freechips.rocketchip.subsystem
 
-import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -6,7 +6,6 @@ import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.prci._
 import freechips.rocketchip.util._
 
 case class BusAtomics(

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -2,8 +2,7 @@
 
 package freechips.rocketchip.subsystem
 
-import Chisel._
-import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.amba.axi4._

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -2,15 +2,9 @@
 
 package freechips.rocketchip.subsystem
 
-import Chisel._
-import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.{Field, Parameters}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp}
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree._
-import freechips.rocketchip.diplomaticobjectmodel.model._
-import freechips.rocketchip.prci.{ClockAdapterNode, ClockNode, ClockTempNode, ResetStretcher}
+import freechips.rocketchip.prci.{ClockNode, ClockTempNode, ResetStretcher}
 import freechips.rocketchip.tile._
 
 case class RocketCrossingParams(

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.subsystem
 
-import Chisel._
 import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -3,7 +3,6 @@
 
 package freechips.rocketchip.system
 
-import Chisel._
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.groundtest.WithTraceGen

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -2,9 +2,7 @@
 
 package freechips.rocketchip.system
 
-import Chisel._
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util.DontTouch

--- a/src/main/scala/tile/BusErrorUnit.scala
+++ b/src/main/scala/tile/BusErrorUnit.scala
@@ -7,7 +7,6 @@ import Chisel.ImplicitConversions._
 import chisel3.util.Valid
 import chisel3.DontCare
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.util._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{BusErrorLogicalTreeNode, LogicalModuleTree, LogicalTreeNode}

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -28,7 +28,6 @@ object FPConstants
   val RM_SZ = 3
   val FLAGS_SZ = 5
 }
-import FPConstants._
 
 trait HasFPUCtrlSigs {
   val ldst = Bool()

--- a/src/main/scala/tile/L1Cache.scala
+++ b/src/main/scala/tile/L1Cache.scala
@@ -4,9 +4,7 @@ package freechips.rocketchip.tile
 
 import Chisel._
 
-import freechips.rocketchip.config.{Parameters, Field}
-import freechips.rocketchip.tilelink.ClientMetadata
-import freechips.rocketchip.util._
+import freechips.rocketchip.config.Parameters
 
 trait L1CacheParams {
   def nSets:         Int

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -8,7 +8,7 @@ import chisel3.withReset
 import freechips.rocketchip.config._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{DCacheLogicalTreeNode, LogicalModuleTree, LogicalTreeNode, RocketLogicalTreeNode, UTLBLogicalTreeNode}
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{DCacheLogicalTreeNode, LogicalModuleTree, RocketLogicalTreeNode, UTLBLogicalTreeNode}
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.rocket._

--- a/src/main/scala/tilelink/Arbiter.scala
+++ b/src/main/scala/tilelink/Arbiter.scala
@@ -6,7 +6,6 @@ import chisel3._
 import chisel3.util._
 import chisel3.util.random.LFSR
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 
 object TLArbiter

--- a/src/main/scala/tilelink/Atomics.scala
+++ b/src/main/scala/tilelink/Atomics.scala
@@ -5,8 +5,6 @@ package freechips.rocketchip.tilelink
 import Chisel.{defaultCompileOptions => _, _}
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
-import TLMessages._
-import TLPermissions._
 
 class Atomics(params: TLBundleParameters) extends Module
 {

--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip.tilelink
 
-import chisel3._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.tilelink
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import scala.math.{min,max}
 
 class TLBufferNode (
   a: BufferParams,

--- a/src/main/scala/tilelink/Bundle_ACancel.scala
+++ b/src/main/scala/tilelink/Bundle_ACancel.scala
@@ -4,8 +4,6 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import scala.collection.immutable.ListMap
 

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -3,8 +3,6 @@
 package freechips.rocketchip.tilelink
 
 import Chisel._
-import chisel3.util.{ReadyValidIO}
-import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import scala.collection.immutable.ListMap
 

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.math.{min,max}
 import TLMessages._
 
 class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/CrossingHelper.scala
+++ b/src/main/scala/tilelink/CrossingHelper.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.tilelink
 
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util.RationalDirection
 
 case class TLInwardCrossingHelper(name: String, scope: LazyScope, node: TLInwardNode) {
   def apply(xing: ClockCrossingType = NoCrossing)(implicit p: Parameters): TLInwardNode = {

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -5,9 +5,7 @@ package freechips.rocketchip.tilelink
 import Chisel._
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.reflect.ClassTag
 
 class TLEdge(
   client:  TLClientPortParameters,

--- a/src/main/scala/tilelink/FIFOFixer.scala
+++ b/src/main/scala/tilelink/FIFOFixer.scala
@@ -5,9 +5,7 @@ package freechips.rocketchip.tilelink
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
-import scala.math.max
 
 class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.tilelink
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import scala.math.{min,max}
 
 class TLFilter(
   mfilter: TLFilter.ManagerFilter = TLFilter.mIdentity,

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -6,7 +6,7 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.math.{min,max}
+import scala.math.min
 
 object EarlyAck {
   sealed trait T

--- a/src/main/scala/tilelink/HintHandler.scala
+++ b/src/main/scala/tilelink/HintHandler.scala
@@ -3,12 +3,10 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import freechips.rocketchip.devices.tilelink.TLROM
-import scala.math.min
 
 // Acks Hints for managers that don't support them or Acks all Hints if !passthrough
 class TLHintHandler(passthrough: Boolean = true)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/Map.scala
+++ b/src/main/scala/tilelink/Map.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.tilelink
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import scala.math.{min,max}
 
 // Moves the AddressSets of slave devices around
 // Combine with TLFilter to remove slaves or reduce their size

--- a/src/main/scala/tilelink/Metadata.scala
+++ b/src/main/scala/tilelink/Metadata.scala
@@ -4,7 +4,6 @@
 package freechips.rocketchip.tilelink
 
 import Chisel._
-import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.rocket.constants.MemoryOpConstants
 import freechips.rocketchip.util._
 

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -4,11 +4,11 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import chisel3.internal.sourceinfo.{SourceInfo, SourceLine}
+import chisel3.internal.sourceinfo.SourceLine
 import chisel3.experimental.chiselName
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util.{HeterogeneousBag, PlusArg}
+import freechips.rocketchip.util.PlusArg
 import freechips.rocketchip.formal._
 
 case class TLMonitorArgs(edge: TLEdge)

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -7,7 +7,6 @@ import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.{AsyncQueueParams,RationalDirection}
-import scala.collection.mutable.ListBuffer
 
 case object TLMonitorBuilder extends Field[TLMonitorArgs => TLMonitorBase](args => new TLMonitor(args))
 

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -8,7 +8,6 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import scala.math.max
-import scala.reflect.ClassTag
 
 //These transfer sizes describe requests issued from masters on the A channel that will be responded by slaves on the D channel
 case class TLMasterToSlaveTransferSizes(

--- a/src/main/scala/tilelink/PatternPusher.scala
+++ b/src/main/scala/tilelink/PatternPusher.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.tilelink
 
 import Chisel._
-import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.tilelink
 
 import Chisel._
 import chisel3.RawModule
-import firrtl.annotations.ModuleName
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.model.{OMRegister, OMRegisterMap}
@@ -12,7 +11,7 @@ import freechips.rocketchip.regmapper._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
 
-import scala.math.{max, min}
+import scala.math.min
 
 class TLRegisterRouterExtraBundle(val sourceBits: Int, val sizeBits: Int) extends Bundle {
   val source = UInt(width = sourceBits max 1)

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.math.{min,max}
 
 class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -8,7 +8,6 @@ import freechips.rocketchip.amba.ahb._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.math.{min, max}
 import AHBParameters._
 
 case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImpMaster)(

--- a/src/main/scala/tilelink/ToAPB.scala
+++ b/src/main/scala/tilelink/ToAPB.scala
@@ -7,7 +7,6 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.amba.apb._
 import freechips.rocketchip.amba._
-import scala.math.{min, max}
 import APBParameters._
 
 case class TLToAPBNode()(implicit valName: ValName) extends MixedAdapterNode(TLImp, APBImp)(

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -8,7 +8,6 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.amba._
-import scala.math.{min, max}
 
 class AXI4TLStateBundle(val sourceBits: Int) extends Bundle {
   val size   = UInt(width = 4)

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -7,7 +7,6 @@ import chisel3.util.{DecoupledIO, log2Ceil, Cat, RegEnable}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import scala.math.{min,max}
 
 // innBeatBytes => the new client-facing bus width
 class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/package.scala
+++ b/src/main/scala/tilelink/package.scala
@@ -2,7 +2,6 @@
 
 package freechips.rocketchip
 
-import Chisel._
 import freechips.rocketchip.diplomacy._
 
 package object tilelink

--- a/src/main/scala/transforms/naming/RenameDesiredNames.scala
+++ b/src/main/scala/transforms/naming/RenameDesiredNames.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.transforms.naming
 
 import firrtl._
-import firrtl.annotations.{CircuitTarget, HasSerializationHints, IsModule, SingleTargetAnnotation, Target}
+import firrtl.annotations.{CircuitTarget, IsModule, SingleTargetAnnotation, Target}
 import firrtl.ir._
 import firrtl.options.Dependency
 import firrtl.transforms.DedupModules

--- a/src/main/scala/util/BundleMap.scala
+++ b/src/main/scala/util/BundleMap.scala
@@ -2,7 +2,6 @@
 package freechips.rocketchip.util
 
 import chisel3._
-import chisel3.util._
 import chisel3.experimental.DataMirror
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.HashMap

--- a/src/main/scala/util/Counters.scala
+++ b/src/main/scala/util/Counters.scala
@@ -4,7 +4,6 @@
 package freechips.rocketchip.util
 
 import Chisel._
-import scala.math.max
 
 // Produces 0-width value when counting to 1
 class ZCounter(val n: Int) {

--- a/src/main/scala/util/Crossing.scala
+++ b/src/main/scala/util/Crossing.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.util
 
 import Chisel._
-import chisel3.util.{DecoupledIO, Decoupled, Irrevocable, IrrevocableIO, ReadyValidIO}
+import chisel3.util.Decoupled
 
 class CrossingIO[T <: Data](gen: T) extends Bundle {
   // Enqueue clock domain

--- a/src/main/scala/util/DescribedSRAM.scala
+++ b/src/main/scala/util/DescribedSRAM.scala
@@ -3,14 +3,10 @@
 
 package freechips.rocketchip.util
 
-import chisel3.internal.InstanceId
 import chisel3.{Data, SyncReadMem, Vec}
 import chisel3.util.log2Ceil
-import freechips.rocketchip.amba.axi4.AXI4RAM
-import freechips.rocketchip.diplomacy.DiplomaticSRAM
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model.{OMSRAM, OMRTLModule}
-import scala.math.log10
 
 object DescribedSRAM {
   def apply[T <: Data](

--- a/src/main/scala/util/Property.scala
+++ b/src/main/scala/util/Property.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.util.property
 
 import Chisel._
-import chisel3.internal.sourceinfo.{SourceInfo, SourceLine}
+import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.util.{ReadyValidIO}
 
 sealed abstract class PropertyType(name: String) {

--- a/src/main/scala/util/ReadyValidCancel.scala
+++ b/src/main/scala/util/ReadyValidCancel.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.util
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.chiselName
-import freechips.rocketchip.util._
 
 /** A [[Bundle]] that adds `earlyValid` and `lateCancel` bits to some data.
   * This indicates that the user expects a "ValidCancel" interface between a producer and a consumer.

--- a/src/main/scala/util/SynchronizerReg.scala
+++ b/src/main/scala/util/SynchronizerReg.scala
@@ -31,7 +31,6 @@ object SynchronizerResetType extends Enumeration {
   val NonSync, Inferred, Sync, Async = Value
 }
 
-import SynchronizerResetType._
 
 private class SynchronizerPrimitiveShiftReg(
   sync: Int,

--- a/src/main/scala/util/TraceCoreInterface.scala
+++ b/src/main/scala/util/TraceCoreInterface.scala
@@ -4,9 +4,7 @@
 package freechips.rocketchip.util
 
 import chisel3._
-import chisel3.util._
 import chisel3.experimental.ChiselEnum
-import freechips.rocketchip.tile._
 
 // Definitions for Trace core Interface defined in RISC-V Processor Trace Specification V1.0
 object TraceItype extends ChiselEnum {


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

---

## Changes and motivation

This PR is two parts:

1. https://github.com/chipsalliance/rocket-chip/commit/0a5e2e8ec5e2230311641f00ad2dd0cfc527eebb - adding [Scalafix](https://scalacenter.github.io/scalafix/) to our SBT project/running it in CI, and
2. https://github.com/chipsalliance/rocket-chip/commit/66a60e55a18fae859730b01c04450b2da3630e19 - running Scalafix to automatically delete any unused imports.

My main motivation for adding Scalalint is solely to get rid of unused imports and to prevent future unused imports from being left into the codebase. In my experience with this in other projects in other languages (Python, JavaScript), this is not a controversial thing to add as a lint check and enforce unconditionally. However, I don't have a good sense of whether this kind of thing is normal or uncontroversial in a Scala project.

My main reason for wanting to get rid of the unnecessary imports is so that it becomes easier to reason about the actual internal architecture of the rocket-chip codebase, since the unnecessary imports make it much more difficult to tell which parts of the codebase depend on which other parts. As a vim user who is not using a language server (yet), I understand that my experience here is not representative of a typical Scala programmer, since IDEs normally make code navigation easier.

That said, I hope this is not too much of a burden for developers, since this will mean that unused imports will be enforced by CI and you will be required to delete them before you can pass CI checks.

## Question about rollout

Normally I do not like enabling and enforcing new lint rules on large, preexisting projects, since it often ends up touching a large number of files and can cause merge conflicts with other open PRs. For this PR, however, I think that because it's restricted to just unused imports, all the merge conflicts will be located in a single place at the top of any affected file, rather than potentially spanning the entirety of a file.

I'm open to a much more gradual rollout strategy, however, where we whitelist the existing violations but enforce the rule for any files that are not currently in violation.

## Other lint rules
Scalafix comes with [7 builtin rules](https://scalacenter.github.io/scalafix/docs/rules/overview.html), but I've only enabled four of them here. I found no violations of [`DisableSyntax`](https://scalacenter.github.io/scalafix/docs/rules/DisableSyntax.html), [`NoAutoTupling`](https://scalacenter.github.io/scalafix/docs/rules/NoAutoTupling.html), or [`NoValInForComprehension`](https://scalacenter.github.io/scalafix/docs/rules/NoValInForComprehension.html), so I decided to enable those checks.

[`RemoveUnused`](https://scalacenter.github.io/scalafix/docs/rules/RemoveUnused.html) obviously has violations, but I enabled the rule and fixed the violations in this PR.

The remaining 3 rules do have violations in this codebase, and some of them I think may not work well in the Chisel DSL. I _think_ [`LeakingImplicitClassVal`](https://scalacenter.github.io/scalafix/docs/rules/LeakingImplicitClassVal.html) and [`ProcedureSyntax`](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html) are probably worth enabling, but I don't feel that I know Scala and Chisel well enough to have a sense of whether these should unconditionally enforced.

[`ExplicitResultTypes`](https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html) gave me the most trouble. Although it offers a lot of customizability, I couldn't really figure out how to configure it such that it doesn't touch almost every file in the codebase. One specific scenario that I saw over and over in our codebase but could not figure out how to whitelist was defining a method or a `val` whose right-hand side is a single expression involving a case class factory method (i.e. `apply()`). For example, it would want every instance of `def foo = Bar()` to be rewritten as `def foo: Bar = Bar()`.

I can understand why it wants to do this; the case class factory is just a convention, and it can't know whether you are just using it as shorthand for `new Bar()` or if it is actually doing something else. The lint rule has a way to configure it to ignore simple definitions that just involve `new MyClass()`, but not for case class factory methods.