### PR TITLE
Enable LeakingImplicitClassVal lint rule

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,6 +1,7 @@
 rules = [
   RemoveUnused,
   DisableSyntax,
+  LeakingImplicitClassVal,
   NoAutoTupling,
   NoValInForComprehension,
 ]

--- a/src/main/scala/amba/axi4/package.scala
+++ b/src/main/scala/amba/axi4/package.scala
@@ -10,7 +10,7 @@ package object axi4
   type AXI4OutwardNode = OutwardNodeHandle[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
   type AXI4InwardNode = InwardNodeHandle[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
 
-  implicit class AXI4ClockDomainCrossing(val x: HasClockDomainCrossing) extends AnyVal {
+  implicit class AXI4ClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
     def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardCrossingHelper(valName.name, x, n)
     def crossOut(n: AXI4OutwardNode)(implicit valName: ValName) = AXI4OutwardCrossingHelper(valName.name, x, n)
     def cross(n: AXI4InwardNode) (implicit valName: ValName) = crossIn(n)

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -195,7 +195,7 @@ package object diplomacy
     }
   }
 
-  implicit class BigIntHexContext(val sc: StringContext) extends AnyVal {
+  implicit class BigIntHexContext(private val sc: StringContext) extends AnyVal {
     def x(args: Any*): BigInt = {
       val orig = sc.s(args: _*)
       BigInt(orig.replace("_", ""), 16)

--- a/src/main/scala/interrupts/package.scala
+++ b/src/main/scala/interrupts/package.scala
@@ -11,7 +11,7 @@ package object interrupts
   type IntOutwardNode = OutwardNodeHandle[IntSourcePortParameters, IntSinkPortParameters, IntEdge, Vec[Bool]]
   type IntNode = SimpleNodeHandle[IntSourcePortParameters, IntSinkPortParameters, IntEdge, Vec[Bool]]
 
-  implicit class IntClockDomainCrossing(val x: HasClockDomainCrossing) extends AnyVal {
+  implicit class IntClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
     def crossIn (n: IntInwardNode) (implicit valName: ValName) = IntInwardCrossingHelper(valName.name, x, n)
     def crossOut(n: IntOutwardNode)(implicit valName: ValName) = IntOutwardCrossingHelper(valName.name, x, n)
     def cross(n: IntInwardNode) (implicit valName: ValName) = crossIn(n)

--- a/src/main/scala/tilelink/package.scala
+++ b/src/main/scala/tilelink/package.scala
@@ -16,7 +16,7 @@ package object tilelink
   type TLClientParameters = TLMasterParameters
   type TLClientPortParameters = TLMasterPortParameters
 
-  implicit class TLClockDomainCrossing(val x: HasClockDomainCrossing) extends AnyVal {
+  implicit class TLClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
     def crossIn (n: TLInwardNode) (implicit valName: ValName) = TLInwardCrossingHelper (valName.name, x, n)
     def crossOut(n: TLOutwardNode)(implicit valName: ValName) = TLOutwardCrossingHelper(valName.name, x, n)
     def cross(n: TLInwardNode) (implicit valName: ValName) = crossIn(n)

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -11,13 +11,13 @@ package object util {
     def unzip = (x.map(_._1), x.map(_._2))
   }
 
-  implicit class UIntIsOneOf(val x: UInt) extends AnyVal {
+  implicit class UIntIsOneOf(private val x: UInt) extends AnyVal {
     def isOneOf(s: Seq[UInt]): Bool = s.map(x === _).orR
   
     def isOneOf(u1: UInt, u2: UInt*): Bool = isOneOf(u1 +: u2.toSeq)
   }
 
-  implicit class SeqToAugmentedSeq[T <: Data](val x: Seq[T]) extends AnyVal {
+  implicit class SeqToAugmentedSeq[T <: Data](private val x: Seq[T]) extends AnyVal {
     def apply(idx: UInt): T = {
       if (x.size <= 1) {
         x.head
@@ -53,7 +53,7 @@ package object util {
   }
 
   // allow bitwise ops on Seq[Bool] just like UInt
-  implicit class SeqBoolBitwiseOps(val x: Seq[Bool]) extends AnyVal {
+  implicit class SeqBoolBitwiseOps(private val x: Seq[Bool]) extends AnyVal {
     def & (y: Seq[Bool]): Seq[Bool] = (x zip y).map { case (a, b) => a && b }
     def | (y: Seq[Bool]): Seq[Bool] = padZip(x, y).map { case (a, b) => a || b }
     def ^ (y: Seq[Bool]): Seq[Bool] = padZip(x, y).map { case (a, b) => a ^ b }
@@ -67,7 +67,7 @@ package object util {
     private def padZip(y: Seq[Bool], z: Seq[Bool]): Seq[(Bool, Bool)] = y.padTo(z.size, false.B) zip z.padTo(y.size, false.B)
   }
 
-  implicit class DataToAugmentedData[T <: Data](val x: T) extends AnyVal {
+  implicit class DataToAugmentedData[T <: Data](private val x: T) extends AnyVal {
     def holdUnless(enable: Bool): T = Mux(enable, x, RegEnable(x, enable))
 
     def getElements: Seq[Element] = x match {
@@ -76,11 +76,11 @@ package object util {
     }
   }
 
-  implicit class SeqMemToAugmentedSeqMem[T <: Data](val x: SeqMem[T]) extends AnyVal {
+  implicit class SeqMemToAugmentedSeqMem[T <: Data](private val x: SeqMem[T]) extends AnyVal {
     def readAndHold(addr: UInt, enable: Bool): T = x.read(addr, enable) holdUnless RegNext(enable)
   }
 
-  implicit class StringToAugmentedString(val x: String) extends AnyVal {
+  implicit class StringToAugmentedString(private val x: String) extends AnyVal {
     /** converts from camel case to to underscores, also removing all spaces */
     def underscore: String = x.tail.foldLeft(x.headOption.map(_.toLower + "") getOrElse "") {
       case (acc, c) if c.isUpper => acc + "_" + c.toLower
@@ -105,7 +105,7 @@ package object util {
   implicit def uintToBitPat(x: UInt): BitPat = BitPat(x)
   implicit def wcToUInt(c: WideCounter): UInt = c.value
 
-  implicit class UIntToAugmentedUInt(val x: UInt) extends AnyVal {
+  implicit class UIntToAugmentedUInt(private val x: UInt) extends AnyVal {
     def sextTo(n: Int): UInt = {
       require(x.getWidth <= n)
       if (x.getWidth == n) x
@@ -187,19 +187,19 @@ package object util {
     def ## (y: Option[UInt]): UInt = y.map(x ## _).getOrElse(x)
   }
 
-  implicit class OptionUIntToAugmentedOptionUInt(val x: Option[UInt]) extends AnyVal {
+  implicit class OptionUIntToAugmentedOptionUInt(private val x: Option[UInt]) extends AnyVal {
     def ## (y: UInt): UInt = x.map(_ ## y).getOrElse(y)
     def ## (y: Option[UInt]): Option[UInt] = x.map(_ ## y)
   }
 
-  implicit class BooleanToAugmentedBoolean(val x: Boolean) extends AnyVal {
+  implicit class BooleanToAugmentedBoolean(private val x: Boolean) extends AnyVal {
     def toInt: Int = if (x) 1 else 0
 
     // this one's snagged from scalaz
     def option[T](z: => T): Option[T] = if (x) Some(z) else None
   }
 
-  implicit class IntToAugmentedInt(val x: Int) extends AnyVal {
+  implicit class IntToAugmentedInt(private val x: Int) extends AnyVal {
     // exact log2
     def log2: Int = {
       require(isPow2(x))
@@ -294,7 +294,7 @@ package object util {
   * For example in order to tap the connection to monitor traffic on an existing connection.
   * In that case you can do 'm :<= p' and 'p :=> m'.
   */
-  implicit class EnhancedChisel3Assign[T <: Data](val x: T) extends AnyVal {
+  implicit class EnhancedChisel3Assign[T <: Data](private val x: T) extends AnyVal {
     /** Assign all output fields of x from y; note that the actual direction of x is irrelevant */
     def :<= (y: T): Unit = FixChisel3.assignL(x, y)
     /** Assign all input fields of y from x; note that the actual direction of y is irrelevant */


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

---

Followup to https://github.com/chipsalliance/rocket-chip/pull/2648.

This PR enables the [`LeakingImplicitClassVal `](https://scalacenter.github.io/scalafix/docs/rules/LeakingImplicitClassVal.html) lint rule in Scalafix. In Scala, `val` constructor parameters are part of the public interface of a class. However, in most cases, `implicit` classes do not intend to publicly expose the `val` parameter, as the parameter is generally only there to assign an internal name to the object being implicitly converted to another type. This lint rule will require that all `val` parameters to `implicit class`es be explicitly marked as `private`.

To the Scala experts: please take a look at the changes to the code required by this new lint rule and let me know if this is a reasonable rule to enable in rocket-chip.