### PR TITLE
Enable ProcedureSyntax lint rule

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,4 +3,5 @@ rules = [
   DisableSyntax,
   NoAutoTupling,
   NoValInForComprehension,
+  ProcedureSyntax,
 ]

--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -37,7 +37,7 @@ class AHBSlaveBundle(val params: AHBBundleParameters) extends Bundle
   val hmaster   = if (params.lite) None else Some(UInt(OUTPUT, width = 4))
   val hsplit    = if (params.lite) None else Some(UInt(INPUT, width = 16))
 
-  def tieoff() {
+  def tieoff(): Unit = {
     hrdata.dir match {
       case INPUT =>
         hreadyout := Bool(false)
@@ -94,7 +94,7 @@ class AHBMasterBundle(val params: AHBBundleParameters) extends Bundle
   val hresp   = UInt(INPUT, width = params.hrespBits)
   val hrdata  = UInt(INPUT, width = params.dataBits)
 
-  def tieoff() {
+  def tieoff(): Unit = {
     hrdata.dir match {
       case INPUT =>
         hgrant.foreach { _ := Bool(false) }

--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -16,7 +16,7 @@ object AHBImpSlave extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortPa
   def bundle(e: AHBEdgeParameters) = AHBSlaveBundle(e.bundle)
   def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
 
-  override def monitor(bundle: AHBSlaveBundle, edge: AHBEdgeParameters) {
+  override def monitor(bundle: AHBSlaveBundle, edge: AHBEdgeParameters): Unit = {
     edge.params.lift(AHBSlaveMonitorBuilder).foreach { builder =>
       val monitor = Module(builder(AHBSlaveMonitorArgs(edge)))
       monitor.io.in := bundle
@@ -38,7 +38,7 @@ object AHBImpMaster extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortP
   def bundle(e: AHBEdgeParameters) = AHBMasterBundle(e.bundle)
   def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
 
-  override def monitor(bundle: AHBMasterBundle, edge: AHBEdgeParameters) {
+  override def monitor(bundle: AHBMasterBundle, edge: AHBEdgeParameters): Unit = {
     edge.params.lift(AHBMasterMonitorBuilder).foreach { builder =>
       val monitor = Module(builder(AHBMasterMonitorArgs(edge)))
       monitor.io.in := bundle

--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -116,5 +116,5 @@ trait HasAHBControlRegMap { this: RegisterRouter =>
     executable = executable)
 
   // Internally, this function should be used to populate the control port with registers
-  protected def regmap(mapping: RegField.Map*) { controlNode.regmap(mapping:_*) }
+  protected def regmap(mapping: RegField.Map*): Unit = { controlNode.regmap(mapping:_*) }
 }

--- a/src/main/scala/amba/apb/Bundles.scala
+++ b/src/main/scala/amba/apb/Bundles.scala
@@ -25,7 +25,7 @@ class APBBundle(val params: APBBundleParameters) extends Bundle
   val prdata    = UInt(INPUT, width = params.dataBits)
   val pduser    = BundleMap(params.responseFields)
 
-  def tieoff() {
+  def tieoff(): Unit = {
     pready.dir match {
       case INPUT =>
         pready  := Bool(false)

--- a/src/main/scala/amba/apb/Nodes.scala
+++ b/src/main/scala/amba/apb/Nodes.scala
@@ -15,7 +15,7 @@ object APBImp extends SimpleNodeImp[APBMasterPortParameters, APBSlavePortParamet
   def bundle(e: APBEdgeParameters) = APBBundle(e.bundle)
   def render(e: APBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, (e.slave.beatBytes * 8).toString)
 
-  override def monitor(bundle: APBBundle, edge: APBEdgeParameters) {
+  override def monitor(bundle: APBBundle, edge: APBEdgeParameters): Unit = {
     edge.params.lift(APBMonitorBuilder).foreach { builder =>
       val monitor = Module(builder(APBMonitorArgs(edge)))
       monitor.io.in := bundle

--- a/src/main/scala/amba/apb/RegisterRouter.scala
+++ b/src/main/scala/amba/apb/RegisterRouter.scala
@@ -97,5 +97,5 @@ trait HasAPBControlRegMap { this: RegisterRouter =>
     executable = executable)
 
   // Internally, this function should be used to populate the control port with registers
-  protected def regmap(mapping: RegField.Map*) { controlNode.regmap(mapping:_*) }
+  protected def regmap(mapping: RegField.Map*): Unit = { controlNode.regmap(mapping:_*) }
 }

--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -75,7 +75,7 @@ class AXI4Bundle(params: AXI4BundleParameters) extends AXI4BundleBase(params)
   val ar = Irrevocable(new AXI4BundleAR(params))
   val r  = Irrevocable(new AXI4BundleR (params)).flip
 
-  def tieoff() {
+  def tieoff(): Unit = {
     ar.ready.dir match {
       case INPUT =>
         ar.ready := Bool(false)

--- a/src/main/scala/amba/axi4/Delayer.scala
+++ b/src/main/scala/amba/axi4/Delayer.scala
@@ -15,7 +15,7 @@ class AXI4Delayer(q: Double)(implicit p: Parameters) extends LazyModule
   require (0.0 <= q && q < 1)
 
   lazy val module = new LazyModuleImp(this) {
-    def feed[T <: Data](sink: IrrevocableIO[T], source: IrrevocableIO[T], noise: T) {
+    def feed[T <: Data](sink: IrrevocableIO[T], source: IrrevocableIO[T], noise: T): Unit = {
       // irrevocable requires that we not lower valid
       val hold = RegInit(Bool(false))
       when (sink.valid)  { hold := Bool(true) }
@@ -28,7 +28,7 @@ class AXI4Delayer(q: Double)(implicit p: Parameters) extends LazyModule
       when (!sink.valid) { sink.bits := noise }
     }
 
-    def anoise[T <: AXI4BundleA](bits: T) {
+    def anoise[T <: AXI4BundleA](bits: T): Unit = {
       bits.id    := LFSRNoiseMaker(bits.params.idBits)
       bits.addr  := LFSRNoiseMaker(bits.params.addrBits)
       bits.len   := LFSRNoiseMaker(bits.params.lenBits)

--- a/src/main/scala/amba/axi4/Nodes.scala
+++ b/src/main/scala/amba/axi4/Nodes.scala
@@ -16,7 +16,7 @@ object AXI4Imp extends SimpleNodeImp[AXI4MasterPortParameters, AXI4SlavePortPara
   def bundle(e: AXI4EdgeParameters) = AXI4Bundle(e.bundle)
   def render(e: AXI4EdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label  = (e.slave.beatBytes * 8).toString)
 
-  override def monitor(bundle: AXI4Bundle, edge: AXI4EdgeParameters) {
+  override def monitor(bundle: AXI4Bundle, edge: AXI4EdgeParameters): Unit = {
     edge.params.lift(AXI4MonitorBuilder).foreach { builder =>
       val monitor = Module(builder(AXI4MonitorArgs(edge)))
       monitor.io.in := bundle

--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -133,5 +133,5 @@ trait HasAXI4ControlRegMap { this: RegisterRouter =>
   val controlXing: AXI4InwardCrossingHelper = this.crossIn(controlNode)
 
   // Internally, this function should be used to populate the control port with registers
-  protected def regmap(mapping: RegField.Map*) { controlNode.regmap(mapping:_*) }
+  protected def regmap(mapping: RegField.Map*): Unit = { controlNode.regmap(mapping:_*) }
 }

--- a/src/main/scala/amba/axi4/Xbar.scala
+++ b/src/main/scala/amba/axi4/Xbar.scala
@@ -235,7 +235,7 @@ object AXI4Xbar
 
 object AXI4Arbiter
 {
-  def apply[T <: Data](policy: TLArbiter.Policy)(sink: IrrevocableIO[T], sources: IrrevocableIO[T]*) {
+  def apply[T <: Data](policy: TLArbiter.Policy)(sink: IrrevocableIO[T], sources: IrrevocableIO[T]*): Unit = {
     if (sources.isEmpty) {
       sink.valid := Bool(false)
     } else {

--- a/src/main/scala/amba/axis/Bundles.scala
+++ b/src/main/scala/amba/axis/Bundles.scala
@@ -20,7 +20,7 @@ case class AXISKeepField(width: Int) extends SimpleBundleField(AXISKeep)(Output(
 case class AXISStrbField(width: Int) extends SimpleBundleField(AXISStrb)(Output(UInt(width.W)), ~0.U(width.W))
 case class AXISDataField(width: Int) extends BundleField(AXISData) {
   def data = Output(UInt(width.W))
-  def default(x: UInt) { x := DontCare }
+  def default(x: UInt): Unit = { x := DontCare }
 }
 
 class AXISBundleBits(val params: AXISBundleParameters) extends BundleMap(AXISBundle.keys(params)) {

--- a/src/main/scala/amba/axis/Xbar.scala
+++ b/src/main/scala/amba/axis/Xbar.scala
@@ -72,7 +72,7 @@ object AXISXbar
   def mapInputIds (ports: Seq[AXISMasterPortParameters]) = TLXbar.assignRanges(ports.map(_.endSourceId))
   def mapOutputIds(ports: Seq[AXISSlavePortParameters]) = TLXbar.assignRanges(ports.map(_.endDestinationId))
 
-  def arbitrate(policy: TLArbiter.Policy)(sink: AXISBundle, sources: Seq[AXISBundle]) {
+  def arbitrate(policy: TLArbiter.Policy)(sink: AXISBundle, sources: Seq[AXISBundle]): Unit = {
     if (sources.isEmpty) {
       sink.valid := false.B
     } else if (sources.size == 1) {

--- a/src/main/scala/amba/package.scala
+++ b/src/main/scala/amba/package.scala
@@ -19,7 +19,7 @@ package object amba {
   case object AMBAProt extends ControlKey[AMBAProtBundle]("amba_prot")
   case class AMBAProtField() extends BundleField(AMBAProt) {
     def data = Output(new AMBAProtBundle)
-    def default(x: AMBAProtBundle) {
+    def default(x: AMBAProtBundle): Unit = {
       x.bufferable := false.B
       x.modifiable := false.B
       x.readalloc  := false.B
@@ -34,6 +34,6 @@ package object amba {
   case object AMBACorrupt extends DataKey[Bool]("corrupt")
   case class AMBACorruptField() extends BundleField(AMBACorrupt) {
     def data = Output(Bool())
-    def default(x: Bool) { x := false.B }
+    def default(x: Bool): Unit = { x := false.B }
   }
 }

--- a/src/main/scala/diplomacy/FixedClockResource.scala
+++ b/src/main/scala/diplomacy/FixedClockResource.scala
@@ -13,7 +13,7 @@ class FixedClockResource(val name: String, val freqMHz: Double, val prefix: Stri
         "compatible"         -> Seq(ResourceString("fixed-clock"))))
   }
 
-  def bind(dev: Device) {
+  def bind(dev: Device): Unit = {
     ResourceBinding { Resource(dev, "clocks").bind(ResourceReference(device.label)) }
   }
 }

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -141,7 +141,7 @@ abstract class LazyModule()(implicit val p: Parameters) {
     * @param buf String buffer to write to.
     * @param pad Padding as prefix for indentation purposes.
     */
-  private def nodesGraphML(buf: StringBuilder, pad: String) {
+  private def nodesGraphML(buf: StringBuilder, pad: String): Unit = {
     buf ++= s"""$pad<node id=\"$index\">\n"""
     buf ++= s"""$pad  <data key=\"n\"><y:ShapeNode><y:NodeLabel modelName=\"sides\" modelPosition=\"w\" rotationAngle=\"270.0\">$instanceName</y:NodeLabel><y:BorderStyle type=\"${if (shouldBeInlined) "dotted" else "line"}\"/></y:ShapeNode></data>\n"""
     buf ++= s"""$pad  <data key=\"d\">$moduleName ($pathName)</data>\n"""
@@ -162,7 +162,7 @@ abstract class LazyModule()(implicit val p: Parameters) {
     * @param buf String buffer to write to.
     * @param pad Padding as prefix for indentation purposes.
     */
-  private def edgesGraphML(buf: StringBuilder, pad: String) {
+  private def edgesGraphML(buf: StringBuilder, pad: String): Unit = {
     nodes.filter(!_.omitGraphML) foreach { n =>
       n.outputs.filter(!_._1.omitGraphML).foreach { case (o, edge) =>
         val RenderedEdge(colour, label, flipped) = edge
@@ -328,7 +328,7 @@ sealed trait LazyModuleImpLike extends RawModule {
     * Ask each [[BaseNode]] in [[wrapper.nodes]] to call [[BaseNode.finishInstantiate]].
     * Annotate this module to tell FIRRTL if it should be inlined.
     */
-  protected[diplomacy] def finishInstantiate() {
+  protected[diplomacy] def finishInstantiate(): Unit = {
     wrapper.nodes.reverse.foreach {
       _.finishInstantiate()
     }
@@ -538,7 +538,7 @@ object InModuleBody {
     val out = new ModuleValue[T] {
       var result: Option[T] = None
 
-      def execute() {
+      def execute(): Unit = {
         result = Some(body)
       }
 

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -639,7 +639,7 @@ trait InwardNode[DI, UI, BI <: Data] extends BaseNode {
     * @param node    the [[OutwardNode]] to bind to this [[InwardNode]].
     * @param binding [[NodeBinding]] type.
     */
-  protected[diplomacy] def iPush(index: Int, node: OutwardNode[DI, UI, BI], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo) {
+  protected[diplomacy] def iPush(index: Int, node: OutwardNode[DI, UI, BI], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo): Unit = {
     val info = sourceLine(sourceInfo, " at ", "")
     require (!iRealized,
       s"""Diplomacy has detected a problem in your code:
@@ -732,7 +732,7 @@ trait OutwardNode[DO, UO, BO <: Data] extends BaseNode {
     * @param node    [[InwardNode]] to bind to.
     * @param binding Binding type.
     */
-  protected[diplomacy] def oPush(index: Int, node: InwardNode [DO, UO, BO], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo) {
+  protected[diplomacy] def oPush(index: Int, node: InwardNode [DO, UO, BO], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo): Unit = {
     val info = sourceLine(sourceInfo, " at ", "")
     require (!oRealized,
       s"""Diplomacy has detected a problem in your code:
@@ -1277,7 +1277,7 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
   }
 
   /** Connects the outward part of a node with the inward part of this node. */
-  protected[diplomacy] def bind(h: OutwardNode[DI, UI, BI], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo) {
+  protected[diplomacy] def bind(h: OutwardNode[DI, UI, BI], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo): Unit = {
     val x = this // x := y
     val y = h
     val info = sourceLine(sourceInfo, " at ", "")

--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -90,7 +90,7 @@ abstract class DeviceSnippet extends Device
 object Device
 {
   private var index: Int = 0
-  def skipIndexes(x: Int) { index += x }
+  def skipIndexes(x: Int): Unit = { index += x }
 }
 
 /** A trait for devices that generate interrupts. */
@@ -257,11 +257,11 @@ class MemoryDevice extends Device with DeviceRegName
 
 case class Resource(owner: Device, key: String)
 {
-  def bind(user: Device, value: ResourceValue) {
+  def bind(user: Device, value: ResourceValue): Unit = {
     val scope = BindingScope.active.get
     scope.resourceBindings = (this, Some(user), value) +: scope.resourceBindings
   }
-  def bind(value: ResourceValue) {
+  def bind(value: ResourceValue): Unit = {
     val scope = BindingScope.active.get
     scope.resourceBindings = (this, None, value) +: scope.resourceBindings
   }
@@ -403,7 +403,7 @@ object ResourceBinding
   /** Add a resource callback function to the callback list BindingScope.resourceBindingFns.
     * @param block      the callback function to be added.
     */
-  def apply(block: => Unit) {
+  def apply(block: => Unit): Unit = {
     val scope = BindingScope.find()
     require (scope.isDefined, "ResourceBinding must be called from within a BindingScope")
     scope.get.resourceBindingFns = { () => block } +: scope.get.resourceBindingFns

--- a/src/main/scala/formal/FormalUtils.scala
+++ b/src/main/scala/formal/FormalUtils.scala
@@ -130,7 +130,7 @@ object SourceGet {
 object ResetUtils {
   def inactive_output_override[T <: Data](inactive_length: Int)
                                          (sigs: T,
-                                          override_assn: (T)=>Unit) {
+                                          override_assn: (T)=>Unit): Unit = {
     require(inactive_length >= 0)
 
     if(inactive_length>0) {

--- a/src/main/scala/jtag/JtagShifter.scala
+++ b/src/main/scala/jtag/JtagShifter.scala
@@ -21,7 +21,7 @@ class ShifterIO extends Bundle {
 
   /** Sets a output shifter IO's control signals from a input shifter IO's control signals.
     */
-  def chainControlFrom(in: ShifterIO) {
+  def chainControlFrom(in: ShifterIO): Unit = {
     shift := in.shift
     capture := in.capture
     update := in.update

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -244,7 +244,7 @@ object JtagTapGenerator {
       controllerInternal.io.dataChainIn := bypassChain.io.chainOut
     }
 
-    def mapInSelect(x: (Chain, Bool)) {
+    def mapInSelect(x: (Chain, Bool)): Unit = {
       val (chain, select) = x
       when (select) {
         chain.io.chainIn := controllerInternal.io.dataChainOut

--- a/src/main/scala/rocket/Events.scala
+++ b/src/main/scala/rocket/Events.scala
@@ -14,11 +14,11 @@ class EventSet(val gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bo
     hits := events.map(_._2())
     gate(mask, hits.asUInt)
   }
-  def dump() {
+  def dump(): Unit = {
     for (((name, _), i) <- events.zipWithIndex)
       when (check(1.U << i)) { printf(s"Event $name\n") }
   }
-  def withCovers {
+  def withCovers: Unit = {
     events.zipWithIndex.foreach {
       case ((name, func), i) => cover(gate((1.U << i), (func() << i)), name)
     }
@@ -71,7 +71,7 @@ class SuperscalarEventSets(val eventSets: Seq[(Seq[EventSet], (UInt, UInt) => UI
 
   def toScalarEventSets: EventSets = new EventSets(eventSets.map(_._1.head))
 
-  def cover() { eventSets.foreach(_._1.foreach(_.withCovers)) }
+  def cover(): Unit = { eventSets.foreach(_._1.foreach(_.withCovers)) }
 
   private def decode(counter: UInt): (UInt, UInt) = {
     require(eventSets.size <= (1 << maxEventSetIdBits))

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -35,7 +35,7 @@ class PMPReg(implicit p: Parameters) extends CoreBundle()(p) {
   val cfg = new PMPConfig
   val addr = UInt((paddrBits - PMP.lgAlign).W)
 
-  def reset() {
+  def reset(): Unit = {
     cfg.a := 0
     cfg.l := 0
   }

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -114,7 +114,7 @@ class TLBEntry(val nSectors: Int, val superpage: Boolean, val superpageOnly: Boo
     }
   }
 
-  def insert(tag: UInt, level: UInt, entry: TLBEntryData) {
+  def insert(tag: UInt, level: UInt, entry: TLBEntryData): Unit = {
     this.tag := tag
     this.level := level.extract(log2Ceil(pgLevels - superpageOnly.toInt)-1, 0)
 
@@ -123,8 +123,8 @@ class TLBEntry(val nSectors: Int, val superpage: Boolean, val superpageOnly: Boo
     data(idx) := entry.asUInt
   }
 
-  def invalidate() { valid.foreach(_ := false) }
-  def invalidateVPN(vpn: UInt) {
+  def invalidate(): Unit = { valid.foreach(_ := false) }
+  def invalidateVPN(vpn: UInt): Unit = {
     if (superpage) {
       when (hit(vpn)) { invalidate() }
     } else {
@@ -138,7 +138,7 @@ class TLBEntry(val nSectors: Int, val superpage: Boolean, val superpageOnly: Boo
       }
     }
   }
-  def invalidateNonGlobal() {
+  def invalidateNonGlobal(): Unit = {
     for ((v, e) <- valid zip entry_data)
       when (!e.g) { v := false }
   }

--- a/src/main/scala/subsystem/InterruptBus.scala
+++ b/src/main/scala/subsystem/InterruptBus.scala
@@ -61,7 +61,7 @@ trait HasSyncExtInterrupts extends HasExtInterrupts { this: BaseSubsystem =>
 trait HasExtInterruptsBundle {
   val interrupts: UInt
 
-  def tieOffInterrupts(dummy: Int = 1) {
+  def tieOffInterrupts(dummy: Int = 1): Unit = {
     interrupts := UInt(0)
   }
 }

--- a/src/main/scala/system/RocketTestSuite.scala
+++ b/src/main/scala/system/RocketTestSuite.scala
@@ -57,9 +57,9 @@ class RegressionTestSuite(val names: LinkedHashSet[String]) extends RocketTestSu
 object TestGeneration {
   private val suites = collection.mutable.ListMap[String, RocketTestSuite]()
 
-  def addSuite(s: RocketTestSuite) { suites += (s.makeTargetName -> s) }
+  def addSuite(s: RocketTestSuite): Unit = { suites += (s.makeTargetName -> s) }
   
-  def addSuites(s: Seq[RocketTestSuite]) { s.foreach(addSuite) }
+  def addSuites(s: Seq[RocketTestSuite]): Unit = { s.foreach(addSuite) }
 
   private[rocketchip] def gen(kind: String, s: Seq[RocketTestSuite]) = {
     if(s.length > 0) {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -288,14 +288,14 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   def rawReset = externalClockSinkNode.in.head._1.reset
 
   /** Helper function for connecting MMIO devices inside the tile to an xbar that will make them visible to external masters. */
-  def connectTLSlave(xbarNode: TLOutwardNode, node: TLNode, bytes: Int) {
+  def connectTLSlave(xbarNode: TLOutwardNode, node: TLNode, bytes: Int): Unit = {
     DisableMonitors { implicit p =>
       (Seq(node, TLFragmenter(bytes, cacheBlockBytes, earlyAck=EarlyAck.PutFulls))
         ++ (xBytes != bytes).option(TLWidthWidget(xBytes)))
         .foldRight(xbarNode)(_ :*= _)
     }
   }
-  def connectTLSlave(node: TLNode, bytes: Int) { connectTLSlave(tlSlaveXbar.node, node, bytes) }
+  def connectTLSlave(node: TLNode, bytes: Int): Unit = { connectTLSlave(tlSlaveXbar.node, node, bytes) }
 
   /** TileLink node which represents the view that the intra-tile masters have of the rest of the system. */
   val visibilityNode = p(TileVisibilityNodeKey)

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -60,7 +60,7 @@ trait SinksExternalInterrupts { this: BaseTile =>
   }
 
   // go from flat diplomatic Interrupts to bundled TileInterrupts
-  def decodeCoreInterrupts(core: TileInterrupts) {
+  def decodeCoreInterrupts(core: TileInterrupts): Unit = {
     val async_ips = Seq(core.debug)
     val periph_ips = Seq(
       core.msip,
@@ -80,19 +80,19 @@ trait SourcesExternalNotifications { this: BaseTile =>
   // Report unrecoverable error conditions
   val haltNode = IntSourceNode(IntSourcePortSimple())
 
-  def reportHalt(could_halt: Option[Bool]) {
+  def reportHalt(could_halt: Option[Bool]): Unit = {
     val (halt_and_catch_fire, _) = haltNode.out(0)
     halt_and_catch_fire(0) := could_halt.map(h => RegEnable(true.B, false.B, BlockDuringReset(h))).getOrElse(false.B)
   }
 
-  def reportHalt(errors: Seq[CanHaveErrors]) {
+  def reportHalt(errors: Seq[CanHaveErrors]): Unit = {
     reportHalt(errors.flatMap(_.uncorrectable).map(_.valid).reduceOption(_||_))
   }
 
   // Report when the tile has ceased to retire instructions
   val ceaseNode = IntSourceNode(IntSourcePortSimple())
 
-  def reportCease(could_cease: Option[Bool], quiescenceCycles: Int = 8) {
+  def reportCease(could_cease: Option[Bool], quiescenceCycles: Int = 8): Unit = {
     def waitForQuiescence(cease: Bool): Bool = {
       // don't report cease until signal is stable for longer than any pipeline depth
       val count = RegInit(0.U(log2Ceil(quiescenceCycles + 1).W))
@@ -114,7 +114,7 @@ trait SourcesExternalNotifications { this: BaseTile =>
   // Report when the tile is waiting for an interrupt
   val wfiNode = IntSourceNode(IntSourcePortSimple())
 
-  def reportWFI(could_wfi: Option[Bool]) {
+  def reportWFI(could_wfi: Option[Bool]): Unit = {
     val (wfi, _) = wfiNode.out(0)
     wfi(0) := could_wfi.map(w => RegNext(BlockDuringReset(w), init=false.B)).getOrElse(false.B)
   }

--- a/src/main/scala/tilelink/Arbiter.scala
+++ b/src/main/scala/tilelink/Arbiter.scala
@@ -30,39 +30,39 @@ object TLArbiter
     readys(width-1, 0)
   }
 
-  def lowestFromSeq[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: Seq[DecoupledIO[T]]) {
+  def lowestFromSeq[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: Seq[DecoupledIO[T]]): Unit = {
     apply(lowestIndexFirst)(sink, sources.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def lowestFromSeq[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: Seq[ReadyValidCancel[T]]) {
+  def lowestFromSeq[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: Seq[ReadyValidCancel[T]]): Unit = {
     applyCancel(lowestIndexFirst)(sink, sources.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def lowest[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: DecoupledIO[T]*) {
+  def lowest[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: DecoupledIO[T]*): Unit = {
     apply(lowestIndexFirst)(sink, sources.toList.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def lowest[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: ReadyValidCancel[T]*) {
+  def lowest[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: ReadyValidCancel[T]*): Unit = {
     applyCancel(lowestIndexFirst)(sink, sources.toList.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def highest[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: DecoupledIO[T]*) {
+  def highest[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: DecoupledIO[T]*): Unit = {
     apply(highestIndexFirst)(sink, sources.toList.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def highest[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: ReadyValidCancel[T]*) {
+  def highest[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: ReadyValidCancel[T]*): Unit = {
     applyCancel(highestIndexFirst)(sink, sources.toList.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def robin[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: DecoupledIO[T]*) {
+  def robin[T <: TLChannel](edge: TLEdge, sink: DecoupledIO[T], sources: DecoupledIO[T]*): Unit = {
     apply(roundRobin)(sink, sources.toList.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def robin[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: ReadyValidCancel[T]*) {
+  def robin[T <: TLChannel](edge: TLEdge, sink: ReadyValidCancel[T], sources: ReadyValidCancel[T]*): Unit = {
     applyCancel(roundRobin)(sink, sources.toList.map(s => (edge.numBeats1(s.bits), s)):_*)
   }
 
-  def apply[T <: Data](policy: Policy)(sink: DecoupledIO[T], sources: (UInt, DecoupledIO[T])*) {
+  def apply[T <: Data](policy: Policy)(sink: DecoupledIO[T], sources: (UInt, DecoupledIO[T])*): Unit = {
     val sink_ACancel = Wire(new ReadyValidCancel(chiselTypeOf(sink.bits)))
     val sources_ACancel = sources.map(s => (s._1, ReadyValidCancel(s._2)))
     applyCancel(policy = policy)(
@@ -71,7 +71,7 @@ object TLArbiter
     sink :<> sink_ACancel.asDecoupled()
   }
 
-  def applyCancel[T <: Data](policy: Policy)(sink: ReadyValidCancel[T], sources: (UInt, ReadyValidCancel[T])*) {
+  def applyCancel[T <: Data](policy: Policy)(sink: ReadyValidCancel[T], sources: (UInt, ReadyValidCancel[T])*): Unit = {
     if (sources.isEmpty) {
       sink.earlyValid := false.B
       sink.lateCancel := DontCare

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -263,7 +263,7 @@ class TLBundle(val params: TLBundleParameters) extends Record
     if (params.hasBCE) ListMap("e" -> e, "d" -> d, "c" -> c, "b" -> b, "a" -> a)
     else ListMap("d" -> d, "a" -> a)
 
-  def tieoff() {
+  def tieoff(): Unit = {
     a.ready.dir match {
       case INPUT =>
         a.ready := Bool(false)

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -242,11 +242,11 @@ trait CanAttachTLSlaves extends HasTLBusParams { this: TLBusWrapper =>
     to("slave" named name) { gen :*= TLBuffer(buffer) :*= outwardNode }
   }
 
-  def toVariableWidthSlaveNode(name: Option[String] = None, buffer: BufferParams = BufferParams.none)(node: TLInwardNode) {
+  def toVariableWidthSlaveNode(name: Option[String] = None, buffer: BufferParams = BufferParams.none)(node: TLInwardNode): Unit = {
     toVariableWidthSlaveNodeOption(name, buffer)(Some(node))
   }
 
-  def toVariableWidthSlaveNodeOption(name: Option[String] = None, buffer: BufferParams = BufferParams.none)(node: Option[TLInwardNode]) {
+  def toVariableWidthSlaveNodeOption(name: Option[String] = None, buffer: BufferParams = BufferParams.none)(node: Option[TLInwardNode]): Unit = {
     node foreach { n => to("slave" named name) {
       n :*= TLFragmenter(beatBytes, blockBytes) :*= TLBuffer(buffer) :*= outwardNode
     }}
@@ -261,7 +261,7 @@ trait CanAttachTLSlaves extends HasTLBusParams { this: TLBusWrapper =>
     }
   }
 
-  def toFixedWidthSlaveNode(name: Option[String] = None, buffer: BufferParams = BufferParams.none)(gen: TLInwardNode) {
+  def toFixedWidthSlaveNode(name: Option[String] = None, buffer: BufferParams = BufferParams.none)(gen: TLInwardNode): Unit = {
     to("slave" named name) { gen :*= TLWidthWidget(beatBytes) :*= TLBuffer(buffer) :*= outwardNode }
   }
 
@@ -274,7 +274,7 @@ trait CanAttachTLSlaves extends HasTLBusParams { this: TLBusWrapper =>
 
   def toFixedWidthSingleBeatSlaveNode
       (widthBytes: Int, name: Option[String] = None, buffer: BufferParams = BufferParams.none)
-      (gen: TLInwardNode) {
+      (gen: TLInwardNode): Unit = {
     to("slave" named name) {
       gen :*= TLFragmenter(widthBytes, blockBytes) :*= TLWidthWidget(beatBytes) :*= TLBuffer(buffer) :*= outwardNode
     }
@@ -319,7 +319,7 @@ trait CanAttachTLMasters extends HasTLBusParams { this: TLBusWrapper =>
 
   def fromMasterNode
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
-      (gen: TLOutwardNode) {
+      (gen: TLOutwardNode): Unit = {
     from("master" named name) {
       inwardNode :=* TLBuffer(buffer) :=* TLFIFOFixer(TLFIFOFixer.all) :=* gen
     }

--- a/src/main/scala/tilelink/Delayer.scala
+++ b/src/main/scala/tilelink/Delayer.scala
@@ -13,7 +13,7 @@ class TLDelayer(q: Double)(implicit p: Parameters) extends LazyModule
   require (0.0 <= q && q < 1)
 
   lazy val module = new LazyModuleImp(this) {
-    def feed[T <: Data](sink: DecoupledIO[T], source: DecoupledIO[T], noise: T) {
+    def feed[T <: Data](sink: DecoupledIO[T], source: DecoupledIO[T], noise: T): Unit = {
       val allow = UInt((q * 65535.0).toInt) <= LFSRNoiseMaker(16, source.valid)
       sink.valid := source.valid && allow
       source.ready := sink.ready && allow

--- a/src/main/scala/tilelink/Isolation.scala
+++ b/src/main/scala/tilelink/Isolation.scala
@@ -21,7 +21,7 @@ class TLIsolation(fOut: (Bool, UInt) => UInt, fIn: (Bool, UInt) => UInt)(implici
     def ISOo[T <: Data](x: T): T = x.fromBits(fOut(io.iso_out, x.asUInt))
     def ISOi[T <: Data](x: T): T = x.fromBits(fIn (io.iso_in,  x.asUInt))
 
-    def ABo[T <: Data](x: AsyncBundle[T], y: AsyncBundle[T]) {
+    def ABo[T <: Data](x: AsyncBundle[T], y: AsyncBundle[T]): Unit = {
       x.mem            := ISOo(y.mem)
       x.widx           := ISOo(y.widx)
       y.ridx           := ISOi(x.ridx)
@@ -34,7 +34,7 @@ class TLIsolation(fOut: (Bool, UInt) => UInt, fIn: (Bool, UInt) => UInt)(implici
       }
     }
 
-    def ABi[T <: Data](x: AsyncBundle[T], y: AsyncBundle[T]) {
+    def ABi[T <: Data](x: AsyncBundle[T], y: AsyncBundle[T]): Unit = {
       x.mem            := ISOi(y.mem)
       x.widx           := ISOi(y.widx)
       y.ridx           := ISOo(x.ridx)
@@ -47,7 +47,7 @@ class TLIsolation(fOut: (Bool, UInt) => UInt, fIn: (Bool, UInt) => UInt)(implici
       }
     }
 
-    def ABz[T <: Data](x: AsyncBundle[T], y: AsyncBundle[T]) {
+    def ABz[T <: Data](x: AsyncBundle[T], y: AsyncBundle[T]): Unit = {
       x.widx           := UInt(0)
       y.ridx           := UInt(0)
       (x.index zip y.index) foreach { case (_, y) => y := UInt(0) }

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -66,7 +66,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       c.visibility.map(_.contains(address)).reduce(_ || _)
     }.reduce(_ && _)
 
-  def legalizeFormatA(bundle: TLBundleA, edge: TLEdge) {
+  def legalizeFormatA(bundle: TLBundleA, edge: TLEdge): Unit = {
     //switch this flag to turn on diplomacy in error messages
     def diplomacyInfo = if (true) "" else "\nThe diplomacy information for the edge is as follows:\n" + edge.formatEdge + "\n"
     monAssert (TLMessages.isA(bundle.opcode), "'A' channel has invalid opcode" + extra)
@@ -155,7 +155,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeFormatB(bundle: TLBundleB, edge: TLEdge) {
+  def legalizeFormatB(bundle: TLBundleB, edge: TLEdge): Unit = {
     monAssert (TLMessages.isB(bundle.opcode), "'B' channel has invalid opcode" + extra)
 
     monAssert (visible(edge.address(bundle), bundle.source, edge), "'B' channel carries an address illegal for the specified bank visibility")
@@ -232,7 +232,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeFormatC(bundle: TLBundleC, edge: TLEdge) {
+  def legalizeFormatC(bundle: TLBundleC, edge: TLEdge): Unit = {
     monAssert (TLMessages.isC(bundle.opcode), "'C' channel has invalid opcode" + extra)
 
     val source_ok = edge.client.contains(bundle.source)
@@ -301,7 +301,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeFormatD(bundle: TLBundleD, edge: TLEdge) {
+  def legalizeFormatD(bundle: TLBundleD, edge: TLEdge): Unit = {
     assume (TLMessages.isD(bundle.opcode), "'D' channel has invalid opcode" + extra)
 
     val source_ok = edge.client.contains(bundle.source)
@@ -362,7 +362,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeFormatE(bundle: TLBundleE, edge: TLEdge) {
+  def legalizeFormatE(bundle: TLBundleE, edge: TLEdge): Unit = {
     val sink_ok = bundle.sink < edge.manager.endSinkId.U
     monAssert (sink_ok, "'E' channels carries invalid sink ID" + extra)
   }
@@ -381,7 +381,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeMultibeatA(a: DecoupledIO[TLBundleA], edge: TLEdge) {
+  def legalizeMultibeatA(a: DecoupledIO[TLBundleA], edge: TLEdge): Unit = {
     val a_first = edge.first(a.bits, a.fire())
     val opcode  = Reg(UInt())
     val param   = Reg(UInt())
@@ -404,7 +404,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeMultibeatB(b: DecoupledIO[TLBundleB], edge: TLEdge) {
+  def legalizeMultibeatB(b: DecoupledIO[TLBundleB], edge: TLEdge): Unit = {
     val b_first = edge.first(b.bits, b.fire())
     val opcode  = Reg(UInt())
     val param   = Reg(UInt())
@@ -427,7 +427,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeADSourceFormal(bundle: TLBundle, edge: TLEdge) {
+  def legalizeADSourceFormal(bundle: TLBundle, edge: TLEdge): Unit = {
     // Symbolic variable
     val sym_source = Wire(UInt(edge.client.endSourceId.W))
     // TODO: Connect sym_source to a fixed value for simulation and to a
@@ -509,7 +509,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
             "request message" + extra)
   }
 
-  def legalizeMultibeatC(c: DecoupledIO[TLBundleC], edge: TLEdge) {
+  def legalizeMultibeatC(c: DecoupledIO[TLBundleC], edge: TLEdge): Unit = {
     val c_first = edge.first(c.bits, c.fire())
     val opcode  = Reg(UInt())
     val param   = Reg(UInt())
@@ -532,7 +532,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeMultibeatD(d: DecoupledIO[TLBundleD], edge: TLEdge) {
+  def legalizeMultibeatD(d: DecoupledIO[TLBundleD], edge: TLEdge): Unit = {
     val d_first = edge.first(d.bits, d.fire())
     val opcode  = Reg(UInt())
     val param   = Reg(UInt())
@@ -558,7 +558,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalizeMultibeat(bundle: TLBundle, edge: TLEdge) {
+  def legalizeMultibeat(bundle: TLBundle, edge: TLEdge): Unit = {
     legalizeMultibeatA(bundle.a, edge)
     legalizeMultibeatD(bundle.d, edge)
     if (edge.client.anySupportProbe && edge.manager.anySupportAcquireB) {
@@ -569,7 +569,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
   //This is left in for almond which doesn't adhere to the tilelink protocol
   @deprecated("Use legalizeADSource instead if possible","")
-  def legalizeADSourceOld(bundle: TLBundle, edge: TLEdge) {
+  def legalizeADSourceOld(bundle: TLBundle, edge: TLEdge): Unit = {
     val inflight = RegInit(0.U(edge.client.endSourceId.W))
 
     val a_first = edge.first(bundle.a.bits, bundle.a.fire())
@@ -603,7 +603,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     when (bundle.a.fire() || bundle.d.fire()) { watchdog := 0.U }
   }
 
-  def legalizeADSource(bundle: TLBundle, edge: TLEdge) {
+  def legalizeADSource(bundle: TLBundle, edge: TLEdge): Unit = {
     val a_size_bus_size       = edge.bundle.sizeBits + 1 //add one so that 0 is not mapped to anything (size 0 -> size 1 in map, size 0 in map means unset)
     val a_opcode_bus_size     = 3 + 1 //opcode size is 3, but add so that 0 is not mapped to anything
     val log_a_opcode_bus_size = log2Ceil(a_opcode_bus_size)
@@ -714,7 +714,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     when (bundle.a.fire() || bundle.d.fire()) { watchdog := 0.U }
   }
 
-  def legalizeCDSource(bundle: TLBundle, edge: TLEdge) {
+  def legalizeCDSource(bundle: TLBundle, edge: TLEdge): Unit = {
     val c_size_bus_size   = edge.bundle.sizeBits + 1 //add one so that 0 is not mapped to anything (size 0 -> size 1 in map, size 0 in map means unset)
     val c_opcode_bus_size = 3 + 1                    //opcode size is 3, but add so that 0 is not mapped to anything
 
@@ -821,7 +821,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     when (bundle.c.fire() || bundle.d.fire()) { watchdog := 0.U }
   }
 
-  def legalizeDESink(bundle: TLBundle, edge: TLEdge) {
+  def legalizeDESink(bundle: TLBundle, edge: TLEdge): Unit = {
     val inflight = RegInit(0.U(edge.manager.endSinkId.W))
 
     val d_first = edge.first(bundle.d.bits, bundle.d.fire())
@@ -844,7 +844,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     inflight := (inflight | d_set) & ~e_clr
   }
 
-  def legalizeUnique(bundle: TLBundle, edge: TLEdge) {
+  def legalizeUnique(bundle: TLBundle, edge: TLEdge): Unit = {
     val sourceBits = log2Ceil(edge.client.endSourceId)
     val tooBig = 14 // >16kB worth of flight information gets to be too much
     if (sourceBits > tooBig) {
@@ -873,7 +873,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
   }
 
-  def legalize(bundle: TLBundle, edge: TLEdge, reset: Reset) {
+  def legalize(bundle: TLBundle, edge: TLEdge, reset: Reset): Unit = {
     legalizeFormat    (bundle, edge)
     legalizeMultibeat (bundle, edge)
     legalizeUnique    (bundle, edge)

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -20,7 +20,7 @@ object TLImp extends NodeImp[TLMasterPortParameters, TLSlavePortParameters, TLEd
 
   def render(ei: TLEdgeIn) = RenderedEdge(colour = "#000000" /* black */, label = (ei.manager.beatBytes * 8).toString)
 
-  override def monitor(bundle: TLBundle, edge: TLEdgeIn) {
+  override def monitor(bundle: TLBundle, edge: TLEdgeIn): Unit = {
     val monitor = Module(edge.params(TLMonitorBuilder)(TLMonitorArgs(edge)))
     monitor.io.in := bundle
   }
@@ -41,7 +41,7 @@ object TLImp_ACancel extends NodeImp[TLMasterPortParameters, TLSlavePortParamete
 
   def render(ei: TLEdgeIn) = TLImp.render(ei)
 
-  override def monitor(bundle: TLBundle_ACancel, edge: TLEdgeIn) {
+  override def monitor(bundle: TLBundle_ACancel, edge: TLEdgeIn): Unit = {
     val monitor = Module(edge.params(TLMonitorBuilder)(TLMonitorArgs(edge)))
     monitor.io.in := bundle.monitorAndNotCancel()
   }

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -106,7 +106,7 @@ case class TLRegisterNode(
     OMRegister.convert(mapping = mapping:_*)
   }
 
-  def genRegDescsJson(mapping: RegField.Map*) {
+  def genRegDescsJson(mapping: RegField.Map*): Unit = {
     // Dump out the register map for documentation purposes.
     val base = address.head.base
     val baseHex = s"0x${base.toInt.toHexString}"
@@ -199,5 +199,5 @@ trait HasTLControlRegMap { this: RegisterRouter =>
   val controlXing: TLInwardCrossingHelper = this.crossIn(controlNode)
 
   // Internally, this function should be used to populate the control port with registers
-  protected def regmap(mapping: RegField.Map*) { controlNode.regmap(mapping:_*) }
+  protected def regmap(mapping: RegField.Map*): Unit = { controlNode.regmap(mapping:_*) }
 }

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -128,7 +128,7 @@ class TLXbar_ACancel(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p
 
 object TLXbar
 {
-  def circuit(policy: TLArbiter.Policy, seqIn: Seq[(TLBundle, TLEdge)], seqOut: Seq[(TLBundle, TLEdge)]) {
+  def circuit(policy: TLArbiter.Policy, seqIn: Seq[(TLBundle, TLEdge)], seqOut: Seq[(TLBundle, TLEdge)]): Unit = {
     val seqOut_ACancel = seqOut.map(sOut => (Wire(new TLBundle_ACancel(sOut._1.params)), sOut._2))
     val seqIn_ACancel = seqIn.map(sIn => (TLBundle_ACancel(sIn._1), sIn._2))
     TLXbar_ACancel.circuit(policy, seqIn_ACancel, seqOut_ACancel)
@@ -185,7 +185,7 @@ object TLXbar
 
 object TLXbar_ACancel
 {
-  def circuit(policy: TLArbiter.Policy, seqIn: Seq[(TLBundle_ACancel, TLEdge)], seqOut: Seq[(TLBundle_ACancel, TLEdge)]) {
+  def circuit(policy: TLArbiter.Policy, seqIn: Seq[(TLBundle_ACancel, TLEdge)], seqOut: Seq[(TLBundle_ACancel, TLEdge)]): Unit = {
     val (io_in, edgesIn) = seqIn.unzip
     val (io_out, edgesOut) = seqOut.unzip
 

--- a/src/main/scala/util/CreditedIO.scala
+++ b/src/main/scala/util/CreditedIO.scala
@@ -139,7 +139,7 @@ class CreditedIOCounter(val init: Int, val depth: Int) {
   def full: Bool = v === depth.U
   def empty: Bool = v === 0.U
 
-  def update(credit: Bool, debit: Bool) {
+  def update(credit: Bool, debit: Bool): Unit = {
     assert((!(credit && full) || debit) && (!(debit && empty) || credit))
     val next = Mux(credit, v + 1.U, v - 1.U)
     when (credit =/= debit) {
@@ -148,5 +148,5 @@ class CreditedIOCounter(val init: Int, val depth: Int) {
     }
   }
 
-  def update(c: CreditedIO[_]) { update(c.credit, c.debit) }
+  def update(c: CreditedIO[_]): Unit = { update(c.credit, c.debit) }
 }

--- a/src/main/scala/util/GeneratorUtils.scala
+++ b/src/main/scala/util/GeneratorUtils.scala
@@ -50,7 +50,7 @@ trait HasRocketChipStageUtils {
 object ElaborationArtefacts {
   var files: Seq[(String, () => String)] = Nil
 
-  def add(extension: String, contents: => String) {
+  def add(extension: String, contents: => String): Unit = {
     files = (extension, () => contents) +: files
   }
 

--- a/src/main/scala/util/LanePositionedQueue.scala
+++ b/src/main/scala/util/LanePositionedQueue.scala
@@ -39,11 +39,11 @@ class LanePositionedDecoupledIO[T <: Data](private val gen: T, val maxValid: Int
     Mux(xhi && yhi, lanes.U, Mux(Mux(xly, !xhi, yhi), xlo, ylo))
   }
 
-  def clamp_ready(x: UInt) { ready := min(x, valid, lanes) }
-  def clamp_valid(x: UInt) { valid := min(x, ready, lanes) }
+  def clamp_ready(x: UInt): Unit = { ready := min(x, valid, lanes) }
+  def clamp_valid(x: UInt): Unit = { valid := min(x, ready, lanes) }
 
   // Feed from LPQ from another
-  def driveWith(x: LanePositionedDecoupledIO[T], selfRotation: UInt = 0.U, xRotation: UInt = 0.U) {
+  def driveWith(x: LanePositionedDecoupledIO[T], selfRotation: UInt = 0.U, xRotation: UInt = 0.U): Unit = {
     val limit = lanes min x.lanes
     val moved = min(ready, x.valid, limit)
     valid := moved
@@ -108,7 +108,7 @@ class LanePositionedQueueIO[T <: Data](private val gen: T, val args: LanePositio
   val abort = if (args.abort) Some(Input(Bool())) else None
 
   // Connect two LPQs (enq <= deq)
-  def driveWith(x: LanePositionedQueueIO[T]) { enq.driveWith(x.deq, enq_0_lane, x.deq_0_lane) }
+  def driveWith(x: LanePositionedQueueIO[T]): Unit = { enq.driveWith(x.deq, enq_0_lane, x.deq_0_lane) }
 }
 
 trait LanePositionedQueueModule[T <: Data] extends Module {

--- a/src/main/scala/util/MultiPortQueue.scala
+++ b/src/main/scala/util/MultiPortQueue.scala
@@ -19,7 +19,7 @@ class MultiPortQueue[T <: Data](gen: T, val enq_lanes: Int, val deq_lanes: Int, 
 }
 
 object MultiPortQueue {
-  def gather[T <: Data](sparse: Seq[DecoupledIO[T]], dense: LanePositionedDecoupledIO[T], offset: UInt = 0.U) {
+  def gather[T <: Data](sparse: Seq[DecoupledIO[T]], dense: LanePositionedDecoupledIO[T], offset: UInt = 0.U): Unit = {
     // Compute per-enq-port ready
     val enq_valid = DensePrefixSum(sparse.map(_.valid.asUInt))(_ +& _)
     val low_ready = if (dense.lanes == 1) 0.U else dense.ready(log2Ceil(dense.lanes)-1, 0)
@@ -46,7 +46,7 @@ object MultiPortQueue {
     }
   }
 
-  def scatter[T <: Data](sparse: Seq[DecoupledIO[T]], dense: LanePositionedDecoupledIO[T], offset: UInt = 0.U) {
+  def scatter[T <: Data](sparse: Seq[DecoupledIO[T]], dense: LanePositionedDecoupledIO[T], offset: UInt = 0.U): Unit = {
     // Computer per-deq-port valid
     val deq_ready = DensePrefixSum(sparse.map(_.ready.asUInt))(_ +& _)
     val low_valid = if (dense.lanes == 1) 0.U else dense.valid(log2Ceil(dense.lanes)-1, 0)

--- a/src/main/scala/util/PlusArg.scala
+++ b/src/main/scala/util/PlusArg.scala
@@ -84,7 +84,7 @@ object PlusArg
     * to kill the simulation when count exceeds the specified integer argument.
     * Default 0 will never assert.
     */
-  def timeout(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32)(count: UInt) {
+  def timeout(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32)(count: UInt): Unit = {
     PlusArgArtefacts.append(name, Some(default), docstring)
     Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count := count
   }

--- a/src/main/scala/util/PrefixSum.scala
+++ b/src/main/scala/util/PrefixSum.scala
@@ -100,7 +100,7 @@ object SparsePrefixSum extends PrefixSum {
 }
 
 object TestPrefixSums {
-  def testSize(size: Int) {
+  def testSize(size: Int): Unit = {
     val input = Seq.tabulate(size) { i => Seq(i) }
     var last: Int = 0
     var value: Vector[Seq[Int]] = Vector.empty
@@ -135,5 +135,5 @@ object TestPrefixSums {
     println(s"PrefixSums correct for size ${size}")
   }
 
-  def test { Seq.tabulate(519){i=>i}.foreach(testSize) }
+  def test: Unit = { Seq.tabulate(519){i=>i}.foreach(testSize) }
 }

--- a/src/main/scala/util/Property.scala
+++ b/src/main/scala/util/Property.scala
@@ -31,11 +31,11 @@ case class CoverPropertyParameters(
 }
 
 abstract class BasePropertyLibrary {
-  def generateProperty(prop_param: BasePropertyParameters)(implicit sourceInfo: SourceInfo)
+  def generateProperty(prop_param: BasePropertyParameters)(implicit sourceInfo: SourceInfo): Unit
 }
 
 class DefaultPropertyLibrary extends BasePropertyLibrary {
-  def generateProperty(prop_param: BasePropertyParameters)(implicit sourceInfo: SourceInfo) {
+  def generateProperty(prop_param: BasePropertyParameters)(implicit sourceInfo: SourceInfo): Unit = {
     // default is to do nothing
     Unit
   }

--- a/src/main/scala/util/ReduceOthers.scala
+++ b/src/main/scala/util/ReduceOthers.scala
@@ -35,7 +35,7 @@ object ReduceOthers {
     }
   }
   // Take pairs of (output_wire, input_bool)
-  def apply(x: Seq[(Bool, Bool)]) {
+  def apply(x: Seq[(Bool, Bool)]): Unit = {
     (x.map(_._1) zip apply(x.map(_._2))) foreach { case (w, x) => w := x }
   }
   private def helper(x: Seq[Bool]): (Seq[Bool], Bool) = {

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -107,10 +107,10 @@ class TrueLRU(n_ways: Int) extends ReplacementPolicy {
     nextState.zipWithIndex.tail.foldLeft((nextState.head.apply(n_ways-1,1),0)) { case ((pe,pi),(ce,ci)) => (Cat(ce.apply(n_ways-1,ci+1), pe), ci) }._1
   }
 
-  def access(touch_way: UInt) {
+  def access(touch_way: UInt): Unit = {
     state_reg := get_next_state(state_reg, touch_way)
   }
-  def access(touch_ways: Seq[Valid[UInt]]) {
+  def access(touch_ways: Seq[Valid[UInt]]): Unit = {
     when (touch_ways.map(_.valid).orR) {
       state_reg := get_next_state(state_reg, touch_ways)
     }
@@ -164,10 +164,10 @@ class PseudoLRU(n_ways: Int) extends ReplacementPolicy {
   private val state_reg = Reg(UInt(nBits.W))
   def state_read = WireDefault(state_reg)
 
-  def access(touch_way: UInt) {
+  def access(touch_way: UInt): Unit = {
     state_reg := get_next_state(state_reg, touch_way)
   }
-  def access(touch_ways: Seq[Valid[UInt]]) {
+  def access(touch_ways: Seq[Valid[UInt]]): Unit = {
     when (touch_ways.map(_.valid).orR) {
       state_reg := get_next_state(state_reg, touch_ways)
     }


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

---

Followup to https://github.com/chipsalliance/rocket-chip/pull/2648. Compared to https://github.com/chipsalliance/rocket-chip/pull/2650, this lint rule requires modifying a much larger number of lines of code in rocket-chip.

This PR enables the [`ProcedureSyntax`](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html) lint rule in Scalafix. A deprecated syntax of Scala was to allow for a Java/C-style method declaration that did not require an explicit `=` separating the method name and type signature from the body of the method. This lint rule detects instances of that older syntax and will change them to 1) have the explicit return type of `Unit` and 2) to place an `=` between the return type and the opening curly brace of the method body.
