### PR TITLE
AXI4Deinterleaver: fix bug introduced in #2642

### DIFF
--- a/src/main/scala/amba/axi4/Deinterleaver.scala
+++ b/src/main/scala/amba/axi4/Deinterleaver.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.amba.axi4
 
 import chisel3._
-import chisel3.util.{Cat, isPow2, log2Ceil,
+import chisel3.util.{Cat, isPow2, log2Ceil, ReadyValidIO,
   log2Up, OHToUInt, Queue, QueueIO, UIntToOH}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -34,7 +34,7 @@ class AXI4Deinterleaver(maxReadBytes: Int, buffer: BufferParams = BufferParams.d
 
       if (beats <= 1) {
         // Nothing to do if only single-beat R
-        in.r <> buffer.irrevocable(out.r)
+        in.r.asInstanceOf[ReadyValidIO[AXI4BundleR]] :<> buffer.irrevocable(out.r)
       } else {
         // Queues to buffer R responses
         val qs = Seq.tabulate(endId) { i =>


### PR DESCRIPTION
We cannot use '<>' due to the usual chisel3 bug with both sides wires.
To appease ':<>', the types must be identical, so we need a cast.

**Type of change**: bug report
**Impact**: no functional change
**Development Phase**: implementation