### PR TITLE
Add PMP granularity to DTS

### DIFF
--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -128,7 +128,9 @@ trait HasNonDiplomaticTileParameters {
         "tlb-split" -> Nil,
         "mmu-type"  -> s"riscv,sv$maxSVAddrBits".asProperty)
 
-    val pmp = if (tileParams.core.nPMPs > 0) Map("riscv,pmpregions" -> tileParams.core.nPMPs.asProperty) else Nil
+    val pmp = if (tileParams.core.nPMPs > 0) Map(
+      "riscv,pmpregions" -> tileParams.core.nPMPs.asProperty,
+      "riscv,pmpgranularity" -> tileParams.core.pmpGranularity.asProperty) else Nil
 
     dcache ++ icache ++ dtlb ++ itlb ++ mmu ++ pmp ++ incoherent
   }


### PR DESCRIPTION
Add `riscv,pmpgranularity` parameter to device tree string; property name inspired by `riscv/riscv-isa-sim` DTB parser.
https://github.com/riscv/riscv-isa-sim/blob/ecc039ef5726315b7e37e8a9c7b682bbe09c9cf5/riscv/dts.cc#L270

Observed the following output in a custom configuration:
```
riscv,isa = "rv32imac";
riscv,pmpgranularity = <4>;
riscv,pmpregions = <4>;
```



<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation
