### PR TITLE
[prci] Add a pair of diplomatic reset synchronizers

### DIFF
--- a/src/main/scala/prci/ResetSynchronizer.scala
+++ b/src/main/scala/prci/ResetSynchronizer.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+package freechips.rocketchip.prci
+
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.util.{ResetCatchAndSync}
+
+/**
+  * Synchronizes the reset of a diplomatic clock-reset pair to its accompanying clock.
+  */
+class ResetSynchronizer(implicit p: Parameters) extends LazyModule {
+  val node = ClockIdentityNode()
+  lazy val module = new LazyRawModuleImp(this) {
+    (node.out zip node.in).map { case ((o, _), (i, _)) =>
+      o.clock := i.clock
+      o.reset := ResetCatchAndSync(i.clock, i.reset.asBool)
+    }
+  }
+}
+
+object ResetSynchronizer {
+  def apply()(implicit p: Parameters, valName: ValName) = LazyModule(new ResetSynchronizer()).node
+}
+
+
+/**
+  * Instantiates a reset synchronizer on all clock-reset pairs in a clock group.
+  */
+class ClockGroupResetSynchronizer(implicit p: Parameters) extends LazyModule {
+  val node = ClockGroupIdentityNode()
+  lazy val module = new LazyRawModuleImp(this) {
+    (node.out zip node.in).map { case ((oG, _), (iG, _)) =>
+      (oG.member.data zip iG.member.data).foreach { case (o, i) =>
+        o.clock := i.clock
+        o.reset := ResetCatchAndSync(i.clock, i.reset.asBool)
+      }
+    }
+  }
+}
+
+object ClockGroupResetSynchronizer {
+  def apply()(implicit p: Parameters, valName: ValName) = LazyModule(new ClockGroupResetSynchronizer()).node
+}


### PR DESCRIPTION

**Type of change**: other enhancement

**Impact**:  API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
* [prci] Add a pair of diplomatic reset synchronizers

Some other thoughts: 
- Here I don't bother exposing any of the underlying parameters of ResetCatchAndSync; if that's desired i can add requested ones. 
- ResetWrangler could be made more diplomatic in spirit by removing its direct instantiation of ResetCatchAndSync. 


