### PR TITLE
Debug: val members in extTrigger bundles for compatibility with cloneType

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -163,12 +163,12 @@ case class DebugModuleHartSelFuncs (
 
 case object DebugModuleHartSelKey extends Field(DebugModuleHartSelFuncs())
 
-class DebugExtTriggerOut (nExtTriggers: Int) extends Bundle {
+class DebugExtTriggerOut (val nExtTriggers: Int) extends Bundle {
   val req = Output(UInt(nExtTriggers.W))
   val ack = Input(UInt(nExtTriggers.W))
 }
 
-class DebugExtTriggerIn (nExtTriggers: Int) extends Bundle {
+class DebugExtTriggerIn (val nExtTriggers: Int) extends Bundle {
   val req = Input(UInt(nExtTriggers.W))
   val ack = Output(UInt(nExtTriggers.W))
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
I had to make this modification so this bundle and bundles which include it can be `cloneType`'d
