### PR TITLE
Improvements To AMBA AXI4 Adapters

### DIFF
--- a/src/main/scala/amba/axi4/Deinterleaver.scala
+++ b/src/main/scala/amba/axi4/Deinterleaver.scala
@@ -9,9 +9,20 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.leftOR
 
+/** This adapter deinterleaves read responses on the R channel.
+  *
+  * Deinterleaving guarantees that once the first beat of a read response
+  * has been accepted by the recipient, all further presented read responses will
+  * be from the same burst transactions, until the burst is complete.
+  *
+  * @param maxReadBytes is the maximum supported read burst size that this adapter
+  *   has been provisioned to support.
+  * @param buffer is the internal buffering to provide in the case where no deinterleaving is required.
+  */
 class AXI4Deinterleaver(maxReadBytes: Int, buffer: BufferParams = BufferParams.default)(implicit p: Parameters) extends LazyModule
 {
-  require (maxReadBytes >= 1 && isPow2(maxReadBytes))
+  require (maxReadBytes >= 1, s"AXI4Deinterleaver: maxReadBytes must be at least 1, not $maxReadBytes")
+  require (isPow2(maxReadBytes), s"AXI4Deinterleaver: maxReadBytes must be a power of two, not $maxReadBytes")
 
   private def beats(slave: AXI4SlavePortParameters): Int =
     (maxReadBytes+slave.beatBytes-1) / slave.beatBytes

--- a/src/main/scala/amba/axi4/IdIndexer.scala
+++ b/src/main/scala/amba/axi4/IdIndexer.scala
@@ -16,7 +16,7 @@ case class AXI4ExtraIdField(width: Int) extends SimpleBundleField(AXI4ExtraId)(U
   * which values are expected to be echoed back to this adapter alongside any downstream response messages,
   * and are then prepended to the RID and BID field to restore the original identifier.
   *
-  * @param idBits is the desired number of AXID bits to be used
+  * @param idBits is the desired number of A[W|R]ID bits to be used
   */
 class AXI4IdIndexer(idBits: Int)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/amba/axi4/IdIndexer.scala
+++ b/src/main/scala/amba/axi4/IdIndexer.scala
@@ -10,9 +10,17 @@ import freechips.rocketchip.util._
 case object AXI4ExtraId extends ControlKey[UInt]("extra_id")
 case class AXI4ExtraIdField(width: Int) extends SimpleBundleField(AXI4ExtraId)(UInt(OUTPUT, width = width), UInt(0))
 
+/** This adapter limits the set of FIFO domain ids used by outbound transactions.
+  *
+  * Extra AWID and ARID bits from upstream transactions are stored in a User Bits field called AXI4ExtraId,
+  * which values are expected to be echoed back to this adapter alongside any downstream response messages,
+  * and are then prepended to the RID and BID field to restore the original identifier.
+  *
+  * @param idBits is the desired number of AXID bits to be used
+  */
 class AXI4IdIndexer(idBits: Int)(implicit p: Parameters) extends LazyModule
 {
-  require (idBits >= 0)
+  require (idBits >= 0, s"AXI4IdIndexer: idBits must be > 0, not $idBits")
 
   val node = AXI4AdapterNode(
     masterFn = { mp =>

--- a/src/main/scala/amba/axi4/UserYanker.scala
+++ b/src/main/scala/amba/axi4/UserYanker.scala
@@ -8,6 +8,14 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 
+/** This adapter prunes all user bit fields of the echo type from request messages,
+  * storing them in queues and echoing them back when matching response messages are recevied.
+  *
+  * It also optionally rate limits the number of transactions that can be in flight simultaneously
+  * per FIFO domain / AXID.
+  *
+  * @param capMaxFlight is an optional maximum number of transactions that can be in flight per AXID.
+  */
 class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) extends LazyModule
 {
   val node = AXI4AdapterNode(

--- a/src/main/scala/amba/axi4/UserYanker.scala
+++ b/src/main/scala/amba/axi4/UserYanker.scala
@@ -12,9 +12,9 @@ import freechips.rocketchip.util._
   * storing them in queues and echoing them back when matching response messages are recevied.
   *
   * It also optionally rate limits the number of transactions that can be in flight simultaneously
-  * per FIFO domain / AXID.
+  * per FIFO domain / A[W|R]ID.
   *
-  * @param capMaxFlight is an optional maximum number of transactions that can be in flight per AXID.
+  * @param capMaxFlight is an optional maximum number of transactions that can be in flight per A[W|R]ID.
   */
 class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -23,15 +23,32 @@ case class AXI4TLStateField(sourceBits: Int) extends BundleField(AXI4TLState) {
   }
 }
 
-class TLtoAXI4IdMap(tl: TLMasterPortParameters, axi4: AXI4MasterPortParameters) 
-  extends IdMap[TLToAXI4IdMapEntry]
+/** TLtoAXI4IdMap serves as a record for the translation performed between id spaces.
+  *
+  * Its member [axi4Masters] is used as the new AXI4MasterParameters in diplomacy.
+  * Its member [mapping] is used as the template for the circuit generated in TLToAXI4Node.module.
+  */
+class TLtoAXI4IdMap(tlPort: TLMasterPortParameters) extends IdMap[TLToAXI4IdMapEntry]
 {
-  private val axiDigits = String.valueOf(axi4.endId-1).length()
-  private val tlDigits = String.valueOf(tl.endSourceId-1).length()
+  val tlMasters = tlPort.masters.sortBy(_.sourceId).sortWith(TLToAXI4.sortByType)
+  private val axi4IdSize = tlMasters.map { tl => if (tl.requestFifo) 1 else tl.sourceId.size }
+  private val axi4IdStart = axi4IdSize.scanLeft(0)(_+_).init
+  val axi4Masters = axi4IdStart.zip(axi4IdSize).zip(tlMasters).map { case ((start, size), tl) =>
+    AXI4MasterParameters(
+      name      = tl.name,
+      id        = IdRange(start, start+size),
+      aligned   = true,
+      maxFlight = Some(if (tl.requestFifo) tl.sourceId.size else 1),
+      nodePath  = tl.nodePath)
+  }
+
+  private val axi4IdEnd = axi4Masters.map(_.id.end).max
+  private val axiDigits = String.valueOf(axi4IdEnd-1).length()
+  private val tlDigits = String.valueOf(tlPort.endSourceId-1).length()
   protected val fmt = s"\t[%${axiDigits}d, %${axiDigits}d) <= [%${tlDigits}d, %${tlDigits}d) %s%s%s"
 
-  val mapping: Seq[TLToAXI4IdMapEntry] = TLToAXI4.sort(tl.clients).zip(axi4.masters).map { case (c, m) =>
-    TLToAXI4IdMapEntry(m.id, c.sourceId, c.name, c.supports.probe, c.requestFifo)
+  val mapping: Seq[TLToAXI4IdMapEntry] = tlMasters.zip(axi4Masters).map { case (tl, axi) =>
+    TLToAXI4IdMapEntry(axi.id, tl.sourceId, tl.name, tl.supports.probe, tl.requestFifo)
   }
 }
 
@@ -43,26 +60,10 @@ case class TLToAXI4IdMapEntry(axi4Id: IdRange, tlId: IdRange, name: String, isCa
   val maxTransactionsInFlight = Some(tlId.size)
 }
 
-case class TLToAXI4Node(stripBits: Int = 0, wcorrupt: Boolean = true)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AXI4Imp)(
+case class TLToAXI4Node(wcorrupt: Boolean = true)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AXI4Imp)(
   dFn = { p =>
-    p.clients.foreach { c =>
-      require (c.sourceId.start % (1 << stripBits) == 0 &&
-               c.sourceId.end   % (1 << stripBits) == 0,
-               s"Cannot strip bits of aligned client ${c.name}: ${c.sourceId}")
-    }
-    val clients = TLToAXI4.sort(p.clients)
-    val idSize = clients.map { c => if (c.requestFifo) 1 else (c.sourceId.size >> stripBits) }
-    val idStart = idSize.scanLeft(0)(_+_).init
-    val masters = ((idStart zip idSize) zip clients) map { case ((start, size), c) =>
-      AXI4MasterParameters(
-        name      = c.name,
-        id        = IdRange(start, start+size),
-        aligned   = true,
-        maxFlight = Some(if (c.requestFifo) c.sourceId.size else (1 << stripBits)),
-        nodePath  = c.nodePath)
-    }
     AXI4MasterPortParameters(
-      masters    = masters,
+      masters    = (new TLtoAXI4IdMap(p)).axi4Masters,
       requestFields = (if (wcorrupt) Seq(AMBACorruptField()) else Seq()) ++ p.requestFields.filter(!_.isInstanceOf[AMBAProtField]),
       echoFields    = AXI4TLStateField(log2Ceil(p.endSourceId)) +: p.echoFields,
       responseKeys  = p.responseKeys)
@@ -90,7 +91,8 @@ case class TLToAXI4Node(stripBits: Int = 0, wcorrupt: Boolean = true)(implicit v
 // wcorrupt alone is not enough; a slave must include AMBACorrupt in the slave port's requestKeys
 class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String] = None, val stripBits: Int = 0, val wcorrupt: Boolean = true)(implicit p: Parameters) extends LazyModule
 {
-  val node = TLToAXI4Node(stripBits, wcorrupt)
+  require(stripBits == 0, "stripBits > 0 is no longer supported on TLToAXI4")
+  val node = TLToAXI4Node(wcorrupt)
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
@@ -101,15 +103,15 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       slaves.foreach { s => require (s.interleavedId == slaves(0).interleavedId) }
 
       // Construct the source=>ID mapping table
-      val map = new TLtoAXI4IdMap(edgeIn.client, edgeOut.master)
+      val map = new TLtoAXI4IdMap(edgeIn.client)
       val sourceStall = Wire(Vec(edgeIn.client.endSourceId, Bool()))
       val sourceTable = Wire(Vec(edgeIn.client.endSourceId, out.aw.bits.id))
       val idStall = Wire(init = Vec.fill(edgeOut.master.endId) { Bool(false) })
       var idCount = Array.fill(edgeOut.master.endId) { None:Option[Int] }
 
-      Annotated.idMapping(this, map.mapping).foreach { case TLToAXI4IdMapEntry(axi4Id, tlId, _, _, fifo) =>
+      map.mapping.foreach { case TLToAXI4IdMapEntry(axi4Id, tlId, _, _, fifo) =>
         for (i <- 0 until tlId.size) {
-          val id = axi4Id.start + (if (fifo) 0 else (i >> stripBits))
+          val id = axi4Id.start + (if (fifo) 0 else i)
           sourceStall(tlId.start + i) := idStall(id)
           sourceTable(tlId.start + i) := UInt(id)
         }
@@ -275,9 +277,6 @@ object TLToAXI4
     val tl2axi4 = LazyModule(new TLToAXI4(combinational, adapterName, stripBits, wcorrupt))
     tl2axi4.node
   }
-
-  def sort(clients: Seq[TLMasterParameters]): Seq[TLMasterParameters] =
-    clients.sortBy(_.sourceId).sortWith(TLToAXI4.sortByType)
 
   def sortByType(a: TLMasterParameters, b: TLMasterParameters): Boolean = {
     if ( a.supports.probe && !b.supports.probe) return false

--- a/src/main/scala/util/Annotations.scala
+++ b/src/main/scala/util/Annotations.scala
@@ -10,7 +10,6 @@ import firrtl.annotations._
 
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.tilelink.TLToAXI4IdMapEntry
 
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods.{pretty, render}
@@ -62,11 +61,6 @@ case class AddressMapAnnotation(target: Named, mapping: Seq[AddressMapEntry], la
     s"""{\n  "${label}":  [\n""" +
       mapping.map(_.range.toJSON).mkString(",\n") +
       "\n  ]\n}"
-}
-
-/** Record a conversion of TL source ids to AXI4 ids. */
-case class TLToAXI4IdMapAnnotation(target: Named, mapping: Seq[TLToAXI4IdMapEntry]) extends SingleTargetAnnotation[Named] {
-  def duplicate(n: Named) = this.copy(n)
 }
 
 /** Marks this module as a candidate for register retiming */
@@ -146,11 +140,6 @@ object Annotated {
 
   def addressMapping(component: InstanceId, mapping: Seq[AddressMapEntry]): Seq[AddressMapEntry] = {
     annotate(new ChiselAnnotation { def toFirrtl = AddressMapAnnotation(component.toNamed, mapping, "mapping") })
-    mapping
-  }
-
-  def idMapping(component: InstanceId, mapping: Seq[TLToAXI4IdMapEntry]): Seq[TLToAXI4IdMapEntry] = {
-    annotate(new ChiselAnnotation { def toFirrtl = TLToAXI4IdMapAnnotation(component.toNamed, mapping) })
     mapping
   }
 


### PR DESCRIPTION
Miscellaneous improvements to several AXI4 AMBA adapters:
- Scala doc
- Clarify some variable names
- More comments
- Unify TLToAXI4 metadata code paths into a single path through `TLtoAXI4IdMap`
- Make any value of `TLToAXI4.stripBits` other than 0 illegal and stop using it internally.
- Remove usage of un-consumed `Annotated.idMapping` and delete associated application and annotation class.

<!-- choose one -->
**Type of change**:other enhancement

<!-- choose one -->
**Impact**: no API changes

<!-- choose one -->
**Development Phase**:  implementation