### PR TITLE
IDPool: RegInit reset literal value

### DIFF
--- a/src/main/scala/util/IDPool.scala
+++ b/src/main/scala/util/IDPool.scala
@@ -15,7 +15,7 @@ class IDPool(numIds: Int, lateValid: Boolean = false, revocableSelect: Boolean =
   })
 
   // True indicates that the id is available
-  val bitmap = RegInit(-1.S(numIds.W).asUInt()(numIds-1, 0))
+  val bitmap = RegInit(UInt(numIds.W), -1.S(numIds.W).asUInt)
   val select = RegInit(0.U(idWidth.W))
   val valid  = RegInit(true.B)
 


### PR DESCRIPTION
**Related issue**: introduced by https://github.com/chipsalliance/rocket-chip/pull/2673

**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
work around Firrtl Async reset check failure
```
======== Starting Transform firrtl.checks.CheckResets ========
Exception in thread "main" firrtl.checks.CheckResets$NonLiteralAsyncResetValueException:  @[IDPool.scala 18:23]: [module IDPool] AsyncReset Reg 'bitmap' reset to non-literal 'bits(_bitmap_T, 7, 0)'
```
introduced by
```
val bitmap = RegInit(-1.S(numIds.W).asUInt()(numIds-1, 0))
```
from https://github.com/chipsalliance/rocket-chip/pull/2673/commits/f165c98d83589e6e85dcfc52b185dd1a55d32e86