### PR TITLE
loosen Node bundle accessor requirements

### DIFF
--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -1235,14 +1235,14 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
       data   = bundleIn(i))
   }
 
-  private var bundlesSafeNow = false
+  private[diplomacy] var instantiated = false
 
   /** Gather Bundle and edge parameters of outward ports.
     *
     * Accessors to the result of negotiation to be used within [[LazyModuleImp]] Code.
     */
   def out: Seq[(BO, EO)] = {
-    require(bundlesSafeNow, s"$name.out should only be called from the context of ${scope.get.name}'s LazyModuleImp, but the current scope is ${LazyModule.scope}.")
+    require(instantiated, s"$name.out should only be called after its parent LazyModule.module has been instantiated")
     bundleOut zip edgesOut
   }
 
@@ -1251,7 +1251,7 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
     * Accessors to the result of negotiation to be used within [[LazyModuleImp]] Code.
     */
   def in: Seq[(BI, EI)] = {
-    require(bundlesSafeNow, s"$name.in should only be called from the context of ${scope.get.name}'s LazyModuleImp, but the current scope is ${LazyModule.scope}.")
+    require(instantiated, s"$name.in should only be called after its parent LazyModule.module has been instantiated")
     bundleIn zip edgesIn
   }
 
@@ -1261,7 +1261,7 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
     * and return all the dangles of this node.
     */
   protected[diplomacy] def instantiate(): Seq[Dangle] = {
-    bundlesSafeNow = true
+    instantiated = true
     if (!circuitIdentity) {
       (iPorts zip in) foreach {
         case ((_, _, p, _), (b, e)) => if (p(MonitorsEnabled)) inner.monitor(b, e)
@@ -1273,7 +1273,6 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
     * wires as the [[LazyModuleImp]] has been completely evaluated to create a [[Module]].
     */
   protected[diplomacy] def finishInstantiate(): Unit = {
-    bundlesSafeNow = false
   }
 
   /** Connects the outward part of a node with the inward part of this node. */

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -227,12 +227,6 @@ abstract class BaseNode(implicit val valName: ValName) {
     */
   protected[diplomacy] def instantiate(): Seq[Dangle]
 
-  /** A callback to finish the node generation.
-    *
-    * This will be executed in [[LazyModuleImpLike.instantiate]].
-    */
-  protected[diplomacy] def finishInstantiate(): Unit
-
   /** @return name of this node. */
   def name: String = scope.map(_.name).getOrElse("TOP") + "." + valName.name
 
@@ -1239,19 +1233,23 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
 
   /** Gather Bundle and edge parameters of outward ports.
     *
-    * Accessors to the result of negotiation to be used within [[LazyModuleImp]] Code.
+    * Accessors to the result of negotiation to be used within
+    * [[LazyModuleImp]] Code. Should only be used within [[LazyModuleImp]] code
+    * or after its instantiation has completed.
     */
   def out: Seq[(BO, EO)] = {
-    require(instantiated, s"$name.out should only be called after its parent LazyModule.module has been instantiated")
+    require(instantiated, s"$name.out should not be called until after instantiation of its parent LazyModule.module has begun")
     bundleOut zip edgesOut
   }
 
   /** Gather Bundle and edge parameters of inward ports.
     *
-    * Accessors to the result of negotiation to be used within [[LazyModuleImp]] Code.
+    * Accessors to the result of negotiation to be used within
+    * [[LazyModuleImp]] Code. Should only be used within [[LazyModuleImp]] code
+    * or after its instantiation has completed.
     */
   def in: Seq[(BI, EI)] = {
-    require(instantiated, s"$name.in should only be called after its parent LazyModule.module has been instantiated")
+    require(instantiated, s"$name.in should not be called until after instantiation of its parent LazyModule.module has begun")
     bundleIn zip edgesIn
   }
 
@@ -1267,12 +1265,6 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
         case ((_, _, p, _), (b, e)) => if (p(MonitorsEnabled)) inner.monitor(b, e)
     } }
     danglesOut ++ danglesIn
-  }
-
-  /** Complete instantiation. It is no longer safe to access the Bundle
-    * wires as the [[LazyModuleImp]] has been completely evaluated to create a [[Module]].
-    */
-  protected[diplomacy] def finishInstantiate(): Unit = {
   }
 
   /** Connects the outward part of a node with the inward part of this node. */


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable --> https://github.com/chipsalliance/rocket-chip/pull/2674
This PR replaces the `bundlesSafeNow` guard with a looser `instantiated` guard that is set to true when `instantiate` is called and is never reset to false afterwards. This allows the `in`/`out` bundles to be accessed by things like Aspects after the `LazyModuleImp` has been instantiated.

protected function `finishInstantiate` is removed from `BaseNode` and `LazyModule` as it is no longer necessary.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
