### PR TITLE
BuiltInDevices: Optional instantiation of TL adapters

### DIFF
--- a/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
+++ b/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
@@ -6,9 +6,18 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 
+case class BuiltInZeroDeviceParams(
+  addr: AddressSet,
+  cacheCork: Option[TLCacheCorkParams] = None,
+  buffer: Option[BufferParams] = Some(BufferParams.default))
+
+case class BuiltInErrorDeviceParams(
+  errorParams: DevNullParams,
+  buffer: Option[BufferParams] = Some(BufferParams.default))
+
 trait HasBuiltInDeviceParams {
-  val zeroDevice: Option[AddressSet]
-  val errorDevice: Option[DevNullParams]
+  val zeroDevice: Option[BuiltInZeroDeviceParams]
+  val errorDevice: Option[BuiltInErrorDeviceParams]
 }
 
 sealed trait BuiltInDevices {
@@ -27,18 +36,24 @@ object BuiltInDevices {
     outwardNode: TLOutwardNode)(implicit p: Parameters) = new BuiltInDevices {
     val errorOpt = params.errorDevice.map { dnp => LazyScope("wrapped_error_device", "ErrorDeviceWrapper") {
       val error = LazyModule(new TLError(
-        params = dnp,
+        params = dnp.errorParams,
         beatBytes = params.beatBytes))
 
-      error.node := TLBuffer() := outwardNode
+      (error.node
+        := dnp.buffer.map { params => TLBuffer(params) }.getOrElse{ TLTempNode() }
+        := outwardNode)
       error
     }}
 
-    val zeroOpt = params.zeroDevice.map { addr => LazyScope("wrapped_zero_device", "ZeroDeviceWrapper") {
+    val zeroOpt = params.zeroDevice.map { zeroParams => LazyScope("wrapped_zero_device", "ZeroDeviceWrapper") {
       val zero = LazyModule(new TLZero(
-        address = addr,
+        address = zeroParams.addr,
         beatBytes = params.beatBytes))
-      zero.node := TLFragmenter(params.beatBytes, params.blockBytes) := TLBuffer() := outwardNode
+      (zero.node
+        := TLFragmenter(params.beatBytes, params.blockBytes)
+        := zeroParams.buffer.map { params => TLBuffer(params) }.getOrElse { TLTempNode() }
+        := zeroParams.cacheCork.map { params => TLCacheCork(params) }.getOrElse { TLTempNode() }
+        := outwardNode)
       zero
     }}
   }

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -24,7 +24,8 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   case ControlBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
     blockBytes = site(CacheBlockBytes),
-    errorDevice = Some(DevNullParams(List(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096)))
+    errorDevice = Some(BuiltInErrorDeviceParams(
+      errorParams = DevNullParams(List(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096))))
   case PeripheryBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
     blockBytes = site(CacheBlockBytes),

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -12,8 +12,8 @@ case class FrontBusParams(
     beatBytes: Int,
     blockBytes: Int,
     dtsFrequency: Option[BigInt] = None,
-    zeroDevice: Option[AddressSet] = None,
-    errorDevice: Option[DevNullParams] = None)
+    zeroDevice: Option[BuiltInZeroDeviceParams] = None,
+    errorDevice: Option[BuiltInErrorDeviceParams] = None)
   extends HasTLBusParams
   with HasBuiltInDeviceParams
   with TLBusWrapperInstantiationLike

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -13,8 +13,8 @@ case class MemoryBusParams(
   beatBytes: Int,
   blockBytes: Int,
   dtsFrequency: Option[BigInt] = None,
-  zeroDevice: Option[AddressSet] = None,
-  errorDevice: Option[DevNullParams] = None,
+  zeroDevice: Option[BuiltInZeroDeviceParams] = None,
+  errorDevice: Option[BuiltInErrorDeviceParams] = None,
   replication: Option[ReplicatedRegion] = None)
   extends HasTLBusParams
   with HasBuiltInDeviceParams

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -19,8 +19,8 @@ case class PeripheryBusParams(
     blockBytes: Int,
     atomics: Option[BusAtomics] = Some(BusAtomics()),
     dtsFrequency: Option[BigInt] = None,
-    zeroDevice: Option[AddressSet] = None,
-    errorDevice: Option[DevNullParams] = None,
+    zeroDevice: Option[BuiltInZeroDeviceParams] = None,
+    errorDevice: Option[BuiltInErrorDeviceParams] = None,
     replication: Option[ReplicatedRegion] = None)
   extends HasTLBusParams
   with HasBuiltInDeviceParams

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -13,8 +13,8 @@ case class SystemBusParams(
     blockBytes: Int,
     policy: TLArbiter.Policy = TLArbiter.roundRobin,
     dtsFrequency: Option[BigInt] = None,
-    zeroDevice: Option[AddressSet] = None,
-    errorDevice: Option[DevNullParams] = None,
+    zeroDevice: Option[BuiltInZeroDeviceParams] = None,
+    errorDevice: Option[BuiltInErrorDeviceParams] = None,
     replication: Option[ReplicatedRegion] = None)
   extends HasTLBusParams
   with HasBuiltInDeviceParams

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -8,8 +8,14 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import TLMessages._
 
-class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Parameters) extends LazyModule
+case class TLCacheCorkParams(
+  unsafe: Boolean = false,
+  sinkIds: Int = 8)
+
+class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: Parameters) extends LazyModule
 {
+  val unsafe = params.unsafe
+  val sinkIds = params.sinkIds
   val node = TLAdapterNode(
     clientFn  = { case cp =>
       cp.v1copy(clients = cp.clients.map { c => c.v1copy(
@@ -166,9 +172,13 @@ class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Paramet
 
 object TLCacheCork
 {
+  def apply(params: TLCacheCorkParams)(implicit p: Parameters): TLNode =
+  {
+    val cork = LazyModule(new TLCacheCork(params))
+    cork.node
+  }
   def apply(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Parameters): TLNode =
   {
-    val cork = LazyModule(new TLCacheCork(unsafe, sinkIds))
-    cork.node
+    apply(TLCacheCorkParams(unsafe, sinkIds))
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Makes optional the instantiation of previously mandatory adapters for these devices, and also adds a CacheCork option for the Zero device
