### PR TITLE
PTW do not count pte_miss on leaf walk level

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -322,7 +322,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     }
     is (s_wait2) {
       next_state := s_wait3
-      io.dpath.perf.pte_miss := true
+      io.dpath.perf.pte_miss := count < pgLevels-1
       when (io.mem.s2_xcpt.ae.ld) {
         resp_ae := true
         next_state := s_ready


### PR DESCRIPTION
**Related issue**: follow-up to https://github.com/chipsalliance/rocket-chip/pull/2688

**Type of change**: bug report

**Impact**: API modification

**Development Phase**: implementation

**Release Notes**
do not count PTE Cache Miss performance monitor event on the leaf (last) level of the page table walk, because the PTE Cache is not used there