### PR TITLE
Support noisy drops from L1 D$

### DIFF
--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -45,6 +45,8 @@ case class DCacheParams(
 
   def replacement = new RandomReplacement(nWays)
 
+  def silentDrop: Boolean = !acquireBeforeRelease
+
   require((!scratch.isDefined || nWays == 1),
     "Scratchpad only allowed in direct-mapped cache.")
   require((!scratch.isDefined || nMSHRs == 0),


### PR DESCRIPTION
This reduces the latency of some inclusion and coherence misses, in exchange for additional C-channel traffic.  It is disabled when using the broadcast hub, because there it doesn't improve latency.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
