### PR TITLE
Cutpoint annotations

### DIFF
--- a/src/main/scala/util/Cutpoint.scala
+++ b/src/main/scala/util/Cutpoint.scala
@@ -1,0 +1,49 @@
+// See LICENSE.Berkeley for license details.
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import chisel3._
+import firrtl.annotations.{Annotation, ReferenceTarget, SingleTargetAnnotation}
+import firrtl.{CircuitState, LowForm, Transform}
+import chisel3.experimental.{ChiselAnnotation, annotate}
+import firrtl.stage.RunFirrtlTransformAnnotation
+
+/** Marks a signal with an annotation so it can be parsed by post-processors as a cutpoint */
+object Cutpoint {
+  def cutpoint (signal: Bits): Unit = {
+    // create annotation for a cutpoint
+    annotate(new ChiselAnnotation {
+      override def toFirrtl: Annotation = CutpointAnnotation(signal.toTarget)
+    })
+    // run transform that prints out cutpoint annotation information
+    annotate(new ChiselAnnotation {
+      override def toFirrtl: Annotation = RunFirrtlTransformAnnotation(new PrintCutpointsTransform)
+    })
+  }
+}
+
+/** Annotation containing information about a cutpointed wire */
+case class CutpointAnnotation(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
+  override def duplicate(n: ReferenceTarget): Annotation = this.copy(target = n)
+  override def serialize: String = {
+    s"cutpoint(\n${target.prettyPrint("  ")})"
+  }
+}
+
+/** Transform that prints out cutpoint information */
+class PrintCutpointsTransform extends Transform {
+  override val inputForm = LowForm
+  override val outputForm = LowForm
+
+  override def execute(state: CircuitState): CircuitState = {
+    val annos = state.annotations.flatMap {
+      case a: CutpointAnnotation =>
+        println(a.serialize) // TODO dump to a file + format properly with paths
+        None
+      case a => Some(a)
+    }
+
+    state.copy(annotations = annos)
+  }
+}

--- a/src/main/scala/util/Cutpoint.scala
+++ b/src/main/scala/util/Cutpoint.scala
@@ -1,49 +1,93 @@
-// See LICENSE.Berkeley for license details.
 // See LICENSE.SiFive for license details.
 
 package freechips.rocketchip.util
 
 import chisel3._
-import firrtl.annotations.{Annotation, ReferenceTarget, SingleTargetAnnotation}
-import firrtl.{CircuitState, LowForm, Transform}
+import firrtl.annotations.{Annotation, MultiTargetAnnotation, ReferenceTarget, Target}
+import firrtl.{AnnotationSeq, CircuitState, DependencyAPIMigration, LowForm, Transform}
 import chisel3.experimental.{ChiselAnnotation, annotate}
+import firrtl.annotations.TargetToken.{Instance, Ref}
 import firrtl.stage.RunFirrtlTransformAnnotation
+import firrtl.options.CustomFileEmission
 
-/** Marks a signal with an annotation so it can be parsed by post-processors as a cutpoint */
+/** Marks a signal with a [[CutpointAnnotation]]. Optionally, a label can be
+  * passed in.
+  *
+  * The Verilog paths to each cutpoint will be emitted in a metadata file,
+  * called cutpoints.<label>.txt.
+  */
 object Cutpoint {
-  def cutpoint (signal: Bits): Unit = {
+  def cutpoint (signal: Bits, label: String = ""): Unit = {
     // create annotation for a cutpoint
     annotate(new ChiselAnnotation {
-      override def toFirrtl: Annotation = CutpointAnnotation(signal.toTarget)
+      override def toFirrtl: Annotation = CutpointAnnotation(Seq(Seq(signal.toAbsoluteTarget)), label)
     })
-    // run transform that prints out cutpoint annotation information
-    annotate(new ChiselAnnotation {
-      override def toFirrtl: Annotation = RunFirrtlTransformAnnotation(new PrintCutpointsTransform)
-    })
+  }
+  // run transform that prints out cutpoint annotation information
+  annotate(new ChiselAnnotation {
+    override def toFirrtl: Annotation = RunFirrtlTransformAnnotation(new AggregateCutpointsTransform)
+  })
+}
+
+/** Annotation containing target information for a cutpointed wire and label
+  * information for constructing a file name. Cutpoint paths will be written
+  * to the file with the constructed name.
+  */
+case class CutpointAnnotation(targets: Seq[Seq[ReferenceTarget]], label: String = "") extends MultiTargetAnnotation
+    with CustomFileEmission {
+  def duplicate(n: Seq[Seq[Target]]): Annotation = this.copy(targets = n.map {
+    case t: Seq[ReferenceTarget] => t
+    case t => firrtl.Utils.throwInternalError(s"Error in CutpointAnnotation: seeing ${t.getClass} where ReferenceTarget is expected")
+  }, label = label)
+
+  // construct file name
+  def baseFileName(annotations: AnnotationSeq) = if (label.isEmpty) "cutpoints" else s"cutpoints.$label"
+  def suffix: Option[String] = Some(".txt")
+  // create bytes written to file
+  def getBytes: Iterable[Byte] = {
+    val cutpointVerilogPaths: Seq[String] = targets.flatten.map( t => toVerilogPath(t))
+    cutpointVerilogPaths.mkString("\n").getBytes()
+  }
+
+  /** Construct a verilog path from [[ReferenceTarget]] information. */
+  def toVerilogPath(target: ReferenceTarget): String = {
+    val moduleString = target.moduleOpt.getOrElse("")
+    val tokenString = target.tokens.map {
+      case Ref(r)      => s"$r"
+      case Instance(i) => s"$i."
+      case _ => ""
+    }.mkString("")
+    s"$moduleString.$tokenString"
   }
 }
 
-/** Annotation containing information about a cutpointed wire */
-case class CutpointAnnotation(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
-  override def duplicate(n: ReferenceTarget): Annotation = this.copy(target = n)
-  override def serialize: String = {
-    s"cutpoint(\n${target.prettyPrint("  ")})"
-  }
-}
-
-/** Transform that prints out cutpoint information */
-class PrintCutpointsTransform extends Transform {
-  override val inputForm = LowForm
-  override val outputForm = LowForm
+/** Transform that aggregates [[CutpointAnnotation]]s based on their labels. */
+class AggregateCutpointsTransform extends Transform with DependencyAPIMigration {
+  override def optionalPrerequisites = firrtl.stage.Forms.BackendEmitters
 
   override def execute(state: CircuitState): CircuitState = {
-    val annos = state.annotations.flatMap {
+    // flatten annotations into tuples of (label, cutpoint)
+    val cutpointTargets: Seq[(String, ReferenceTarget)] = state.annotations.flatMap {
       case a: CutpointAnnotation =>
-        println(a.serialize) // TODO dump to a file + format properly with paths
-        None
-      case a => Some(a)
+        Some(a.targets.flatten.map( t => (a.label, t) ))
+      case _ => None
+    }.flatten
+
+    // consolidate cutpoints with the same label
+    val annoMap: Map[String, Seq[ReferenceTarget]] = cutpointTargets.groupBy(_._1).map {
+      case (label, cutpoint) => (label, cutpoint.map(_._2))
     }
 
-    state.copy(annotations = annos)
+    // create one [[CutpointAnnotation]] per label
+    val cutpointAnnos = annoMap.map {
+      case (label, cutpoints) => CutpointAnnotation(Seq(cutpoints), label)
+    }
+
+    // return remaining annotations
+    val annos = state.annotations.flatMap {
+      case _: CutpointAnnotation => None
+      case a => Some(a)
+    }
+    state.copy(annotations = annos ++ cutpointAnnos)
   }
 }

--- a/src/main/scala/util/Cutpoint.scala
+++ b/src/main/scala/util/Cutpoint.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.util
 
 import chisel3._
 import firrtl.annotations.{Annotation, MultiTargetAnnotation, ReferenceTarget, Target}
-import firrtl.{AnnotationSeq, CircuitState, DependencyAPIMigration, LowForm, Transform}
+import firrtl.{AnnotationSeq, CircuitState, DependencyAPIMigration, Transform}
 import chisel3.experimental.{ChiselAnnotation, annotate}
 import firrtl.annotations.TargetToken.{Instance, Ref}
 import firrtl.stage.RunFirrtlTransformAnnotation

--- a/src/test/scala/annotationTests/CutpointAnnotationSpec.scala
+++ b/src/test/scala/annotationTests/CutpointAnnotationSpec.scala
@@ -1,0 +1,28 @@
+// See LICENSE for license details.
+
+package freechips.rocketchip.annotationTests
+
+import chisel3.testers.BasicTester
+import chisel3._
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
+import freechips.rocketchip.util.CutpointAnnotation
+import org.scalatest.FlatSpec
+import freechips.rocketchip.util.Cutpoint
+
+class CutpointTester extends RawModule {
+  val in = IO(Input(Bool()))
+  val out = IO(Output(Bool()))
+  out := ~in
+  Cutpoint.cutpoint(in)
+  Cutpoint.cutpoint(out)
+}
+
+class CutpointAnnotationSpec extends FlatSpec {
+  "cutpoint annotations" should "appear" in {
+    val firrtl = (new ChiselStage).emitFirrtl( new CutpointTester)
+
+    println(firrtl)
+  }
+}
+
+

--- a/src/test/scala/annotationTests/CutpointAnnotationSpec.scala
+++ b/src/test/scala/annotationTests/CutpointAnnotationSpec.scala
@@ -1,28 +1,79 @@
-// See LICENSE for license details.
+// See LICENSE.SiFive for license details.
 
 package freechips.rocketchip.annotationTests
 
-import chisel3.testers.BasicTester
+import java.io.File
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
 import chisel3._
-import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
-import freechips.rocketchip.util.CutpointAnnotation
-import org.scalatest.FlatSpec
+import chisel3.stage.ChiselStage
 import freechips.rocketchip.util.Cutpoint
 
-class CutpointTester extends RawModule {
-  val in = IO(Input(Bool()))
-  val out = IO(Output(Bool()))
-  out := ~in
-  Cutpoint.cutpoint(in)
-  Cutpoint.cutpoint(out)
-}
+/** Circuit for testing [[Cutpoint]].
+  *
+  * Two 2:1 adders are instantiated within a top-level adder, which sums the
+  * submodule adders' sum together. Cutpoints are placed on wires throughout.
+  */
+object CutpointAnnotationTester {
 
-class CutpointAnnotationSpec extends FlatSpec {
-  "cutpoint annotations" should "appear" in {
-    val firrtl = (new ChiselStage).emitFirrtl( new CutpointTester)
+  class AdderModule(width: Int) extends MultiIOModule {
+    val io = IO(new Bundle {
+      val a = Input(UInt(width.W))
+      val b = Input(UInt(width.W))
+      val sum = Output(UInt(width.W))
+    })
+    io.sum := io.a + io.b
+    Cutpoint.cutpoint(io.b, "adderModule")
+  }
 
-    println(firrtl)
+  class AdderTop extends MultiIOModule {
+    val width = 5
+    val io = IO(new Bundle {
+      val a = Input(UInt(width.W))
+      val b = Input(UInt(width.W))
+      val sum = Output(UInt(width.W))
+    })
+    val adderA = Module(new AdderModule(width))
+    val adderB = Module(new AdderModule(width))
+    adderA.io.a := io.a
+    adderA.io.b := io.b
+    adderB.io.a := io.a
+    adderB.io.b := io.b
+    io.sum := adderA.io.sum + adderB.io.sum
+    Cutpoint.cutpoint(io.a)
+    Cutpoint.cutpoint(adderA.io.a)
   }
 }
 
+/** Test for [[Cutpoint]].
+  *
+  * Checks that the cutpoints in the circuit above are written correctly into
+  * the correct files.
+  */
+class CutpointAnnotationSpec extends AnyFlatSpec {
 
+  "cutpoint annotations" should "appear" in {
+    // create target directory
+    val testDir = new File("target", "CutpointAnnotationSpec")
+    testDir.mkdir()
+
+    // emit verilog and associated files
+    (new ChiselStage).emitVerilog(new CutpointAnnotationTester.AdderTop, Array("-td", testDir.getPath))
+
+    // check cutpoint files for correct cutpoint paths
+    val cutpointsFile = new File(testDir, "cutpoints.txt")
+    val cutpointsAdderModuleFile = new File(testDir, "cutpoints.adderModule.txt")
+
+    testDir should exist
+    cutpointsFile should exist
+    cutpointsAdderModuleFile should exist
+
+    val cutpoints = scala.io.Source.fromFile(cutpointsFile).getLines.toList
+    val cutpointAdderModule = scala.io.Source.fromFile(cutpointsAdderModuleFile).getLines.toList
+
+    cutpoints should contain allOf ("AdderTop.adderA.io_a", "AdderTop.io_a")
+    cutpointAdderModule should contain allOf ("AdderTop.adderB.io_b", "AdderTop.adderA.io_b")
+  }
+}


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: N/A

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Adds the `Cutpoint` object, which can be used to mark signals as cutpoints. These signals will be written to a `cutpoints.<label>.txt` file.