### PR TITLE
NMI implementation

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -111,6 +111,8 @@ class RocketLogicalTreeNode(
       hasVectoredInterrupts = true,
       interruptLatency = 4,
       nLocalInterrupts = coreParams.nLocalInterrupts,
+      rnmiPresent = coreParams.useNMI,
+      unmiPresent = coreParams.useNMI,
       nBreakpoints = coreParams.nBreakpoints,
       mcontextWidth = coreParams.mcontextWidth,
       scontextWidth = coreParams.scontextWidth,

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -22,6 +22,8 @@ case class OMRocketCore(
   hasVectoredInterrupts: Boolean,
   interruptLatency: Int,
   nLocalInterrupts: Int,
+  rnmiPresent: Boolean,
+  unmiPresent: Boolean,
   nBreakpoints: Int,
   mcontextWidth: Int,
   scontextWidth: Int,

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -133,13 +133,16 @@ object CSR
   }
 
   val ADDRSZ = 12
-  def busErrorIntCause = 128
+  def busErrorIntCause = 128  //TODO: Remove once other clients no longer need this
   def debugIntCause = 14 // keep in sync with MIP.debug
   def debugTriggerCause = {
     val res = debugIntCause
     require(!(Causes.all contains res))
     res
   }
+  def unmiIntCause = 15  // NMI: Higher numbers = higher priority, must not reuse debugIntCause
+  def rnmiIntCause = 13
+  def rnmiBEUCause = 12
 
   val firstCtr = CSRs.cycle
   val firstCtrH = CSRs.cycleh
@@ -341,14 +344,13 @@ class CSRFile(
     sup.debug := false
     sup.zero2 := false
     sup.lip foreach { _ := true }
-    val supported_high_interrupts = if (io.interrupts.buserror.nonEmpty) UInt(BigInt(1) << CSR.busErrorIntCause) else 0.U
 
     val del = Wire(init=sup)
     del.msip := false
     del.mtip := false
     del.meip := false
 
-    (sup.asUInt | supported_high_interrupts, del.asUInt)
+    (sup.asUInt, del.asUInt)
   }
   val delegable_exceptions = UInt(Seq(
     Causes.misaligned_fetch,
@@ -394,6 +396,16 @@ class CSRFile(
     case None => Reg(UInt(width = mtvecWidth))
   }
 
+  val reset_mnstatus = Wire(init=new MStatus().fromBits(0))
+  reset_mnstatus.mpp := PRV.M
+  val reg_mnscratch = Reg(Bits(width = xLen))
+  val reg_mnepc = Reg(UInt(width = vaddrBitsExtended))
+  val reg_mncause = RegInit(0.U(xLen.W))
+  val reg_mnstatus = Reg(init=reset_mnstatus)
+  val reg_rnmie = RegInit(true.B)
+  val reg_unmie = RegInit(true.B)
+  val nmie = WireInit(reg_rnmie && reg_unmie)
+
   val delegable_counters = ((BigInt(1) << (nPerfCounters + CSR.firstHPM)) - 1).U
   val (reg_mcounteren, read_mcounteren) = {
     val reg = Reg(UInt(32.W))
@@ -434,15 +446,19 @@ class CSRFile(
   io.interrupts.seip.foreach { mip.seip := reg_mip.seip || _ }
   mip.rocc := io.rocc_interrupt
   val read_mip = mip.asUInt & supported_interrupts
-  val high_interrupts = io.interrupts.buserror.map(_ << CSR.busErrorIntCause).getOrElse(0.U)
 
-  val pending_interrupts = high_interrupts | (read_mip & reg_mie)
+  val pending_interrupts = read_mip & reg_mie
   val d_interrupts = io.interrupts.debug << CSR.debugIntCause
-  val m_interrupts = Mux(reg_mstatus.prv <= PRV.S || reg_mstatus.mie, ~(~pending_interrupts | read_mideleg), UInt(0))
-  val s_interrupts = Mux(reg_mstatus.prv < PRV.S || (reg_mstatus.prv === PRV.S && reg_mstatus.sie), pending_interrupts & read_mideleg, UInt(0))
-  val (anyInterrupt, whichInterrupt) = chooseInterrupt(Seq(s_interrupts, m_interrupts, d_interrupts))
+  val (n_interrupts, nmiFlag) = io.interrupts.nmi.map(nmi =>
+    (((nmi.unmi && reg_unmie) << CSR.unmiIntCause) |
+    ((nmi.rnmi && reg_rnmie) << CSR.rnmiIntCause) |
+    io.interrupts.buserror.map(_ << CSR.rnmiBEUCause).getOrElse(0.U),
+    !io.interrupts.debug && (nmi.unmi && reg_unmie || nmi.rnmi && reg_rnmie))).getOrElse(0.U, false.B)
+  val m_interrupts = Mux(nmie && (reg_mstatus.prv <= PRV.S || reg_mstatus.mie), ~(~pending_interrupts | read_mideleg), UInt(0))
+  val s_interrupts = Mux(nmie && (reg_mstatus.prv < PRV.S || (reg_mstatus.prv === PRV.S && reg_mstatus.sie)), pending_interrupts & read_mideleg, UInt(0))
+  val (anyInterrupt, whichInterrupt) = chooseInterrupt(Seq(s_interrupts, m_interrupts, n_interrupts, d_interrupts))
   val interruptMSB = BigInt(1) << (xLen-1)
-  val interruptCause = UInt(interruptMSB) + whichInterrupt
+  val interruptCause = UInt(interruptMSB) + (nmiFlag << (xLen-2)) + whichInterrupt
   io.interrupt := (anyInterrupt && !io.singleStep || reg_singleStepped) && !(reg_debug || io.status.cease)
   io.interrupt_cause := interruptCause
   io.bp := reg_bp take nBreakpoints
@@ -491,6 +507,14 @@ class CSRFile(
     CSRs.dscratch -> reg_dscratch.asUInt) ++
     reg_dscratch1.map(r => CSRs.dscratch1 -> r)
 
+  val read_mnstatus = WireInit(0.U.asTypeOf(new MStatus()))
+  read_mnstatus.mpp := io.status.mpp
+  val nmi_csrs = if (!usingNMI) LinkedHashMap() else LinkedHashMap[Int,Bits](
+    CSRs.mnscratch -> reg_mnscratch,
+    CSRs.mnepc -> readEPC(reg_mnepc).sextTo(xLen),
+    CSRs.mncause -> reg_mncause,
+    CSRs.mnstatus -> read_mnstatus.asUInt)
+
   val context_csrs = LinkedHashMap[Int,Bits]() ++
     reg_mcontext.map(r => CSRs.mcontext -> r) ++
     reg_scontext.map(r => CSRs.scontext -> r)
@@ -512,6 +536,7 @@ class CSRFile(
     CSRs.vlenb -> (vLen / 8).U)
 
   read_mapping ++= debug_csrs
+  read_mapping ++= nmi_csrs
   read_mapping ++= context_csrs
   read_mapping ++= fp_csrs
   read_mapping ++= vector_csrs
@@ -610,6 +635,7 @@ class CSRFile(
                                  CEASE->       List(N,N,N,Y,N,N),
                                  WFI->         List(N,N,N,N,Y,N)) ++
     usingDebug.option(           DRET->        List(N,N,Y,N,N,N)) ++
+    usingNMI.option(             MNRET->       List(N,N,Y,N,N,N)) ++
     coreParams.haveCFlush.option(CFLUSH_D_L1-> List(N,N,N,N,N,N)) ++
     usingSupervisor.option(      SRET->        List(N,N,Y,N,N,N)) ++
     usingVM.option(              SFENCE_VMA->  List(N,N,N,N,N,Y))
@@ -646,14 +672,14 @@ class CSRFile(
     io_dec.system_illegal := reg_mstatus.prv < io_dec.csr(9,8) ||
       is_wfi && !allow_wfi ||
       is_ret && !allow_sret ||
-      is_ret && io_dec.csr(10) && !reg_debug ||
+      is_ret && io_dec.csr(10) && io_dec.csr(7) && !reg_debug ||
       is_sfence && !allow_sfence_vma
   }
 
   val cause =
     Mux(insn_call, reg_mstatus.prv + Causes.user_ecall,
     Mux[UInt](insn_break, Causes.breakpoint, io.cause))
-  val cause_lsbs = cause(log2Ceil(1 + CSR.busErrorIntCause)-1, 0)
+  val cause_lsbs = cause(log2Ceil(mip.getWidth)-1, 0)
   val causeIsDebugInt = cause(xLen-1) && cause_lsbs === CSR.debugIntCause
   val causeIsDebugTrigger = !cause(xLen-1) && cause_lsbs === CSR.debugTriggerCause
   val causeIsDebugBreak = !cause(xLen-1) && insn_break && Cat(reg_dcsr.ebreakm, reg_dcsr.ebreakh, reg_dcsr.ebreaks, reg_dcsr.ebreaku)(reg_mstatus.prv)
@@ -674,7 +700,19 @@ class CSRFile(
     val doVector = base(0) && cause(cause.getWidth-1) && (cause_lsbs >> mtvecInterruptAlign) === 0
     Mux(doVector, interruptVec, base >> mtvecBaseAlign << mtvecBaseAlign)
   }
-  val tvec = Mux(trapToDebug, debugTVec, notDebugTVec)
+
+  val causeIsUnmiInt = cause(xLen-1) && cause(xLen-2) && cause_lsbs === CSR.unmiIntCause
+  val causeIsRnmiInt = cause(xLen-1) && cause(xLen-2) && (cause_lsbs === CSR.rnmiIntCause || cause_lsbs === CSR.rnmiBEUCause)
+  val causeIsRnmiBEU = cause(xLen-1) && cause(xLen-2) && cause_lsbs === CSR.rnmiBEUCause
+  val causeIsNmi = causeIsUnmiInt || causeIsRnmiInt
+  val nmiTVecInt = io.interrupts.nmi.map(nmi => Mux(causeIsRnmiInt, nmi.rnmi_interrupt_vector, nmi.unmi_interrupt_vector)).getOrElse(0.U)
+  val nmiTVecXcpt = io.interrupts.nmi.map(nmi => Mux(reg_unmie, nmi.rnmi_exception_vector, nmi.unmi_exception_vector)).getOrElse(0.U)
+  val trapToNmiInt = usingNMI.B && causeIsNmi
+  val trapToNmiXcpt = usingNMI.B && !nmie
+  val trapToNmi = trapToNmiInt || trapToNmiXcpt
+  val nmiTVec = Mux(causeIsNmi, nmiTVecInt, nmiTVecXcpt)
+
+  val tvec = Mux(trapToDebug, debugTVec, Mux(trapToNmi, nmiTVec, notDebugTVec))
   io.evec := tvec
   io.ptbr := reg_satp
   io.eret := insn_call || insn_break || insn_ret
@@ -694,6 +732,7 @@ class CSRFile(
 
   when (insn_wfi && !io.singleStep && !reg_debug) { reg_wfi := true }
   when (pending_interrupts.orR || io.interrupts.debug || exception) { reg_wfi := false }
+  io.interrupts.nmi.map(nmi => when (nmi.unmi || nmi.rnmi) { reg_wfi := false } )
 
   when (io.retire(0) || exception) { reg_singleStepped := true }
   when (!io.singleStep) { reg_singleStepped := false }
@@ -713,7 +752,16 @@ class CSRFile(
         reg_dcsr.prv := trimPrivilege(reg_mstatus.prv)
         new_prv := PRV.M
       }
-    }.elsewhen (delegate) {
+    }.elsewhen (trapToNmiInt) {
+      when (reg_rnmie || reg_unmie && causeIsUnmiInt) {
+        reg_rnmie := false.B
+        reg_unmie := !causeIsUnmiInt
+        reg_mnepc := epc
+        reg_mncause := (BigInt(1) << (xLen-1)).U | Mux(causeIsUnmiInt, 1.U, Mux(causeIsRnmiBEU, 3.U, 2.U))
+        reg_mnstatus.mpp := trimPrivilege(reg_mstatus.prv)
+        new_prv := PRV.M
+      }
+    }.elsewhen (delegate && nmie) {
       reg_sepc := epc
       reg_scause := cause
       xcause_dest := sCause
@@ -762,10 +810,15 @@ class CSRFile(
       reg_mstatus.spp := PRV.U
       ret_prv := reg_mstatus.spp
       io.evec := readEPC(reg_sepc)
-    }.elsewhen (Bool(usingDebug) && io.rw.addr(10)) {
+    }.elsewhen (Bool(usingDebug) && io.rw.addr(10) && io.rw.addr(7)) {
       ret_prv := reg_dcsr.prv
       reg_debug := false
       io.evec := readEPC(reg_dpc)
+    }.elsewhen (Bool(usingNMI) && io.rw.addr(10) && !io.rw.addr(7)) {
+      ret_prv := reg_mnstatus.mpp
+      reg_rnmie := true.B
+      reg_unmie := true.B
+      io.evec := readEPC(reg_mnepc)
     }.otherwise {
       reg_mstatus.mie := reg_mstatus.mpie
       reg_mstatus.mpie := true
@@ -887,6 +940,14 @@ class CSRFile(
       when (decoded_addr(CSRs.mtvec))  { reg_mtvec := wdata }
     when (decoded_addr(CSRs.mcause))   { reg_mcause := wdata & UInt((BigInt(1) << (xLen-1)) + (BigInt(1) << whichInterrupt.getWidth) - 1) }
     when (decoded_addr(CSRs.mtval))    { reg_mtval := wdata(vaddrBitsExtended-1,0) }
+
+    if (usingNMI) {
+      val new_mnstatus = new MStatus().fromBits(wdata)
+      when (decoded_addr(CSRs.mnscratch)) { reg_mnscratch := wdata }
+      when (decoded_addr(CSRs.mnepc))     { reg_mnepc := formEPC(wdata) }
+      when (decoded_addr(CSRs.mncause))   { reg_mncause := wdata & UInt((BigInt(1) << (xLen-1)) + BigInt(3)) }
+      when (decoded_addr(CSRs.mnstatus))  { reg_mnstatus.mpp := legalizePrivilege(new_mnstatus.mpp) }
+    }
 
     for (((e, c), i) <- (reg_hpmevent zip reg_hpmcounter) zipWithIndex) {
       writeCounter(i + CSR.firstMHPC, c, wdata)

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -406,7 +406,7 @@ class CSRFile(
   val reg_mnstatus = Reg(init=reset_mnstatus)
   val reg_rnmie = RegInit(true.B)
   val reg_unmie = RegInit(true.B)
-  val nmie = WireInit(reg_rnmie && reg_unmie)
+  val nmie = reg_rnmie && reg_unmie
 
   val delegable_counters = ((BigInt(1) << (nPerfCounters + CSR.firstHPM)) - 1).U
   val (reg_mcounteren, read_mcounteren) = {

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -716,7 +716,7 @@ class CSRFile(
   val trapToNmiInt = usingNMI.B && causeIsNmi
   val trapToNmiXcpt = usingNMI.B && !nmie
   val trapToNmi = trapToNmiInt || trapToNmiXcpt
-  val nmiTVec = Mux(causeIsNmi, nmiTVecInt, nmiTVecXcpt)
+  val nmiTVec = (Mux(causeIsNmi, nmiTVecInt, nmiTVecXcpt)>>1)<<1
 
   val tvec = Mux(trapToDebug, debugTVec, Mux(trapToNmi, nmiTVec, notDebugTVec))
   io.evec := tvec

--- a/src/main/scala/rocket/IDecode.scala
+++ b/src/main/scala/rocket/IDecode.scala
@@ -160,6 +160,12 @@ class DebugDecode(implicit val p: Parameters) extends DecodeConstants
     DRET->      List(Y,N,N,N,N,N,N,X,N,A2_X,   A1_X,   IMM_X, DW_X,  FN_X,     N,M_X,        N,N,N,N,N,N,N,CSR.I,N,N,N,N))
 }
 
+class NMIDecode(implicit val p: Parameters) extends DecodeConstants
+{
+  val table: Array[(BitPat, List[BitPat])] = Array(
+    MNRET->     List(Y,N,N,N,N,N,N,X,N,A2_X,   A1_X,   IMM_X, DW_X,  FN_X,     N,M_X,        N,N,N,N,N,N,N,CSR.I,N,N,N,N))
+}
+
 class I32Decode(implicit val p: Parameters) extends DecodeConstants
 {
   val table: Array[(BitPat, List[BitPat])] = Array(

--- a/src/main/scala/rocket/Instructions.scala
+++ b/src/main/scala/rocket/Instructions.scala
@@ -210,6 +210,7 @@ object Instructions {
   def URET               = BitPat("b00000000001000000000000001110011")
   def SRET               = BitPat("b00010000001000000000000001110011")
   def MRET               = BitPat("b00110000001000000000000001110011")
+  def MNRET              = BitPat("b01110000001000000000000001110011")
   def DRET               = BitPat("b01111011001000000000000001110011")
   def SFENCE_VMA         = BitPat("b0001001??????????000000001110011")
   def WFI                = BitPat("b00010000010100000000000001110011")
@@ -1000,6 +1001,10 @@ object CSRs {
   val mcause = 0x342
   val mtval = 0x343
   val mip = 0x344
+  val mnscratch = 0x350
+  val mnepc = 0x351
+  val mncause = 0x352
+  val mnstatus = 0x353
   val pmpcfg0 = 0x3a0
   val pmpcfg1 = 0x3a1
   val pmpcfg2 = 0x3a2

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -26,6 +26,7 @@ case class RocketCoreParams(
   useRVE: Boolean = false,
   useSCIE: Boolean = false,
   nLocalInterrupts: Int = 0,
+  useNMI: Boolean = true,
   nBreakpoints: Int = 1,
   useBPWatch: Boolean = false,
   mcontextWidth: Int = 0,

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -177,6 +177,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     (usingVM.option(new SVMDecode)) ++:
     (usingSupervisor.option(new SDecode)) ++:
     (usingDebug.option(new DebugDecode)) ++:
+    (usingNMI.option(new NMIDecode)) ++:
     Seq(new FenceIDecode(tile.dcache.flushOnFenceI)) ++:
     coreParams.haveCFlush.option(new CFlushDecode(tile.dcache.canSupportCFlushLine)) ++:
     Seq(new IDecode)

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -26,7 +26,7 @@ case class RocketCoreParams(
   useRVE: Boolean = false,
   useSCIE: Boolean = false,
   nLocalInterrupts: Int = 0,
-  useNMI: Boolean = true,
+  useNMI: Boolean = false,
   nBreakpoints: Int = 1,
   useBPWatch: Boolean = false,
   mcontextWidth: Int = 0,

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -124,6 +124,8 @@ trait HasTileInterruptSources
   }
 }
 
+/** Source of Non-maskable Interrupt (NMI) input bundle to each tile.
+  */
 trait HasTileNMISources extends InstantiatesTiles { this: BaseSubsystem =>
   /** NMI input bundle */
   val tileNMINode = BundleBridgeEphemeralNode[NMI]()
@@ -334,7 +336,7 @@ trait CanAttachTile {
     }
   }
 
-  /** Connect NMI inputs to the tile. No clock crossing needed. */
+  /** Connect NMI inputs to the tile. These inputs are synchronous to the respective core_clock. */
   def connectNMI(tile: TileType, context: TileContextType): Unit = {
     implicit val p = context.p
     tile.nmiNode := context.tileNMINode

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -438,5 +438,5 @@ trait HasTilesModuleImp extends LazyModuleImp with HasPeripheryDebugModuleImp {
       (outer.seipNode.get.out(i)._1)(0) := pin
     }
   }
-  val nmi = outer.tiles.zip(outer.tileNMIIONodes).zipWithIndex.map { case ((tile, n), i) => if (tile.tileParams.core.useNMI) n.makeIO(s"nmi_$i") }
+  val nmi = outer.tiles.zip(outer.tileNMIIONodes).zipWithIndex.map { case ((tile, n), i) => tile.tileParams.core.useNMI.option(n.makeIO(s"nmi_$i")) }
 }

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -225,6 +225,12 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   val resetVectorNode: BundleBridgeInwardNode[UInt] =
     resetVectorSinkNode := resetVectorNexusNode := BundleBridgeNameNode("reset_vector")
 
+  /** Nodes for connecting NMI interrupt sources and vectors into the tile */
+  val nmiNexusNode: BundleBridgeNode[NMI] = BundleBroadcast[NMI]()
+  val nmiSinkNode = BundleBridgeSink[NMI](Some(() => new NMI(visiblePhysAddrBits)))
+  val nmiNode: BundleBridgeInwardNode[NMI] =
+    nmiSinkNode := nmiNexusNode := BundleBridgeNameNode("nmi")
+
   /** Node for broadcasting an address prefix to diplomatic consumers within the tile.
     *
     * The prefix should be applied by consumers by or-ing ouputs of this node

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -104,10 +104,6 @@ trait HasCoreParameters extends HasTileParameters {
   def vMemDataBits = if (usingVector) coreParams.vMemDataBits else 0
   def maxVLMax = vLen
 
-  if (tileParams.beuAddr.nonEmpty) {
-    require(usingNMI, "If BEU is present, then NMI must also be present")
-  }
-
   if (usingVector) {
     require(isPow2(vLen), s"vLen ($vLen) must be a power of 2")
     require(eLen >= 32 && vLen % eLen == 0, s"eLen must divide vLen ($vLen) and be no less than 32")

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -32,6 +32,7 @@ trait CoreParams {
   val retireWidth: Int
   val instBits: Int
   val nLocalInterrupts: Int
+  val useNMI: Boolean = true
   val nPMPs: Int
   val pmpGranularity: Int
   val nBreakpoints: Int
@@ -77,6 +78,7 @@ trait HasCoreParameters extends HasTileParameters {
   val usingBitManip = coreParams.useBitManip
   val usingVector = coreParams.useVector
   val usingSCIE = coreParams.useSCIE
+  val usingNMI = coreParams.useNMI
 
   val retireWidth = coreParams.retireWidth
   val fetchWidth = coreParams.fetchWidth

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -32,7 +32,7 @@ trait CoreParams {
   val retireWidth: Int
   val instBits: Int
   val nLocalInterrupts: Int
-  val useNMI: Boolean = true
+  val useNMI: Boolean
   val nPMPs: Int
   val pmpGranularity: Int
   val nBreakpoints: Int
@@ -103,6 +103,10 @@ trait HasCoreParameters extends HasTileParameters {
   def eLen = coreParams.eLen(xLen, fLen)
   def vMemDataBits = if (usingVector) coreParams.vMemDataBits else 0
   def maxVLMax = vLen
+
+  if (tileParams.beuAddr.nonEmpty) {
+    require(usingNMI, "If BEU is present, then NMI must also be present")
+  }
 
   if (usingVector) {
     require(isPow2(vLen), s"vLen ($vLen) must be a power of 2")

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -9,6 +9,15 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
 
+class NMI(val w: Int) extends Bundle {
+  val rnmi = Bool()
+  val rnmi_interrupt_vector = UInt(w.W)
+  val rnmi_exception_vector = UInt(w.W)
+  val unmi = Bool()
+  val unmi_interrupt_vector = UInt(w.W)
+  val unmi_exception_vector = UInt(w.W)
+}
+
 class TileInterrupts(implicit p: Parameters) extends CoreBundle()(p) {
   val debug = Bool()
   val mtip = Bool()
@@ -16,6 +25,7 @@ class TileInterrupts(implicit p: Parameters) extends CoreBundle()(p) {
   val meip = Bool()
   val seip = usingSupervisor.option(Bool())
   val lip = Vec(coreParams.nLocalInterrupts, Bool())
+  val nmi = usingNMI.option(new NMI(resetVectorLen))
 }
 
 // Use diplomatic interrupts to external interrupts from the subsystem into the tile

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -164,6 +164,8 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
     beu.module.io.errors.icache := outer.frontend.module.io.errors
   }
 
+  core.io.interrupts.nmi.foreach { nmi => nmi := outer.nmiSinkNode.bundle }
+
   // Pass through various external constants and reports that were bundle-bridged into the tile
   outer.traceSourceNode.bundle <> core.io.trace
   outer.traceSourceNode.bundle.zip(core.io.trace).foreach { case(tb, t) => tb.valid := t.valid && traceValidEnable }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- New NMI inputs covering both resumable and unresumable NMI
- NMI wired through and integrated into the CSR module's interrupt handling infrastructure
- New CSRs for NMI created.
- New mnret instruction created.
- Object model items now reflects presence of NMI
- Bus Error Unit local interrupt is now wired to cause RNMI and populate mncause with a unique exception code.
