### PR TITLE
PLIC Priority RegFieldDesc fix off-by-one

### DIFF
--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -187,12 +187,17 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
       harts(hart)   := ShiftRegister(Reg(next = fanin.io.max) > threshold(hart), params.intStages)
     }
 
+    // Priority registers are 32-bit aligned so treat each as its own group.
+    // Otherwise, the off-by-one nature of the priority registers gets confusing.
+    require(PLICConsts.priorityBytes == 4,
+      s"PLIC Priority register descriptions assume 32-bits per priority, not ${PLICConsts.priorityBytes}")
+
     def priorityRegDesc(i: Int) =
       RegFieldDesc(
         name      = s"priority_$i",
         desc      = s"Acting priority of interrupt source $i",
-        group     = Some("priority"),
-        groupDesc = Some("Acting priorities of each interrupt source."),
+        group     = Some(s"priority_${i}"),
+        groupDesc = Some("Acting priority of interrupt source $i")
         reset     = if (nPriorities > 0) None else Some(1))
 
     def pendingRegDesc(i: Int) =

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -197,7 +197,7 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
         name      = s"priority_$i",
         desc      = s"Acting priority of interrupt source $i",
         group     = Some(s"priority_${i}"),
-        groupDesc = Some("Acting priority of interrupt source $i")
+        groupDesc = Some(s"Acting priority of interrupt source ${i}")
         reset     = if (nPriorities > 0) None else Some(1))
 
     def pendingRegDesc(i: Int) =

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -197,7 +197,7 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
         name      = s"priority_$i",
         desc      = s"Acting priority of interrupt source $i",
         group     = Some(s"priority_${i}"),
-        groupDesc = Some(s"Acting priority of interrupt source ${i}")
+        groupDesc = Some(s"Acting priority of interrupt source ${i}"),
         reset     = if (nPriorities > 0) None else Some(1))
 
     def pendingRegDesc(i: Int) =

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -221,7 +221,8 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
       }
 
     val priorityRegFields = priority.zipWithIndex.map { case (p, i) =>
-      PLICConsts.priorityBase+4*(i+1) -> Seq(priorityRegField(p, i+1)) }
+      PLICConsts.priorityBase+PLICConsts.priorityBytes*(i+1) ->
+      Seq(priorityRegField(p, i+1)) }
     val pendingRegFields = Seq(PLICConsts.pendingBase ->
       (RegField(1) +: pending.zipWithIndex.map { case (b, i) => RegField.r(1, b, pendingRegDesc(i+1))}))
     val enableRegFields = enables.zipWithIndex.map { case (e, i) =>


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

PLIC Priority registers are now explicitly named with a suffix. This prevents tooling which assumes that the "first" register in a group should have the 0th index ending up with Priority[2] ending up in a register called priority_1, and so on.