### PR TITLE
Avoid Subsystem Implicit Clock

### DIFF
--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -109,6 +109,14 @@ trait CanHavePeripheryCLINT { this: BaseSubsystem =>
     val clint = LazyModule(new CLINT(params, cbus.beatBytes))
     LogicalModuleTree.add(logicalTreeNode, clint.logicalTreeNode)
     clint.node := tlbus.coupleTo("clint") { TLFragmenter(tlbus) := _ }
+
+    // Override the implicit clock and reset -- could instead include a clockNode in the clint, and make it a RawModuleImp?
+    InModuleBody {
+      clint.module.clock := tlbus.module.clock
+      clint.module.reset := tlbus.module.reset
+    }
+
     clint
+
   }
 }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -358,7 +358,7 @@ trait CanHavePeripheryPLIC { this: BaseSubsystem =>
     plic.intnode :=* ibus.toPLIC
 
     // TODO: What should be responsible for defining the ibus domain when there's no PLIC?
-    ibus.interruptBusDomainWrapper.clockNode := tlbus.fixedClockNode
+    ibus.clockNode := tlbus.fixedClockNode
 
     plic
   }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -357,9 +357,6 @@ trait CanHavePeripheryPLIC { this: BaseSubsystem =>
     plic.node := tlbus.coupleTo("plic") { TLFragmenter(tlbus) := _ }
     plic.intnode :=* ibus.toPLIC
 
-    // TODO: What should be responsible for defining the ibus domain when there's no PLIC?
-    ibus.clockNode := tlbus.fixedClockNode
-
     plic
   }
 }

--- a/src/main/scala/prci/ClockGroup.scala
+++ b/src/main/scala/prci/ClockGroup.scala
@@ -49,7 +49,7 @@ class ClockGroupAggregator(groupName: String)(implicit p: Parameters) extends La
     val (out, _) = node.out.unzip
     val outputs = out.flatMap(_.member.data)
 
-    require (node.in.size == 1)
+    require (node.in.size == 1, s"Aggregator for groupName: ${groupName} had ${node.in.size} inward edges instead of 1")
     require (in.head.member.size == outputs.size)
     in.head.member.data.zip(outputs).foreach { case (i, o) => o := i }
   }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -82,6 +82,10 @@ abstract class BaseSubsystem(val location: HierarchicalLocation = InSubsystem)
   val sbus = tlBusWrapperLocationMap(SBUS)
   tlBusWrapperLocationMap.lift(SBUS).map { _.clockGroupNode := asyncClockGroupsNode }
 
+  // TODO: Preserve legacy implicit-clock behavior for IBUS for now. If binding
+  // a PLIC to the CBUS, ensure it is synchronously coupled to the SBUS.
+  ibus.clockNode := sbus.fixedClockNode
+
   // TODO deprecate these public members to see where users are manually hardcoding a particular bus that might actually not exist in a certain dynamic topology
   val pbus = tlBusWrapperLocationMap.lift(PBUS).getOrElse(sbus)
   val fbus = tlBusWrapperLocationMap.lift(FBUS).getOrElse(sbus)

--- a/src/main/scala/subsystem/InterruptBus.scala
+++ b/src/main/scala/subsystem/InterruptBus.scala
@@ -6,13 +6,15 @@ import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
+import freechips.rocketchip.prci.{ClockSinkDomain}
 
 /** Collects interrupts from internal and external devices and feeds them into the PLIC */ 
 class InterruptBusWrapper(implicit p: Parameters) extends SimpleLazyModule with LazyScope with HasClockDomainCrossing {
   override def shouldBeInlined = true
-  val int_bus = LazyModule(new IntXbar)
-  private val int_in_xing = this.crossIn(int_bus.intnode)
-  private val int_out_xing = this.crossOut(int_bus.intnode)
+  val interruptBusDomainWrapper = LazyModule(new ClockSinkDomain() { override def shouldBeInlined = true })
+  val int_bus = interruptBusDomainWrapper { LazyModule(new IntXbar) }   // Interrupt crossbar
+  private val int_in_xing  = interruptBusDomainWrapper.crossIn(int_bus.intnode)
+  private val int_out_xing = interruptBusDomainWrapper.crossOut(int_bus.intnode)
   def from(name: Option[String])(xing: ClockCrossingType) = int_in_xing(xing) :=* IntNameNode(name)
   def to(name: Option[String])(xing: ClockCrossingType) = IntNameNode(name) :*= int_out_xing(xing)
   def fromAsync: IntInwardNode = from(None)(AsynchronousCrossing(8,3))

--- a/src/main/scala/subsystem/InterruptBus.scala
+++ b/src/main/scala/subsystem/InterruptBus.scala
@@ -9,12 +9,11 @@ import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci.{ClockSinkDomain}
 
 /** Collects interrupts from internal and external devices and feeds them into the PLIC */ 
-class InterruptBusWrapper(implicit p: Parameters) extends SimpleLazyModule with LazyScope with HasClockDomainCrossing {
+class InterruptBusWrapper(implicit p: Parameters) extends ClockSinkDomain {
   override def shouldBeInlined = true
-  val interruptBusDomainWrapper = LazyModule(new ClockSinkDomain() { override def shouldBeInlined = true })
-  val int_bus = interruptBusDomainWrapper { LazyModule(new IntXbar) }   // Interrupt crossbar
-  private val int_in_xing  = interruptBusDomainWrapper.crossIn(int_bus.intnode)
-  private val int_out_xing = interruptBusDomainWrapper.crossOut(int_bus.intnode)
+  val int_bus = LazyModule(new IntXbar)   // Interrupt crossbar
+  private val int_in_xing  = this.crossIn(int_bus.intnode)
+  private val int_out_xing = this.crossOut(int_bus.intnode)
   def from(name: Option[String])(xing: ClockCrossingType) = int_in_xing(xing) :=* IntNameNode(name)
   def to(name: Option[String])(xing: ClockCrossingType) = IntNameNode(name) :*= int_out_xing(xing)
   def fromAsync: IntInwardNode = from(None)(AsynchronousCrossing(8,3))


### PR DESCRIPTION
An alternate implementation to #2622. 

Two problems:
- Not sure if the extra layers of module hierarchy are desired, but we can always inline the CD wrappers.
- Something needs to supply the IBus ClockSource when there's no PLIC.

~~I think it would be really cool if we had a mixin for LazyModule, `DiplomaticImplicitClockAndReset` or something, that would add a ClockSinkNode and automatically drive the ModuleImp's implicit clock and reset using that node's resulting clock bundle.~~ This is effectively covered by extending `ClockSinkDomain`. 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change** other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
