### PR TITLE
Add An Optional L2:MBus crossing; Misc Xtype + Bus Frequency Config Mixins

### DIFF
--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -41,6 +41,14 @@ case class SubsystemCrossingParams(
   fbusToSbusXType: ClockCrossingType = SynchronousCrossing()
 )
 
+/** Keys to parameterize the most common crossings between the five traditional TL buses. Used to populated
+  * [[SubsystemCrossingParams]].
+  */
+case object SbusToMbusXTypeKey extends Field[ClockCrossingType](NoCrossing)
+case object SbusToCbusXTypeKey extends Field[ClockCrossingType](NoCrossing)
+case object CbusToPbusXTypeKey extends Field[ClockCrossingType](SynchronousCrossing())
+case object FbusToSbusXTypeKey extends Field[ClockCrossingType](SynchronousCrossing())
+
 // Taken together these case classes provide a backwards-compatibility parameterization
 //  of a bus topology that contains the five traditional tilelink bus wrappers.
 //  Users desiring a different topology are free to define a similar subclass,

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -75,13 +75,14 @@ case class HierarchicalBusTopologyParams(
 case class CoherentBusTopologyParams(
   sbus: SystemBusParams, // TODO remove this after better width propagation
   mbus: MemoryBusParams,
-  l2: BankedL2Params
+  l2: BankedL2Params,
+  sbusToMbusXType: ClockCrossingType = NoCrossing
 ) extends TLBusWrapperTopology(
   instantiations = (if (l2.nBanks == 0) Nil else List(
     (MBUS, mbus),
     (L2, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, l2.nBanks, L2.name)(l2.coherenceManager)))),
   connections = if (l2.nBanks == 0) Nil else List(
     (SBUS, L2,   TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_STAR)()),
-    (L2,  MBUS,  TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_QUERY)())
+    (L2,  MBUS,  TLBusWrapperConnection.crossTo(xType = sbusToMbusXType, nodeBinding = BIND_QUERY))
   )
 )

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -49,6 +49,13 @@ case object SbusToCbusXTypeKey extends Field[ClockCrossingType](NoCrossing)
 case object CbusToPbusXTypeKey extends Field[ClockCrossingType](SynchronousCrossing())
 case object FbusToSbusXTypeKey extends Field[ClockCrossingType](SynchronousCrossing())
 
+
+/** By default, ClockSources for the five traditional TL buses are provided from
+  * connections that originate at the SBUS. Setting this to false removes these connections and permits
+  * supplying diplomatic clocks to each bus independently.
+  */
+case object DriveClocksFromSBus extends Field[Boolean](true)
+
 // Taken together these case classes provide a backwards-compatibility parameterization
 //  of a bus topology that contains the five traditional tilelink bus wrappers.
 //  Users desiring a different topology are free to define a similar subclass,
@@ -67,16 +74,17 @@ case class HierarchicalBusTopologyParams(
   pbus: PeripheryBusParams,
   fbus: FrontBusParams,
   cbus: PeripheryBusParams,
-  xTypes: SubsystemCrossingParams
+  xTypes: SubsystemCrossingParams,
+  driveClocksFromSBus: Boolean = true
 ) extends TLBusWrapperTopology(
   instantiations = List(
     (PBUS, pbus),
     (FBUS, fbus),
     (CBUS, cbus)),
   connections = List(
-    (SBUS, CBUS, TLBusWrapperConnection  .crossTo(xTypes.sbusToCbusXType)),
-    (CBUS, PBUS, TLBusWrapperConnection  .crossTo(xTypes.cbusToPbusXType)),
-    (FBUS, SBUS, TLBusWrapperConnection.crossFrom(xTypes.fbusToSbusXType)))
+    (SBUS, CBUS, TLBusWrapperConnection  .crossTo(xTypes.sbusToCbusXType, if (driveClocksFromSBus) Some(true) else None)),
+    (CBUS, PBUS, TLBusWrapperConnection  .crossTo(xTypes.cbusToPbusXType, if (driveClocksFromSBus) Some(true) else None)),
+    (FBUS, SBUS, TLBusWrapperConnection.crossFrom(xTypes.fbusToSbusXType, if (driveClocksFromSBus) Some(false) else None)))
 )
 
 /** Parameterization of a topology containing a banked coherence manager and a bus for attaching memory devices. */
@@ -84,13 +92,17 @@ case class CoherentBusTopologyParams(
   sbus: SystemBusParams, // TODO remove this after better width propagation
   mbus: MemoryBusParams,
   l2: BankedL2Params,
-  sbusToMbusXType: ClockCrossingType = NoCrossing
+  sbusToMbusXType: ClockCrossingType = NoCrossing,
+  driveMBusClockFromSBus: Boolean = true
 ) extends TLBusWrapperTopology(
   instantiations = (if (l2.nBanks == 0) Nil else List(
     (MBUS, mbus),
     (L2, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, l2.nBanks, L2.name)(l2.coherenceManager)))),
   connections = if (l2.nBanks == 0) Nil else List(
     (SBUS, L2,   TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_STAR)()),
-    (L2,  MBUS,  TLBusWrapperConnection.crossTo(xType = sbusToMbusXType, nodeBinding = BIND_QUERY))
+    (L2,  MBUS,  TLBusWrapperConnection.crossTo(
+      xType = sbusToMbusXType,
+      driveClockFromMaster = if (driveMBusClockFromSBus) Some(true) else None,
+      nodeBinding = BIND_QUERY))
   )
 )

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -71,11 +71,15 @@ class WithCoherentBusTopology extends Config((site, here, up) => {
       pbus = site(PeripheryBusKey),
       fbus = site(FrontBusKey),
       cbus = site(ControlBusKey),
-      xTypes = SubsystemCrossingParams()),
+      xTypes = SubsystemCrossingParams(
+        sbusToCbusXType = site(SbusToCbusXTypeKey),
+        cbusToPbusXType = site(CbusToPbusXTypeKey),
+        fbusToSbusXType = site(FbusToSbusXTypeKey))),
     CoherentBusTopologyParams(
       sbus = site(SystemBusKey),
       mbus = site(MemoryBusKey),
-      l2 = site(BankedL2Key)))
+      l2 = site(BankedL2Key),
+      sbusToMbusXType = site(SbusToMbusXTypeKey)))
 })
 
 class WithNBigCores(n: Int, overrideIdOffset: Option[Int] = None) extends Config((site, here, up) => {
@@ -442,3 +446,46 @@ object LegacyTileFieldHelper {
     }
   }
 }
+
+/**
+  * Mixins to specify crossing types between the 5 traditional TL buses
+  *
+  * Note: these presuppose the legacy connections between buses and set
+  * parameters in SubsystemCrossingParams; they may not be resuable in custom
+  * topologies (but you can specify the desired crossings in your topology).
+  *
+  * @param xType The clock crossing type
+  */
+
+class WithSbusToMbusCrossingType(xType: ClockCrossingType) extends Config((site, here, up) => {
+  case SbusToMbusXTypeKey => xType
+})
+class WithSbusToCbusCrossingType(xType: ClockCrossingType) extends Config((site, here, up) => {
+  case SbusToCbusXTypeKey => xType
+})
+class WithCbusToPbusCrossingType(xType: ClockCrossingType) extends Config((site, here, up) => {
+  case CbusToPbusXTypeKey => xType
+})
+class WithFbusToSbusCrossingType(xType: ClockCrossingType) extends Config((site, here, up) => {
+  case FbusToSbusXTypeKey => xType
+})
+
+/**
+  * Mixins to set the dtsFrequency field of BusParams -- these will percolate its way
+  * up the diplomatic graph to the clock sources.
+  */
+class WithPeripheryBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
+  case PeripheryBusKey => up(PeripheryBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).round)))
+})
+class WithMemoryBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
+  case MemoryBusKey => up(MemoryBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).round)))
+})
+class WithSystemBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
+  case SystemBusKey => up(SystemBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).round)))
+})
+class WithFrontBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
+  case FrontBusKey => up(FrontBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).round)))
+})
+class WithControlBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
+  case ControlBusKey => up(ControlBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).round)))
+})

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -74,12 +74,14 @@ class WithCoherentBusTopology extends Config((site, here, up) => {
       xTypes = SubsystemCrossingParams(
         sbusToCbusXType = site(SbusToCbusXTypeKey),
         cbusToPbusXType = site(CbusToPbusXTypeKey),
-        fbusToSbusXType = site(FbusToSbusXTypeKey))),
+        fbusToSbusXType = site(FbusToSbusXTypeKey)),
+      driveClocksFromSBus = site(DriveClocksFromSBus)),
     CoherentBusTopologyParams(
       sbus = site(SystemBusKey),
       mbus = site(MemoryBusKey),
       l2 = site(BankedL2Key),
-      sbusToMbusXType = site(SbusToMbusXTypeKey)))
+      sbusToMbusXType = site(SbusToMbusXTypeKey),
+      driveMBusClockFromSBus = site(DriveClocksFromSBus)))
 })
 
 class WithNBigCores(n: Int, overrideIdOffset: Option[Int] = None) extends Config((site, here, up) => {
@@ -488,4 +490,9 @@ class WithFrontBusFrequency(freqMHz: Double) extends Config((site, here, up) => 
 })
 class WithControlBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
   case ControlBusKey => up(ControlBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).round)))
+})
+
+/** Under the default multi-bus topologies, this leaves bus ClockSinks undriven by the topology itself */
+class WithDontDriveBusClocksFromSBus extends Config((site, here, up) => {
+  case DriveClocksFromSBus => false
 })


### PR DESCRIPTION
This upstreams some of stuff we're using in Chipyard, that was discussed in ucb-bar/chipyard#690. It splats out the existing SubsystemCrossingParams into multiple `Key`s per Henry's suggestion. We could consider deprecating that class now. 

I've also added the ability to disable the default DriveClockFromMaster behavior in the provided topologies. We're driving them ourselves in Chipyard, mostly because we want to make clock naming independent of xtype selection. 

One idea I had for making it easier to define custom topologies downstream, might be to push this into the `Parameter`s instance with two Maps:
1) Map[Location, TLBusWrapperInstantiationLike] to represent instantiations
2) Map[(Location, Location), TLBusWrapperConnection] to represent connections. 

This might help avoid needing to duplicate a bunch of code to handle parameterizing multiple similar intermediate topologies (you wouldn't need to have any named subclasses of TLBusWrapperTopology) I am, however, always a little concerned about pushing more complexity into `p`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: ucb-bar/chipyard#690 <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
- Added optional MBus crossing to CoherentBusTopology
