### PR TITLE
Create TargetDirKey to expose Stage's --target-dir to Config

### DIFF
--- a/src/main/scala/stage/phases/PreElaboration.scala
+++ b/src/main/scala/stage/phases/PreElaboration.scala
@@ -14,10 +14,6 @@ import freechips.rocketchip.util.HasRocketChipStageUtils
 
 case object TargetDirKey extends Field[String](".")
 
-case class WithTargetDir(dir: String) extends Config((site, here, up) => {
-  case TargetDirKey => dir
-})
-
 /** Constructs a generator function that returns a top module with given config parameters */
 class PreElaboration extends Phase with PreservesAll[Phase] with HasRocketChipStageUtils {
 
@@ -30,7 +26,9 @@ class PreElaboration extends Phase with PreservesAll[Phase] with HasRocketChipSt
     val rOpts = view[RocketChipOptions](annotations)
     val topMod = rOpts.topModule.get
 
-    val config = getConfig(rOpts.configNames.get) ++ WithTargetDir(stageOpts.targetDir)
+    val config = getConfig(rOpts.configNames.get).alterPartial {
+	case TargetDirKey => stageOpts.targetDir
+    }
 
     val gen = () =>
       topMod

--- a/src/main/scala/stage/phases/PreElaboration.scala
+++ b/src/main/scala/stage/phases/PreElaboration.scala
@@ -7,7 +7,7 @@ import chisel3.stage.ChiselGeneratorAnnotation
 import firrtl.AnnotationSeq
 import firrtl.options.Viewer.view
 import firrtl.options.{Dependency, Phase, PreservesAll, StageOptions}
-import freechips.rocketchip.config.{Config, Field, Parameters}
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.stage.RocketChipOptions
 import freechips.rocketchip.util.HasRocketChipStageUtils
@@ -27,7 +27,7 @@ class PreElaboration extends Phase with PreservesAll[Phase] with HasRocketChipSt
     val topMod = rOpts.topModule.get
 
     val config = getConfig(rOpts.configNames.get).alterPartial {
-	case TargetDirKey => stageOpts.targetDir
+      case TargetDirKey => stageOpts.targetDir
     }
 
     val gen = () =>


### PR DESCRIPTION
`TargetDirKey` is a `Field[String]` that gets populated with the `TargetDirectoryAnnotation`
during `PreElaboration`.

Enables other `Config` `Field`s to refer to the Stage's TargetDir.  Specifically, the current [chipyard.config.WithBootROM](https://github.com/ucb-bar/chipyard/blob/0685812c342c31d735472ad13573ce8f21ed3687/generators/chipyard/src/main/scala/ConfigFragments.scala#L36-L38) depends on finding a file relative to the current-working directory of the `Stage`.  Adding `TargetDirKey` will allow `chipyard.config.WithBootROM` to look for contents relative to the TargetDir.  This will be helpful as we develop distributed elaboraton flows for Firesim in firesim#651

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**:  API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Create a `TargetDirKey` that `PreElaboration` populates with value of `TargetDirAnnotation`