### PR TITLE
Fix regression introduced by 407496940 for M_PWR commands

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -528,7 +528,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
 
   // store->load RAW hazard detection
   def s1Depends(addr: UInt, mask: UInt) =
-    addr(idxMSB, wordOffBits) === s1_req.addr(idxMSB, wordOffBits) &&
+    addr(idxMSB, wordOffBits) === s1_vaddr(idxMSB, wordOffBits) &&
     Mux(s1_write, (eccByteMask(mask) & eccByteMask(s1_mask_xwr)).orR, (mask & s1_mask_xwr).orR)
   val s1_hazard =
     (pstore1_valid_likely && s1Depends(pstore1_addr, pstore1_mask)) ||


### PR DESCRIPTION
Partial writes to the same word were not hazard-checked properly for
VIPT caches with page size < way size.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
