### PR TITLE
PTW.scala: enabling configurable L2 TLB (sets/ways)

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -37,6 +37,7 @@ case class RocketCoreParams(
   haveCFlush: Boolean = false,
   misaWritable: Boolean = true,
   nL2TLBEntries: Int = 0,
+  nL2TLBWays: Int = 1,
   mtvecInit: Option[BigInt] = Some(BigInt(0)),
   mtvecWritable: Boolean = true,
   fastLoadWord: Boolean = true,

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -45,6 +45,7 @@ trait CoreParams {
   val misaWritable: Boolean
   val haveCFlush: Boolean
   val nL2TLBEntries: Int
+  val nL2TLBWays: Int
   val mtvecInit: Option[BigInt]
   val mtvecWritable: Boolean
   def customCSRs(implicit p: Parameters): CustomCSRs = new CustomCSRs


### PR DESCRIPTION
**Related issue**: contributed by @ncppd from https://github.com/chipsalliance/rocket-chip/pull/2743

**Type of change**: feature request

**Impact**: API addition (no impact on existing code)

**Development Phase**: implementation

**Release Notes**
Add `RocketCoreParameters.nL2TLBWays` to configure a set-associative L2TLB with invalid-first-then-PLRU replacement policy.
For now, keep the default direct-mapped (1-way) dimensions.