### PR TITLE
SetAssocLRU: initialize state

### DIFF
--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -300,7 +300,9 @@ class SetAssocLRU(n_sets: Int, n_ways: Int, policy: String) extends SetAssocRepl
     case "lru"   => new TrueLRU(n_ways)
     case t => throw new IllegalArgumentException(s"unknown Replacement Policy type $t")
   }
-  val state_vec = Reg(Vec(n_sets, UInt(logic.nBits.W)))
+  val state_vec =
+    if (logic.nBits == 0) Reg(Vec(n_sets, UInt(logic.nBits.W))) // Work around elaboration error on following line
+    else RegInit(VecInit(Seq.fill(n_sets)(0.U(logic.nBits.W))))
 
   def access(set: UInt, touch_way: UInt) = {
     state_vec(set) := logic.get_next_state(state_vec(set), touch_way)


### PR DESCRIPTION
**Related issue**: https://github.com/chipsalliance/rocket-chip/pull/2748 introduced an X-prop regression in the TLB: the PseudoLRU state was being reset, but not so for the SetAssocLRU state.  Fix by resetting more things :-(

**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation