### PR TITLE
TileLink warnings: edge.manager.supports*

### DIFF
--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -81,8 +81,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     //The monitor doesn’t check for acquire T vs acquire B, it assumes that acquire B implies acquire T and only checks for acquire B
     //TODO: check for acquireT?
     when (bundle.opcode === TLMessages.AcquireBlock) {
-      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquireBlock carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquireBlock smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquireBlock address not aligned to size" + extra)
@@ -92,8 +92,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.AcquirePerm) {
-      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquirePerm carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquirePerm smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquirePerm address not aligned to size" + extra)
@@ -105,7 +105,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     when (bundle.opcode === TLMessages.Get) {
       monAssert (edge.master.emitsGet(bundle.source, bundle.size), "'A' channel carries Get type which master claims it can't emit" + diplomacyInfo + extra)
-      monAssert (edge.slave.expectsVipCheckerSupportsGet(edge.address(bundle), bundle.size, None), "'A' channel carries Get type which slave claims it can't support" + diplomacyInfo + extra)
+      monAssert (edge.slave.supportsGetFast(edge.address(bundle), bundle.size, None), "'A' channel carries Get type which slave claims it can't support" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel Get carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Get address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel Get carries invalid param" + extra)
@@ -114,7 +114,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.emitsPutFull(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutFull(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsPutFull(bundle.source, bundle.size) && edge.slave.supportsPutFullFast(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel PutFull carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutFull address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutFull carries invalid param" + extra)
@@ -122,7 +122,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.emitsPutPartial(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutPartial(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsPutPartial(bundle.source, bundle.size) && edge.slave.supportsPutPartialFast(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel PutPartial carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutPartial address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutPartial carries invalid param" + extra)
@@ -130,7 +130,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.emitsArithmetic(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsArithmetic(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsArithmetic(bundle.source, bundle.size) && edge.slave.supportsArithmeticFast(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Arithmetic carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Arithmetic address not aligned to size" + extra)
       monAssert (TLAtomics.isArithmetic(bundle.param), "'A' channel Arithmetic carries invalid opcode param" + extra)
@@ -138,7 +138,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.emitsLogical(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsLogical(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsLogical(bundle.source, bundle.size) && edge.slave.supportsLogicalFast(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Logical carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Logical address not aligned to size" + extra)
       monAssert (TLAtomics.isLogical(bundle.param), "'A' channel Logical carries invalid opcode param" + extra)
@@ -146,7 +146,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.emitsHint(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsHint(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsHint(bundle.source, bundle.size) && edge.slave.supportsHintFast(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Hint carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Hint address not aligned to size" + extra)
       monAssert (TLHints.isHints(bundle.param), "'A' channel Hint carries invalid opcode param" + extra)
@@ -167,7 +167,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     val legal_source = Mux1H(edge.client.find(bundle.source), edge.client.clients.map(c => c.sourceId.start.U)) === bundle.source
 
     when (bundle.opcode === TLMessages.Probe) {
-      assume (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
+      assume (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
       assume (address_ok, "'B' channel Probe carries unmanaged address" + extra)
       assume (legal_source, "'B' channel Probe carries source that is not first source" + extra)
       assume (is_aligned, "'B' channel Probe address not aligned to size" + extra)
@@ -177,7 +177,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.emitsPutFullFast(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel Get carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Get carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Get address not aligned to size" + extra)
@@ -187,7 +187,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.emitsPutFullFast(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutFull carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutFull carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutFull address not aligned to size" + extra)
@@ -196,7 +196,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.supportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutPartial(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.emitsPutPartialFast(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutPartial carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutPartial carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutPartial address not aligned to size" + extra)
@@ -205,7 +205,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.supportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsArithmetic(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
+      monAssert (edge.master.supportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.emitsArithmeticFast(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
       monAssert (address_ok, "'B' channel Arithmetic carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Arithmetic carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Arithmetic address not aligned to size" + extra)
@@ -214,7 +214,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.supportsLogical(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsLogical(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
+      monAssert (edge.master.supportsLogical(edge.source(bundle), bundle.size) && edge.slave.emitsLogicalFast(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Logical carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Logical carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Logical address not aligned to size" + extra)
@@ -223,7 +223,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.supportsHint(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsHint(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
+      monAssert (edge.master.supportsHint(edge.source(bundle), bundle.size) && edge.slave.emitsHintFast(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Hint carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Hint carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Hint address not aligned to size" + extra)
@@ -259,8 +259,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Release) {
-      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel Release carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel Release smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel Release address not aligned to size" + extra)
@@ -269,8 +269,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ReleaseData) {
-      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel ReleaseData carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel ReleaseData smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel ReleaseData address not aligned to size" + extra)

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -81,8 +81,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     //The monitor doesn’t check for acquire T vs acquire B, it assumes that acquire B implies acquire T and only checks for acquire B
     //TODO: check for acquireT?
     when (bundle.opcode === TLMessages.AcquireBlock) {
-      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquireBlock carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquireBlock smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquireBlock address not aligned to size" + extra)
@@ -92,8 +92,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.AcquirePerm) {
-      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquirePerm carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquirePerm smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquirePerm address not aligned to size" + extra)
@@ -105,7 +105,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     when (bundle.opcode === TLMessages.Get) {
       monAssert (edge.master.emitsGet(bundle.source, bundle.size), "'A' channel carries Get type which master claims it can't emit" + diplomacyInfo + extra)
-      monAssert (edge.slave.supportsGetFast(edge.address(bundle), bundle.size, None), "'A' channel carries Get type which slave claims it can't support" + diplomacyInfo + extra)
+      monAssert (edge.slave.supportsGetSafe(edge.address(bundle), bundle.size, None), "'A' channel carries Get type which slave claims it can't support" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel Get carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Get address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel Get carries invalid param" + extra)
@@ -114,7 +114,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.emitsPutFull(bundle.source, bundle.size) && edge.slave.supportsPutFullFast(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsPutFull(bundle.source, bundle.size) && edge.slave.supportsPutFullSafe(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel PutFull carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutFull address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutFull carries invalid param" + extra)
@@ -122,7 +122,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.emitsPutPartial(bundle.source, bundle.size) && edge.slave.supportsPutPartialFast(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsPutPartial(bundle.source, bundle.size) && edge.slave.supportsPutPartialSafe(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel PutPartial carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutPartial address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutPartial carries invalid param" + extra)
@@ -130,7 +130,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.emitsArithmetic(bundle.source, bundle.size) && edge.slave.supportsArithmeticFast(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsArithmetic(bundle.source, bundle.size) && edge.slave.supportsArithmeticSafe(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Arithmetic carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Arithmetic address not aligned to size" + extra)
       monAssert (TLAtomics.isArithmetic(bundle.param), "'A' channel Arithmetic carries invalid opcode param" + extra)
@@ -138,7 +138,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.emitsLogical(bundle.source, bundle.size) && edge.slave.supportsLogicalFast(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsLogical(bundle.source, bundle.size) && edge.slave.supportsLogicalSafe(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Logical carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Logical address not aligned to size" + extra)
       monAssert (TLAtomics.isLogical(bundle.param), "'A' channel Logical carries invalid opcode param" + extra)
@@ -146,7 +146,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.emitsHint(bundle.source, bundle.size) && edge.slave.supportsHintFast(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsHint(bundle.source, bundle.size) && edge.slave.supportsHintSafe(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Hint carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Hint address not aligned to size" + extra)
       monAssert (TLHints.isHints(bundle.param), "'A' channel Hint carries invalid opcode param" + extra)
@@ -167,7 +167,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     val legal_source = Mux1H(edge.client.find(bundle.source), edge.client.clients.map(c => c.sourceId.start.U)) === bundle.source
 
     when (bundle.opcode === TLMessages.Probe) {
-      assume (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
+      assume (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
       assume (address_ok, "'B' channel Probe carries unmanaged address" + extra)
       assume (legal_source, "'B' channel Probe carries source that is not first source" + extra)
       assume (is_aligned, "'B' channel Probe address not aligned to size" + extra)
@@ -177,7 +177,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.emitsPutFullFast(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.emitsPutFullSafe(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel Get carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Get carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Get address not aligned to size" + extra)
@@ -187,7 +187,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.emitsPutFullFast(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.emitsPutFullSafe(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutFull carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutFull carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutFull address not aligned to size" + extra)
@@ -196,7 +196,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.supportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.emitsPutPartialFast(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.emitsPutPartialSafe(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutPartial carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutPartial carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutPartial address not aligned to size" + extra)
@@ -205,7 +205,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.supportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.emitsArithmeticFast(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
+      monAssert (edge.master.supportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.emitsArithmeticSafe(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
       monAssert (address_ok, "'B' channel Arithmetic carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Arithmetic carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Arithmetic address not aligned to size" + extra)
@@ -214,7 +214,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.supportsLogical(edge.source(bundle), bundle.size) && edge.slave.emitsLogicalFast(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
+      monAssert (edge.master.supportsLogical(edge.source(bundle), bundle.size) && edge.slave.emitsLogicalSafe(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Logical carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Logical carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Logical address not aligned to size" + extra)
@@ -223,7 +223,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.supportsHint(edge.source(bundle), bundle.size) && edge.slave.emitsHintFast(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
+      monAssert (edge.master.supportsHint(edge.source(bundle), bundle.size) && edge.slave.emitsHintSafe(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Hint carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Hint carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Hint address not aligned to size" + extra)
@@ -259,8 +259,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Release) {
-      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel Release carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel Release smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel Release address not aligned to size" + extra)
@@ -269,8 +269,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ReleaseData) {
-      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBFast(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeFast(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel ReleaseData carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel ReleaseData smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel ReleaseData address not aligned to size" + extra)

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -81,8 +81,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     //The monitor doesn’t check for acquire T vs acquire B, it assumes that acquire B implies acquire T and only checks for acquire B
     //TODO: check for acquireT?
     when (bundle.opcode === TLMessages.AcquireBlock) {
-      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquireBlock carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquireBlock smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquireBlock address not aligned to size" + extra)
@@ -92,8 +92,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.AcquirePerm) {
-      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquirePerm carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquirePerm smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquirePerm address not aligned to size" + extra)
@@ -104,7 +104,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      monAssert (edge.master.expectsVipCheckerEmitsGet(bundle.source, bundle.size), "'A' channel carries Get type which master claims it can't emit" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsGet(bundle.source, bundle.size), "'A' channel carries Get type which master claims it can't emit" + diplomacyInfo + extra)
       monAssert (edge.slave.expectsVipCheckerSupportsGet(edge.address(bundle), bundle.size, None), "'A' channel carries Get type which slave claims it can't support" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel Get carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Get address not aligned to size" + extra)
@@ -114,7 +114,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.expectsVipCheckerEmitsPutFull(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutFull(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.emitsPutFull(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutFull(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel PutFull carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutFull address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutFull carries invalid param" + extra)
@@ -122,7 +122,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.expectsVipCheckerEmitsPutPartial(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutPartial(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsPutPartial(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutPartial(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel PutPartial carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutPartial address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutPartial carries invalid param" + extra)
@@ -130,7 +130,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.expectsVipCheckerEmitsArithmetic(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsArithmetic(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsArithmetic(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsArithmetic(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Arithmetic carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Arithmetic address not aligned to size" + extra)
       monAssert (TLAtomics.isArithmetic(bundle.param), "'A' channel Arithmetic carries invalid opcode param" + extra)
@@ -138,7 +138,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.expectsVipCheckerEmitsLogical(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsLogical(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsLogical(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsLogical(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Logical carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Logical address not aligned to size" + extra)
       monAssert (TLAtomics.isLogical(bundle.param), "'A' channel Logical carries invalid opcode param" + extra)
@@ -146,7 +146,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.expectsVipCheckerEmitsHint(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsHint(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.emitsHint(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsHint(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Hint carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Hint address not aligned to size" + extra)
       monAssert (TLHints.isHints(bundle.param), "'A' channel Hint carries invalid opcode param" + extra)
@@ -167,7 +167,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     val legal_source = Mux1H(edge.client.find(bundle.source), edge.client.clients.map(c => c.sourceId.start.U)) === bundle.source
 
     when (bundle.opcode === TLMessages.Probe) {
-      assume (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
+      assume (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
       assume (address_ok, "'B' channel Probe carries unmanaged address" + extra)
       assume (legal_source, "'B' channel Probe carries source that is not first source" + extra)
       assume (is_aligned, "'B' channel Probe address not aligned to size" + extra)
@@ -177,7 +177,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      monAssert (edge.master.expectsVipCheckerSupportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel Get carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Get carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Get address not aligned to size" + extra)
@@ -187,7 +187,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.expectsVipCheckerSupportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutFull carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutFull carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutFull address not aligned to size" + extra)
@@ -196,7 +196,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.expectsVipCheckerSupportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutPartial(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.supportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutPartial(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutPartial carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutPartial carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutPartial address not aligned to size" + extra)
@@ -205,7 +205,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.expectsVipCheckerSupportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsArithmetic(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
+      monAssert (edge.master.supportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsArithmetic(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
       monAssert (address_ok, "'B' channel Arithmetic carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Arithmetic carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Arithmetic address not aligned to size" + extra)
@@ -214,7 +214,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.expectsVipCheckerSupportsLogical(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsLogical(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
+      monAssert (edge.master.supportsLogical(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsLogical(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Logical carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Logical carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Logical address not aligned to size" + extra)
@@ -223,7 +223,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.expectsVipCheckerSupportsHint(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsHint(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
+      monAssert (edge.master.supportsHint(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsHint(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Hint carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Hint carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Hint address not aligned to size" + extra)
@@ -259,8 +259,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Release) {
-      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
-      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel Release carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel Release smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel Release address not aligned to size" + extra)
@@ -269,8 +269,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ReleaseData) {
-      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
-      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
+      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel ReleaseData carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel ReleaseData smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel ReleaseData address not aligned to size" + extra)

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -81,8 +81,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     //The monitor doesn’t check for acquire T vs acquire B, it assumes that acquire B implies acquire T and only checks for acquire B
     //TODO: check for acquireT?
     when (bundle.opcode === TLMessages.AcquireBlock) {
-      monAssert (edge.expectsVipCheckerMasterToSlaveAcquireB(bundle.source, edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.expectsVipCheckerSlaveToMasterProbe(edge.source(bundle), edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquireBlock carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquireBlock smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquireBlock address not aligned to size" + extra)
@@ -92,8 +92,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.AcquirePerm) {
-      monAssert (edge.expectsVipCheckerMasterToSlaveAcquireB(bundle.source, edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.expectsVipCheckerSlaveToMasterProbe(edge.source(bundle), edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquirePerm carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquirePerm smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquirePerm address not aligned to size" + extra)
@@ -114,7 +114,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.expectsVipCheckerMasterToSlavePutFull(bundle.source, edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsPutFull(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutFull(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel PutFull carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutFull address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutFull carries invalid param" + extra)
@@ -122,7 +122,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.expectsVipCheckerMasterToSlavePutPartial(bundle.source, edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsPutPartial(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsPutPartial(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel PutPartial carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutPartial address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutPartial carries invalid param" + extra)
@@ -130,7 +130,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.expectsVipCheckerMasterToSlaveArithmetic(bundle.source, edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsArithmetic(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsArithmetic(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Arithmetic carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Arithmetic address not aligned to size" + extra)
       monAssert (TLAtomics.isArithmetic(bundle.param), "'A' channel Arithmetic carries invalid opcode param" + extra)
@@ -138,7 +138,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.expectsVipCheckerMasterToSlaveLogical(bundle.source, edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsLogical(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsLogical(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Logical carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Logical address not aligned to size" + extra)
       monAssert (TLAtomics.isLogical(bundle.param), "'A' channel Logical carries invalid opcode param" + extra)
@@ -146,7 +146,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.expectsVipCheckerMasterToSlaveHint(bundle.source, edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsHint(bundle.source, bundle.size) && edge.slave.expectsVipCheckerSupportsHint(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Hint carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Hint address not aligned to size" + extra)
       monAssert (TLHints.isHints(bundle.param), "'A' channel Hint carries invalid opcode param" + extra)
@@ -167,7 +167,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     val legal_source = Mux1H(edge.client.find(bundle.source), edge.client.clients.map(c => c.sourceId.start.U)) === bundle.source
 
     when (bundle.opcode === TLMessages.Probe) {
-      assume (edge.expectsVipCheckerSlaveToMasterProbe(edge.source(bundle), edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
+      assume (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
       assume (address_ok, "'B' channel Probe carries unmanaged address" + extra)
       assume (legal_source, "'B' channel Probe carries source that is not first source" + extra)
       assume (is_aligned, "'B' channel Probe address not aligned to size" + extra)
@@ -177,7 +177,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      monAssert (edge.expectsVipCheckerSlaveToMasterPutFull(edge.source(bundle), edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel Get carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Get carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Get address not aligned to size" + extra)
@@ -187,7 +187,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.expectsVipCheckerSlaveToMasterPutFull(edge.source(bundle), edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsPutFull(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutFull(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutFull carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutFull carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutFull address not aligned to size" + extra)
@@ -196,7 +196,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.expectsVipCheckerSlaveToMasterPutPartial(edge.source(bundle), edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsPutPartial(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutPartial carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutPartial carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutPartial address not aligned to size" + extra)
@@ -205,7 +205,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.expectsVipCheckerSlaveToMasterArithmetic(edge.source(bundle), edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsArithmetic(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
       monAssert (address_ok, "'B' channel Arithmetic carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Arithmetic carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Arithmetic address not aligned to size" + extra)
@@ -214,7 +214,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.expectsVipCheckerSlaveToMasterLogical(edge.source(bundle), edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsLogical(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsLogical(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Logical carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Logical carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Logical address not aligned to size" + extra)
@@ -223,7 +223,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.expectsVipCheckerSlaveToMasterHint(edge.source(bundle), edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsHint(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsHint(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Hint carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Hint carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Hint address not aligned to size" + extra)
@@ -259,8 +259,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Release) {
-      monAssert (edge.expectsVipCheckerMasterToSlaveAcquireB(edge.source(bundle), edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
-      monAssert (edge.expectsVipCheckerSlaveToMasterProbe(edge.source(bundle), edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel Release carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel Release smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel Release address not aligned to size" + extra)
@@ -269,8 +269,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ReleaseData) {
-      monAssert (edge.expectsVipCheckerMasterToSlaveAcquireB(edge.source(bundle), edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
-      monAssert (edge.expectsVipCheckerSlaveToMasterProbe(edge.source(bundle), edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.master.expectsVipCheckerEmitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerSupportsAcquireB(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
+      monAssert (edge.master.expectsVipCheckerSupportsProbe(edge.source(bundle), bundle.size) && edge.slave.expectsVipCheckerEmitsProbe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel ReleaseData carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel ReleaseData smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel ReleaseData address not aligned to size" + extra)

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -557,15 +557,15 @@ class TLSlavePortParameters private(
   def mayDenyPut  = slaves.exists(_.mayDenyPut)
 
   // Diplomatically determined operation sizes emitted by all outward Slaves
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to emits* which generate circuitry to check which specific addresses
   val allEmitClaims = slaves.map(_.emits).reduce( _ intersect _)
 
   // Operation Emitted by at least one outward Slaves
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to emits* which generate circuitry to check which specific addresses
   val anyEmitClaims = slaves.map(_.emits).reduce(_ mincover _)
 
   // Diplomatically determined operation sizes supported by all outward Slaves
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to supports* which generate circuitry to check which specific addresses
   val allSupportClaims = slaves.map(_.supports).reduce( _ intersect _)
   val allSupportAcquireT   = allSupportClaims.acquireT
   val allSupportAcquireB   = allSupportClaims.acquireB
@@ -577,7 +577,7 @@ class TLSlavePortParameters private(
   val allSupportHint       = allSupportClaims.hint
 
   // Operation supported by at least one outward Slaves
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to supports* which generate circuitry to check which specific addresses
   val anySupportClaims = slaves.map(_.supports).reduce(_ mincover _)
   val anySupportAcquireT   = !anySupportClaims.acquireT.none
   val anySupportAcquireB   = !anySupportClaims.acquireB.none
@@ -687,23 +687,13 @@ class TLSlavePortParameters private(
   def supportsPutPartialFast (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putPartial, address, lgSize, range)
   def supportsHintFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.hint,       address, lgSize, range)
 
-  // Check for support of a given operation at a specific address
-  def expectsVipCheckerSupportsAcquireT  (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.acquireT,   address, lgSize, range)
-  def expectsVipCheckerSupportsAcquireB  (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.acquireB,   address, lgSize, range)
-  def expectsVipCheckerSupportsArithmetic(address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.arithmetic, address, lgSize, range)
-  def expectsVipCheckerSupportsLogical   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.logical,    address, lgSize, range)
-  def expectsVipCheckerSupportsGet       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.get,        address, lgSize, range)
-  def expectsVipCheckerSupportsPutFull   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putFull,    address, lgSize, range)
-  def expectsVipCheckerSupportsPutPartial(address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putPartial, address, lgSize, range)
-  def expectsVipCheckerSupportsHint      (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.hint,       address, lgSize, range)
-
-  def expectsVipCheckerEmitsProbe        (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.probe,         address, lgSize, range)
-  def expectsVipCheckerEmitsArithmetic   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.arithmetic,    address, lgSize, range)
-  def expectsVipCheckerEmitsLogical      (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.logical,       address, lgSize, range)
-  def expectsVipCheckerEmitsGet          (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.get,           address, lgSize, range)
-  def expectsVipCheckerEmitsPutFull      (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.putFull,       address, lgSize, range)
-  def expectsVipCheckerEmitsPutPartial   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.putPartial,    address, lgSize, range)
-  def expectsVipCheckerEmitsHint         (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.hint,          address, lgSize, range)
+  def emitsProbeFast         (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.probe,         address, lgSize, range)
+  def emitsArithmeticFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.arithmetic,    address, lgSize, range)
+  def emitsLogicalFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.logical,       address, lgSize, range)
+  def emitsGetFast           (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.get,           address, lgSize, range)
+  def emitsPutFullFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.putFull,       address, lgSize, range)
+  def emitsPutPartialFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.putPartial,    address, lgSize, range)
+  def emitsHintFast          (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.hint,          address, lgSize, range)
 
   def findTreeViolation() = slaves.flatMap(_.findTreeViolation()).headOption
   def isTree = !slaves.exists(!_.isTree)
@@ -1112,15 +1102,15 @@ class TLMasterPortParameters private(
   }
 
   // Diplomatically determined operation sizes emitted by all inward Masters
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to emits* which generate circuitry to check which specific addresses
   val allEmitClaims = masters.map(_.emits).reduce( _ intersect _)
 
   // Diplomatically determined operation sizes Emitted by at least one inward Masters
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to emits* which generate circuitry to check which specific addresses
   val anyEmitClaims = masters.map(_.emits).reduce(_ mincover _)
 
   // Diplomatically determined operation sizes supported by all inward Masters
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to supports* which generate circuitry to check which specific addresses
   val allSupportProbe      = masters.map(_.supportsProbe)     .reduce(_ intersect _)
   val allSupportArithmetic = masters.map(_.supportsArithmetic).reduce(_ intersect _)
   val allSupportLogical    = masters.map(_.supportsLogical)   .reduce(_ intersect _)
@@ -1130,7 +1120,7 @@ class TLMasterPortParameters private(
   val allSupportHint       = masters.map(_.supportsHint)      .reduce(_ intersect _)
 
   // Diplomatically determined operation sizes supported by at least one master
-  // as opposed to expectsVipChecker which generate circuitry to check which specific addresses
+  // as opposed to supports* which generate circuitry to check which specific addresses
   val anySupportProbe      = masters.map(!_.supportsProbe.none)     .reduce(_ || _)
   val anySupportArithmetic = masters.map(!_.supportsArithmetic.none).reduce(_ || _)
   val anySupportLogical    = masters.map(!_.supportsLogical.none)   .reduce(_ || _)

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -669,39 +669,23 @@ class TLSlavePortParameters private(
     }.foldLeft(Bool(false))(_||_)
   }
 
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveAcquireT instead of manager.supportsAcquireTSafe","")
   def supportsAcquireTSafe   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.acquireT,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveAcquireB instead of manager.supportsAcquireBSafe","")
   def supportsAcquireBSafe   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.acquireB,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveArithmetic instead of manager.supportsArithmeticSafe","")
-  def supportsArithmeticSafe (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.arithmetic,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveLogical instead of manager.supportsLogicalSafe","")
-  def supportsLogicalSafe    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.logical,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveGet instead of manager.supportsGetSafe","")
-  def supportsGetSafe        (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.get,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlavePutFull instead of manager.supportsPutFullSafe","")
-  def supportsPutFullSafe    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.putFull,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlavePutPartial instead of manager.supportsPutPartialSafe","")
-  def supportsPutPartialSafe (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.putPartial,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveHint instead of manager.supportsHintSafe","")
-  def supportsHintSafe       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.hint,   address, lgSize, range)
+  def supportsArithmeticSafe (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.arithmetic, address, lgSize, range)
+  def supportsLogicalSafe    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.logical,    address, lgSize, range)
+  def supportsGetSafe        (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.get,        address, lgSize, range)
+  def supportsPutFullSafe    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.putFull,    address, lgSize, range)
+  def supportsPutPartialSafe (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.putPartial, address, lgSize, range)
+  def supportsHintSafe       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.hint,       address, lgSize, range)
 
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveAcquireT instead of manager.supportsAcquireTFast","")
   def supportsAcquireTFast   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.acquireT,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveAcquireB instead of manager.supportsAcquireBFast","")
   def supportsAcquireBFast   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.acquireB,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveArithmetic instead of manager.supportsArithmeticFast","")
-  def supportsArithmeticFast (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.arithmetic,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveLogical instead of manager.supportsLogicalFast","")
-  def supportsLogicalFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.logical,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveGet instead of manager.supportsGetFast","")
-  def supportsGetFast        (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.get,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlavePutFull instead of manager.supportsPutFullFast","")
-  def supportsPutFullFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putFull,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlavePutPartial instead of manager.supportsPutPartialFast","")
-  def supportsPutPartialFast (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putPartial,   address, lgSize, range)
-  @deprecated("Use edge.expectsVipCheckerMasterToSlaveHint instead of manager.supportsHintFast","")
-  def supportsHintFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.hint,   address, lgSize, range)
+  def supportsArithmeticFast (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.arithmetic, address, lgSize, range)
+  def supportsLogicalFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.logical,    address, lgSize, range)
+  def supportsGetFast        (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.get,        address, lgSize, range)
+  def supportsPutFullFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putFull,    address, lgSize, range)
+  def supportsPutPartialFast (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putPartial, address, lgSize, range)
+  def supportsHintFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.hint,       address, lgSize, range)
 
   // Check for support of a given operation at a specific address
   def expectsVipCheckerSupportsAcquireT  (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.acquireT,   address, lgSize, range)
@@ -1175,20 +1159,13 @@ class TLMasterPortParameters private(
     }
   }
 
-  @deprecated("Use edge.expectsVipCheckerSlaveToMasterProbe instead of clientPort.supportsProbe","")
-  def supportsProbe = expectsVipCheckerSupportsProbe
-  @deprecated("Use edge.expectsVipCheckerSlaveToMasterArithmetic instead of clientPort.supportsArithmetic","")
+  def supportsProbe      = expectsVipCheckerSupportsProbe
   def supportsArithmetic = expectsVipCheckerSupportsArithmetic
-  @deprecated("Use edge.expectsVipCheckerSlaveToMasterLogical instead of clientPort.supportsLogical","")
-  def supportsLogical = expectsVipCheckerSupportsLogical
-  @deprecated("Use edge.expectsVipCheckerSlaveToMasterGet instead of clientPort.supportsGet","")
-  def supportsGet = expectsVipCheckerSupportsGet
-  @deprecated("Use edge.expectsVipCheckerSlaveToMasterPutFull instead of clientPort.supportsPutFull","")
-  def supportsPutFull = expectsVipCheckerSupportsPutFull
-  @deprecated("Use edge.expectsVipCheckerSlaveToMasterPutPartial instead of clientPort.supportsPutPartial","")
+  def supportsLogical    = expectsVipCheckerSupportsLogical
+  def supportsGet        = expectsVipCheckerSupportsGet
+  def supportsPutFull    = expectsVipCheckerSupportsPutFull
   def supportsPutPartial = expectsVipCheckerSupportsPutPartial
-  @deprecated("Use edge.expectsVipCheckerSlaveToMasterHint instead of clientPort.supportsHint","")
-  def supportsHint = expectsVipCheckerSupportsHint
+  def supportsHint       = expectsVipCheckerSupportsHint
 
   // Check for support of a given operation at a specific id
   val expectsVipCheckerSupportsProbe      = sourceIdHelper(_.supports.probe)      _

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -653,6 +653,9 @@ class TLSlavePortParameters private(
     // the right answer even if you give it an illegal address'
     // the not safe version is a cheaper circuit but if you give it an illegal address then it might produce the wrong answer
     // fast presumes address legality
+
+    // This groupByIntoSeq deterministically groups all address sets for which a given `member` transfer size applies.
+    // In the resulting Map of cases, the keys are transfer sizes and the values are all address sets which emit or support that size.
     val supportCases = groupByIntoSeq(slaves)(m => trim(member(m))).map { case (k: TransferSizes, vs: Seq[TLSlaveParameters]) =>
       k -> vs.flatMap(_.address)
     }

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -1159,22 +1159,14 @@ class TLMasterPortParameters private(
     }
   }
 
-  def supportsProbe      = expectsVipCheckerSupportsProbe
-  def supportsArithmetic = expectsVipCheckerSupportsArithmetic
-  def supportsLogical    = expectsVipCheckerSupportsLogical
-  def supportsGet        = expectsVipCheckerSupportsGet
-  def supportsPutFull    = expectsVipCheckerSupportsPutFull
-  def supportsPutPartial = expectsVipCheckerSupportsPutPartial
-  def supportsHint       = expectsVipCheckerSupportsHint
-
   // Check for support of a given operation at a specific id
-  val expectsVipCheckerSupportsProbe      = sourceIdHelper(_.supports.probe)      _
-  val expectsVipCheckerSupportsArithmetic = sourceIdHelper(_.supports.arithmetic) _
-  val expectsVipCheckerSupportsLogical    = sourceIdHelper(_.supports.logical)    _
-  val expectsVipCheckerSupportsGet        = sourceIdHelper(_.supports.get)        _
-  val expectsVipCheckerSupportsPutFull    = sourceIdHelper(_.supports.putFull)    _
-  val expectsVipCheckerSupportsPutPartial = sourceIdHelper(_.supports.putPartial) _
-  val expectsVipCheckerSupportsHint       = sourceIdHelper(_.supports.hint)       _
+  val supportsProbe      = sourceIdHelper(_.supports.probe)      _
+  val supportsArithmetic = sourceIdHelper(_.supports.arithmetic) _
+  val supportsLogical    = sourceIdHelper(_.supports.logical)    _
+  val supportsGet        = sourceIdHelper(_.supports.get)        _
+  val supportsPutFull    = sourceIdHelper(_.supports.putFull)    _
+  val supportsPutPartial = sourceIdHelper(_.supports.putPartial) _
+  val supportsHint       = sourceIdHelper(_.supports.hint)       _
 
   // TODO: Merge sourceIdHelper2 with sourceIdHelper
   private def sourceIdHelper2(
@@ -1193,14 +1185,14 @@ class TLMasterPortParameters private(
   }
 
   // Check for emit of a given operation at a specific id
-  def expectsVipCheckerEmitsAcquireT  (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.acquireT,   sourceId, lgSize)
-  def expectsVipCheckerEmitsAcquireB  (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.acquireB,   sourceId, lgSize)
-  def expectsVipCheckerEmitsArithmetic(sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.arithmetic, sourceId, lgSize)
-  def expectsVipCheckerEmitsLogical   (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.logical,    sourceId, lgSize)
-  def expectsVipCheckerEmitsGet       (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.get,        sourceId, lgSize)
-  def expectsVipCheckerEmitsPutFull   (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.putFull,    sourceId, lgSize)
-  def expectsVipCheckerEmitsPutPartial(sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.putPartial, sourceId, lgSize)
-  def expectsVipCheckerEmitsHint      (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.hint,       sourceId, lgSize)
+  def emitsAcquireT  (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.acquireT,   sourceId, lgSize)
+  def emitsAcquireB  (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.acquireB,   sourceId, lgSize)
+  def emitsArithmetic(sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.arithmetic, sourceId, lgSize)
+  def emitsLogical   (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.logical,    sourceId, lgSize)
+  def emitsGet       (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.get,        sourceId, lgSize)
+  def emitsPutFull   (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.putFull,    sourceId, lgSize)
+  def emitsPutPartial(sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.putPartial, sourceId, lgSize)
+  def emitsHint      (sourceId: UInt, lgSize: UInt) = sourceIdHelper2(_.emits.hint,       sourceId, lgSize)
 
   def infoString = masters.map(_.infoString).mkString
 

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -1387,38 +1387,6 @@ case class TLEdgeParameters(
 
   def diplomaticClaimsMasterToSlave = master.anyEmitClaims.intersect(slave.anySupportClaims)
 
-  // For emits, check that the source is allowed to send this transactions
-  //These A channel messages from MasterToSlave are:
-  //being routed to a slave based on address bits,
-  //    so they need to be passed to a helper that checks whether the slave that owns certain addresses
-  //    claimed to support transactions of this size/type
-  //being sent from a master using sourceId bits,
-  //    so they need to be passed to a helper that checks whether the master that owns certain sourceIds
-  //    claimed to emit transactions of this size/type
-  def expectsVipCheckerMasterToSlaveAcquireT   (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsAcquireT      (sourceId, lgSize) && slave.expectsVipCheckerSupportsAcquireT   (address, lgSize, range)
-  def expectsVipCheckerMasterToSlaveAcquireB   (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsAcquireB      (sourceId, lgSize) && slave.expectsVipCheckerSupportsAcquireB   (address, lgSize, range)
-  def expectsVipCheckerMasterToSlaveArithmetic (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsArithmetic    (sourceId, lgSize) && slave.expectsVipCheckerSupportsArithmetic (address, lgSize, range)
-  def expectsVipCheckerMasterToSlaveLogical    (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsLogical       (sourceId, lgSize) && slave.expectsVipCheckerSupportsLogical    (address, lgSize, range)
-  def expectsVipCheckerMasterToSlaveGet        (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsGet           (sourceId, lgSize) && slave.expectsVipCheckerSupportsGet        (address, lgSize, range)
-  def expectsVipCheckerMasterToSlavePutFull    (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsPutFull       (sourceId, lgSize) && slave.expectsVipCheckerSupportsPutFull    (address, lgSize, range)
-  def expectsVipCheckerMasterToSlavePutPartial (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsPutPartial    (sourceId, lgSize) && slave.expectsVipCheckerSupportsPutPartial (address, lgSize, range)
-  def expectsVipCheckerMasterToSlaveHint       (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerEmitsHint          (sourceId, lgSize) && slave.expectsVipCheckerSupportsHint       (address, lgSize, range)
-
-  //Duality: these B channel messages from SlaveToMaster are:
-  //being routed to a master based on sourceId bits,
-  //    so they need to be passed to a helper that checks whether the master that owns certain sourceIds
-  //    claimed to support transactions of this size/type
-  //being sent from a slave owning certain addresses,
-  //    so they need to be passed to a helper that checks with the slave that owns certain addresses claimed
-  //    to emit transactions of this size/type
-  def expectsVipCheckerSlaveToMasterProbe      (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerSupportsProbe      (sourceId, lgSize) && slave.expectsVipCheckerEmitsProbe         (address, lgSize, range)
-  def expectsVipCheckerSlaveToMasterArithmetic (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerSupportsArithmetic (sourceId, lgSize) && slave.expectsVipCheckerEmitsArithmetic    (address, lgSize, range)
-  def expectsVipCheckerSlaveToMasterLogical    (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerSupportsLogical    (sourceId, lgSize) && slave.expectsVipCheckerEmitsLogical       (address, lgSize, range)
-  def expectsVipCheckerSlaveToMasterGet        (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerSupportsGet        (sourceId, lgSize) && slave.expectsVipCheckerEmitsGet           (address, lgSize, range)
-  def expectsVipCheckerSlaveToMasterPutFull    (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerSupportsPutFull    (sourceId, lgSize) && slave.expectsVipCheckerEmitsPutFull       (address, lgSize, range)
-  def expectsVipCheckerSlaveToMasterPutPartial (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerSupportsPutPartial (sourceId, lgSize) && slave.expectsVipCheckerEmitsPutPartial    (address, lgSize, range)
-  def expectsVipCheckerSlaveToMasterHint       (sourceId: UInt, address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = master.expectsVipCheckerSupportsHint       (sourceId, lgSize) && slave.expectsVipCheckerEmitsHint          (address, lgSize, range)
-
   val bundle = TLBundleParameters(master, slave)
   def formatEdge = master.infoString + "\n" + slave.infoString
 }

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -687,13 +687,13 @@ class TLSlavePortParameters private(
   def supportsPutPartialFast (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.putPartial, address, lgSize, range)
   def supportsHintFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.supports.hint,       address, lgSize, range)
 
-  def emitsProbeFast         (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.probe,         address, lgSize, range)
-  def emitsArithmeticFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.arithmetic,    address, lgSize, range)
-  def emitsLogicalFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.logical,       address, lgSize, range)
-  def emitsGetFast           (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.get,           address, lgSize, range)
-  def emitsPutFullFast       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.putFull,       address, lgSize, range)
-  def emitsPutPartialFast    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.putPartial,    address, lgSize, range)
-  def emitsHintFast          (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(false, _.emits.hint,          address, lgSize, range)
+  def emitsProbeSafe         (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.emits.probe,         address, lgSize, range)
+  def emitsArithmeticSafe    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.emits.arithmetic,    address, lgSize, range)
+  def emitsLogicalSafe       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.emits.logical,       address, lgSize, range)
+  def emitsGetSafe           (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.emits.get,           address, lgSize, range)
+  def emitsPutFullSafe       (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.emits.putFull,       address, lgSize, range)
+  def emitsPutPartialSafe    (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.emits.putPartial,    address, lgSize, range)
+  def emitsHintSafe          (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.emits.hint,          address, lgSize, range)
 
   def findTreeViolation() = slaves.flatMap(_.findTreeViolation()).headOption
   def isTree = !slaves.exists(!_.isTree)

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -827,21 +827,6 @@ class TLMasterParameters private(
     case _ => throw new IndexOutOfBoundsException(n.toString)
   }
 
-  @deprecated("Use supports.probe instead of supportsProbe","")
-  def supportsProbe:       TransferSizes   = supports.probe
-  @deprecated("Use supports.arithmetic instead of supportsArithmetic","")
-  def supportsArithmetic:  TransferSizes   = supports.arithmetic
-  @deprecated("Use supports.logical instead of supportsLogical","")
-  def supportsLogical:     TransferSizes   = supports.logical
-  @deprecated("Use supports.get instead of supportsGet","")
-  def supportsGet:         TransferSizes   = supports.get
-  @deprecated("Use supports.putFull instead of supportsPutFull","")
-  def supportsPutFull:     TransferSizes   = supports.putFull
-  @deprecated("Use supports.putPartial instead of supportsPutPartial","")
-  def supportsPutPartial:  TransferSizes   = supports.putPartial
-  @deprecated("Use supports.hint instead of supportsHint","")
-  def supportsHint:        TransferSizes   = supports.hint
-
   require (!sourceId.isEmpty)
   require (!visibility.isEmpty)
   require (supports.putFull.contains(supports.putPartial))
@@ -1114,23 +1099,23 @@ class TLMasterPortParameters private(
 
   // Diplomatically determined operation sizes supported by all inward Masters
   // as opposed to supports* which generate circuitry to check which specific addresses
-  val allSupportProbe      = masters.map(_.supportsProbe)     .reduce(_ intersect _)
-  val allSupportArithmetic = masters.map(_.supportsArithmetic).reduce(_ intersect _)
-  val allSupportLogical    = masters.map(_.supportsLogical)   .reduce(_ intersect _)
-  val allSupportGet        = masters.map(_.supportsGet)       .reduce(_ intersect _)
-  val allSupportPutFull    = masters.map(_.supportsPutFull)   .reduce(_ intersect _)
-  val allSupportPutPartial = masters.map(_.supportsPutPartial).reduce(_ intersect _)
-  val allSupportHint       = masters.map(_.supportsHint)      .reduce(_ intersect _)
+  val allSupportProbe      = masters.map(_.supports.probe)     .reduce(_ intersect _)
+  val allSupportArithmetic = masters.map(_.supports.arithmetic).reduce(_ intersect _)
+  val allSupportLogical    = masters.map(_.supports.logical)   .reduce(_ intersect _)
+  val allSupportGet        = masters.map(_.supports.get)       .reduce(_ intersect _)
+  val allSupportPutFull    = masters.map(_.supports.putFull)   .reduce(_ intersect _)
+  val allSupportPutPartial = masters.map(_.supports.putPartial).reduce(_ intersect _)
+  val allSupportHint       = masters.map(_.supports.hint)      .reduce(_ intersect _)
 
   // Diplomatically determined operation sizes supported by at least one master
   // as opposed to supports* which generate circuitry to check which specific addresses
-  val anySupportProbe      = masters.map(!_.supportsProbe.none)     .reduce(_ || _)
-  val anySupportArithmetic = masters.map(!_.supportsArithmetic.none).reduce(_ || _)
-  val anySupportLogical    = masters.map(!_.supportsLogical.none)   .reduce(_ || _)
-  val anySupportGet        = masters.map(!_.supportsGet.none)       .reduce(_ || _)
-  val anySupportPutFull    = masters.map(!_.supportsPutFull.none)   .reduce(_ || _)
-  val anySupportPutPartial = masters.map(!_.supportsPutPartial.none).reduce(_ || _)
-  val anySupportHint       = masters.map(!_.supportsHint.none)      .reduce(_ || _)
+  val anySupportProbe      = masters.map(!_.supports.probe.none)     .reduce(_ || _)
+  val anySupportArithmetic = masters.map(!_.supports.arithmetic.none).reduce(_ || _)
+  val anySupportLogical    = masters.map(!_.supports.logical.none)   .reduce(_ || _)
+  val anySupportGet        = masters.map(!_.supports.get.none)       .reduce(_ || _)
+  val anySupportPutFull    = masters.map(!_.supports.putFull.none)   .reduce(_ || _)
+  val anySupportPutPartial = masters.map(!_.supports.putPartial.none).reduce(_ || _)
+  val anySupportHint       = masters.map(!_.supports.hint.none)      .reduce(_ || _)
 
   // These return Option[TLMasterParameters] for your convenience
   def find(id: Int) = masters.find(_.sourceId.contains(id))


### PR DESCRIPTION
**Related issue**: follow-up to deprecation warnings introduced in https://github.com/chipsalliance/rocket-chip/pull/2505

**Type of change**: paying off technical debt

**Impact**: API removal

**Development Phase**: implementation

**Release Notes**
the `expectsVipChecker` naming introduced in https://github.com/chipsalliance/rocket-chip/pull/2505 caused confusion, so going back to the "support*/emits*" and "Fast-or-Safe" naming schemes.
