### PR TITLE
compile warning: ElaborationArtefactAnnotation remove unreachable code

### DIFF
--- a/src/main/scala/util/ElaborationArtefactAnnotation.scala
+++ b/src/main/scala/util/ElaborationArtefactAnnotation.scala
@@ -77,7 +77,6 @@ case class MemoryPathToken(target: ReferenceTarget) extends Token {
         many.tail.foldLeft(Seq[Token](MemoryPathToken(many.head.asInstanceOf[ReferenceTarget]))) {
           case (tokens, r: ReferenceTarget) => this.copy(target = r) +: StringToken(" ") +: tokens
         }.reverse
-      case Some(other) => throw new Exception(s"memory $target cannot be renamed to $other")
     }
   }
 }


### PR DESCRIPTION
**Related issue**: introduced by https://github.com/chipsalliance/rocket-chip/pull/2729

**Type of change**: paying off technical debt

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
fix compile warning:
```
[warn] /rocket-chip/src/main/scala/util/ElaborationArtefactAnnotation.scala:80:27: unreachable code
[warn]       case Some(other) => throw new Exception(s"memory $target cannot be renamed to $other")
[warn]                           ^
```