### PR TITLE
chisel3.experimental.chiselName is no longer necessary with chisel3._

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.devices.debug
 
 
 import chisel3._
-import chisel3.experimental.chiselName
 import chisel3.util._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
@@ -283,7 +282,6 @@ object WNotifyVal {
   }
 }
 
-@chiselName
 class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyModule {
 
   // For Shorter Register Names
@@ -691,7 +689,6 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
   }
 }
 
-@chiselName
 class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: Int)(implicit p: Parameters) extends LazyModule
 {
 

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -4,8 +4,6 @@ package freechips.rocketchip.devices.debug
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.chiselName
-
 
 import freechips.rocketchip.config._
 import freechips.rocketchip.jtag._
@@ -74,7 +72,6 @@ class SystemJTAGIO extends Bundle {
 }
 
 // Use the Chisel Name macro due to the bulk of this being inside a withClockAndReset block
-@chiselName
 class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   (implicit val p: Parameters) extends RawModule  {
 

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -7,7 +7,6 @@ import chisel3._
 import chisel3.util._
 import chisel3.util.HasBlackBoxResource
 import chisel3.experimental.IntParam
-import chisel3.experimental.chiselName
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.rocket._
@@ -122,7 +121,6 @@ class AccumulatorExample(opcodes: OpcodeSet, val n: Int = 4)(implicit p: Paramet
   override lazy val module = new AccumulatorExampleModuleImp(this)
 }
 
-@chiselName
 class AccumulatorExampleModuleImp(outer: AccumulatorExample)(implicit p: Parameters) extends LazyRoCCModuleImp(outer)
     with HasCoreParameters {
   val regfile = Mem(outer.n, UInt(xLen.W))
@@ -193,7 +191,6 @@ class  TranslatorExample(opcodes: OpcodeSet)(implicit p: Parameters) extends Laz
   override lazy val module = new TranslatorExampleModuleImp(this)
 }
 
-@chiselName
 class TranslatorExampleModuleImp(outer: TranslatorExample)(implicit p: Parameters) extends LazyRoCCModuleImp(outer)
     with HasCoreParameters {
   val req_addr = Reg(UInt(coreMaxAddrBits.W))
@@ -242,7 +239,6 @@ class  CharacterCountExample(opcodes: OpcodeSet)(implicit p: Parameters) extends
   override val atlNode = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1("CharacterCountRoCC")))))
 }
 
-@chiselName
 class CharacterCountExampleModuleImp(outer: CharacterCountExample)(implicit p: Parameters) extends LazyRoCCModuleImp(outer)
   with HasCoreParameters
   with HasL1CacheParameters {

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.tilelink
 import chisel3._
 import chisel3.util._
 import chisel3.internal.sourceinfo.SourceLine
-import chisel3.experimental.chiselName
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.PlusArg
@@ -31,7 +30,6 @@ object TLMonitor {
   }
 }
 
-@chiselName
 class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirection.Monitor) extends TLMonitorBase(args)
 {
   require (args.edge.params(TLMonitorStrictMode) || (! args.edge.params(TestplanTestType).formal))

--- a/src/main/scala/util/ReadyValidCancel.scala
+++ b/src/main/scala/util/ReadyValidCancel.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.util
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.chiselName
 
 /** A [[Bundle]] that adds `earlyValid` and `lateCancel` bits to some data.
   * This indicates that the user expects a "ValidCancel" interface between a producer and a consumer.
@@ -95,7 +94,6 @@ object ReadyValidCancel {
   * consumer.io.in <> arb.io.out
   * }}}
   */
-@chiselName
 class ReadyValidCancelRRArbiter[T <: Data](gen: T, n: Int, rr: Boolean) extends Module {
   val io = IO(new Bundle{
     val in  = Flipped(Vec(n, ReadyValidCancel(gen)))


### PR DESCRIPTION
**Related issue**: follow-up to https://github.com/chipsalliance/chisel3/pull/1448

**Type of change**: paying off technical debt

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
remove `@chiselName` pragma from all `import chisel3._` files