### PR TITLE
Removed .sbtopts which contains '$PWD' by default, and remove the '\'…

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,0 @@
--Dsbt.sourcemode=true
--Dsbt.workspace=$PWD

--- a/scripts/swap-sbt-build
+++ b/scripts/swap-sbt-build
@@ -11,5 +11,5 @@ if [ -f $sbt_opts ]; then
 else
   echo ".sbtopts does not exist so chisel3 and firrtl are currently built from published artifacts, swapping to build from source..."
   echo "-Dsbt.sourcemode=true"  > $sbt_opts
-  echo "-Dsbt.workspace=\$PWD" >> $sbt_opts
+  echo "-Dsbt.workspace=$(PWD)" >> $sbt_opts
 fi

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -18,6 +18,7 @@ class BaseConfig extends Config(
   new WithTimebase(BigInt(1000000)) ++ // 1 MHz
   new WithDTS("freechips,rocketchip-unknown", Nil) ++
   new WithNExtTopInterrupts(2) ++
+  new WithCoherentBusTopology ++
   new BaseSubsystemConfig()
 )
 


### PR DESCRIPTION
… to ensure the command is executed. Should run './scripts/swap-sbt-build' manually at first.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: .sbtopts is incorrected to set to -Dsbt.workspace=$PWD, which causes loading the project in IDEA failed <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change 
<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
