### PR TITLE
add WithCoherentBusTopology to BaseFPGAConfig

### DIFF
--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -82,5 +82,5 @@ class MMIOPortOnlyConfig extends Config(
   new DefaultConfig
 )
 
-class BaseFPGAConfig extends Config(new BaseConfig)
+class BaseFPGAConfig extends Config(new BaseConfig ++ new WithCoherentBusTopology)
 class DefaultFPGAConfig extends Config(new WithNSmallCores(1) ++ new BaseFPGAConfig)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable --> #2599

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--Add WithCoherentBusTopology to BaseFPGAConfig.  Fixing issue when trying to build rocket-chip for fpga.
-->Add WithCoherentBusTopology to BaseFPGAConfig.  Fixing issue when trying to build rocket-chip for fpga.
