### PR TITLE
ReadyValidCancelRRArbiter: non-power-of-2 round-robin select

### DIFF
--- a/src/main/scala/util/ReadyValidCancel.scala
+++ b/src/main/scala/util/ReadyValidCancel.scala
@@ -125,7 +125,11 @@ class ReadyValidCancelRRArbiter[T <: Data](gen: T, n: Int, rr: Boolean) extends 
       val k = (i + j) % n
       grantVecVec(i)(k) := !(inputEarlyValidVec.rotate(i).take(j).orR)
     }
-    nextSelectEncVec(i) := i.U +& PriorityEncoder(inputEarlyValidVec.rotate(i) & ~1.U(n.W).asBools)
+    if (isPow2(n)) {
+      nextSelectEncVec(i) := i.U +& PriorityEncoder(inputEarlyValidVec.rotate(i) & ~1.U(n.W).asBools)
+    } else {
+      nextSelectEncVec(i) := (i.U +& PriorityEncoder(inputEarlyValidVec.rotate(i) & ~1.U(n.W).asBools)) % n.U
+    }
   }
 
   if (rr) {


### PR DESCRIPTION
**Type of change**: bug report

**Impact**: functional change | no API modification

**Development Phase**: implementation

**Release Notes**
wrap `ReadyValidCancelRRArbiter` `nextSelectEnc` value using modulo when Round-Robin parameters `rr=true && !isPow2(n)` 
