### PR TITLE
Deprecate GenericParameterizedBundle for autoclonetype2

### DIFF
--- a/src/main/scala/util/GenericParameterizedBundle.scala
+++ b/src/main/scala/util/GenericParameterizedBundle.scala
@@ -4,18 +4,5 @@ package freechips.rocketchip.util
 
 import Chisel._
 
+@deprecated("GenericParameterizedBundle is useless anymore after autoclonetype2 is on.", "Rocket Chip 2021.04")
 abstract class GenericParameterizedBundle[+T <: Object](val params: T) extends Bundle
-{
-  override def cloneType = {
-    try {
-      this.getClass.getConstructors.head.newInstance(params).asInstanceOf[this.type]
-    } catch {
-      case e: java.lang.IllegalArgumentException =>
-        throw new Exception("Unable to use GenericParameterizedBundle.cloneType on " +
-                       this.getClass + ", probably because " + this.getClass +
-                       "() takes more than one argument.  Consider overriding " +
-                       "cloneType() on " + this.getClass, e)
-    }
-  }
-}
-


### PR DESCRIPTION
This PR removes `cloneType` implementation in `GenericParameterizedBundle`, which should be the fix for chipsalliance/chisel3#1858.

This PR should be merged in Chisel 3.4.3/3.5 bumpping PR.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
chipsalliance/chisel3#1858

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
deprecate `GenericParameterizedBundle`