### PR TITLE
convert TestHarness to chisel3, work around compatibility mode naming issue.

### DIFF
--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.amba.axi4
 
 import Chisel._
+import chisel3.chiselTypeOf
 import chisel3.util.Irrevocable
 import freechips.rocketchip.util._
 
@@ -82,11 +83,16 @@ class AXI4Bundle(params: AXI4BundleParameters) extends AXI4BundleBase(params)
         aw.ready := Bool(false)
         w.ready  := Bool(false)
         r.valid  := Bool(false)
+        r.bits := 0.U.asTypeOf(chiselTypeOf(b.bits))
         b.valid  := Bool(false)
+        b.bits := 0.U.asTypeOf(chiselTypeOf(b.bits))
       case OUTPUT =>
         ar.valid := Bool(false)
+        ar.bits  := 0.U.asTypeOf(chiselTypeOf(ar.bits))
         aw.valid := Bool(false)
+        aw.bits  := 0.U.asTypeOf(chiselTypeOf(aw.bits))
         w.valid  := Bool(false)
+        w.bits   := 0.U.asTypeOf(chiselTypeOf(w.bits))
         r.ready  := Bool(false)
         b.ready  := Bool(false)
       case _ =>

--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.amba.axi4
 
 import Chisel._
-import chisel3.chiselTypeOf
+import chisel3.DontCare
 import chisel3.util.Irrevocable
 import freechips.rocketchip.util._
 
@@ -83,16 +83,16 @@ class AXI4Bundle(params: AXI4BundleParameters) extends AXI4BundleBase(params)
         aw.ready := Bool(false)
         w.ready  := Bool(false)
         r.valid  := Bool(false)
-        r.bits := 0.U.asTypeOf(chiselTypeOf(b.bits))
+        r.bits   := DontCare
         b.valid  := Bool(false)
-        b.bits := 0.U.asTypeOf(chiselTypeOf(b.bits))
+        b.bits   := DontCare
       case OUTPUT =>
         ar.valid := Bool(false)
-        ar.bits  := 0.U.asTypeOf(chiselTypeOf(ar.bits))
+        ar.bits  := DontCare
         aw.valid := Bool(false)
-        aw.bits  := 0.U.asTypeOf(chiselTypeOf(aw.bits))
+        aw.bits  := DontCare
         w.valid  := Bool(false)
-        w.bits   := 0.U.asTypeOf(chiselTypeOf(w.bits))
+        w.bits   := DontCare
         r.ready  := Bool(false)
         b.ready  := Bool(false)
       case _ =>

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.system
 
-import Chisel._
+import chisel3._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.devices.debug.Debug
 import freechips.rocketchip.diplomacy.LazyModule


### PR DESCRIPTION
This is the work around for TestHarness io cannot be named correctly chipsalliance/chisel3#1862.
But I think this should be safe to merge.


**Related issue**: chipsalliance/chisel3#1862

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation