### PR TITLE
Prevent TLWidthWidget from generating X outputs

### DIFF
--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -50,6 +50,9 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
       }
 
       def helper(idata: UInt): UInt = {
+        // rdata is X until the first time a multi-beat write occurs.
+        // Prevent the X from leaking outside by jamming the mux control until
+        // the first time rdata is written (and hence no longer X).
         val rdata_written_once = RegInit(false.B)
         val masked_enable = enable.map(_ || !rdata_written_once)
 


### PR DESCRIPTION
Widening WidthWidgets contain an uninitialized data register. The first transaction through the widget may propagate that register's contents on the bus, which is logically correct but can propagates a X, violating our constraint that we never provide X in the payload of a valid xact.

Fix by propagating in.bits.data, rather than the register, until the register has been written at least once. This is cheaper than resetting the register.