### PR TITLE
Fix x-prop issue in ScratchpadSlavePort

### DIFF
--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -41,10 +41,11 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
 
     val (tl_in, edge) = node.in(0)
 
-    val s_ready :: s_wait1 :: s_wait2 :: s_replay :: s_init :: s_grant :: s_dummy :: Nil = Enum(UInt(), 7)
+    val s_ready :: s_wait1 :: s_wait2 :: s_replay :: s_init :: s_grant :: Nil = Enum(UInt(), 6)
     val state = Reg(init = s_init)
     val dmem_req_valid = Wire(Bool())
     when (state === s_wait1) { state := s_wait2 }
+    when (state === s_init && tl_in.a.valid) { state := s_ready }
     when (io.dmem.resp.valid) { state := s_grant }
     when (tl_in.d.fire()) { state := s_ready }
     when (io.dmem.s2_nack) { state := s_replay }
@@ -82,9 +83,8 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
     // ready_likely assumes that a valid response in s_wait2 is the vastly
     // common case.  In the uncommon case, we'll erroneously send a request,
     // then s1_kill it the following cycle.
-    // n.b. s_dummy is an invalid state; it's just here for logic optimization.
-    val ready_likely = state.isOneOf(s_ready, s_init, s_wait2, s_dummy)
-    val ready = state.isOneOf(s_ready, s_init) || state.isOneOf(s_wait2, s_dummy) && io.dmem.resp.valid && tl_in.d.ready
+    val ready_likely = state.isOneOf(s_ready, s_wait2)
+    val ready = state === s_ready || state === s_wait2 && io.dmem.resp.valid && tl_in.d.ready
     dmem_req_valid := (tl_in.a.valid && ready) || state === s_replay
     val dmem_req_valid_likely = (tl_in.a.valid && ready_likely) || state === s_replay
 


### PR DESCRIPTION
Don't let D$ req.cmd field become X, or else it'll make req.ready become X, which confuses the Rocket core.

Wrong D$ command was sent on first slave-port access.