### PR TITLE
Suppress an X-propagation in Rocket ITIM

### DIFF
--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -298,8 +298,12 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
     }
   }
 
+  // When writing a full scratchpad word, suppress the read so Xs don't leak out
+  val s1s2_full_word_write = Wire(init = false.B)
+  val s1_dont_read = s1_slaveValid && s1s2_full_word_write
+
   val s1_clk_en = s1_valid || s1_slaveValid
-  val s2_tag_hit = RegEnable(s1_tag_hit, s1_clk_en)
+  val s2_tag_hit = RegEnable(Mux(s1_dont_read, 0.U.asTypeOf(s1_tag_hit), s1_tag_hit), s1_clk_en)
   val s2_hit_way = OHToUInt(s2_tag_hit)
   val s2_scratchpad_word_addr = Cat(s2_hit_way, Mux(s2_slaveValid, s1s3_slaveAddr, io.s2_vaddr)(untagBits-1, log2Ceil(wordBits/8)), UInt(0, log2Ceil(wordBits/8)))
   val s2_dout = RegEnable(s1_dout, s1_clk_en)
@@ -309,11 +313,10 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   val s2_tl_error = RegEnable(s1_tl_error.asUInt.orR, s1_clk_en)
   val s2_data_decoded = dECC.decode(s2_way_mux)
   val s2_disparity = s2_tag_disparity || s2_data_decoded.error
-  val s2_full_word_write = Wire(init = false.B)
 
   val s1_scratchpad_hit = Mux(s1_slaveValid, lineInScratchpad(scratchpadLine(s1s3_slaveAddr)), addrInScratchpad(io.s1_paddr))
   val s2_scratchpad_hit = RegEnable(s1_scratchpad_hit, s1_clk_en)
-  val s2_report_uncorrectable_error = s2_scratchpad_hit && s2_data_decoded.uncorrectable && (s2_valid || (s2_slaveValid && !s2_full_word_write))
+  val s2_report_uncorrectable_error = s2_scratchpad_hit && s2_data_decoded.uncorrectable && (s2_valid || (s2_slaveValid && !s1s2_full_word_write))
   val s2_error_addr = scratchpadBase.map(base => Mux(s2_scratchpad_hit, base + s2_scratchpad_word_addr, 0.U)).getOrElse(0.U)
 
   // output signals
@@ -348,7 +351,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
         val respValid = RegInit(false.B)
         tl.a.ready := !(tl_out.d.valid || s1_slaveValid || s2_slaveValid || s3_slaveValid || respValid || !io.clock_enabled)
         val s1_a = RegEnable(tl.a.bits, s0_slaveValid)
-        s2_full_word_write := edge_in.get.hasData(s1_a) && s1_a.mask.andR
+        s1s2_full_word_write := edge_in.get.hasData(s1_a) && s1_a.mask.andR
         when (s0_slaveValid) {
           val a = tl.a.bits
           s1s3_slaveAddr := tl.a.bits.address
@@ -387,7 +390,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
         }
 
         respValid := s2_slaveValid || (respValid && !tl.d.ready)
-        val respError = RegEnable(s2_scratchpad_hit && s2_data_decoded.uncorrectable && !s2_full_word_write, s2_slaveValid)
+        val respError = RegEnable(s2_scratchpad_hit && s2_data_decoded.uncorrectable && !s1s2_full_word_write, s2_slaveValid)
         when (s2_slaveValid) {
           when (edge_in.get.hasData(s1_a) || s2_data_decoded.error) { s3_slaveValid := true }
           def byteEn(i: Int) = !(edge_in.get.hasData(s1_a) && s1_a.mask(i))


### PR DESCRIPTION
ITIM writes are implemented as RMW operations and so cause ITIM reads.
Thus, initializing the ITIM can cause Xs to leak out.  But full-word ITIM writes don't need to be RMW, so we can suppress the Xs from leaking out in that special case.

Conveniently, we already require that TIMs be initialized with full-word writes for ECC purposes, so preventing the Xs from leaking out only in the full-word write case suffices.