### PR TITLE
remove testOnly, since upstream implemented it.

### DIFF
--- a/common.sc
+++ b/common.sc
@@ -57,12 +57,6 @@ trait CommonRocketChip extends SbtModule with PublishModule {
     def testFrameworks = T {
       Seq("org.scalatest.tools.Framework")
     }
-
-    // a sbt-like testOnly command.
-    // for example, mill -i "chisel3[2.12.12].test.testOnly" "chiselTests.BitwiseOpsSpec"
-    def testOnly(args: String*) = T.command {
-      super.runMain("org.scalatest.run", args: _*)
-    }
   }
 
   override def millSourcePath = super.millSourcePath / os.up


### PR DESCRIPTION
Mill implemented its own `testOnly` in https://github.com/com-lihaoyi/mill/commit/838e3259921718778b01b554455bbf1942865cb5 , this PR fixed compile in mill 0.9.8.