### PR TITLE
PTW timing: L2TLB PLRU select write way

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -226,7 +226,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     val r_valid_vec = valid.map(_(r_idx)).asUInt
     when (l2_refill && !invalidated) {
       val entry = Wire(new L2TLBEntry(nL2TLBSets))
-      val wmask = if (coreParams.nL2TLBWays > 1) Mux(r_valid_vec.andR, UIntToOH(l2_plru.way(r_idx)), PriorityEncoderOH(~r_valid_vec)) else 1.U(1.W)
+      val wmask = if (coreParams.nL2TLBWays > 1) Mux(r_valid_vec.andR, UIntToOH(RegNext(l2_plru.way(r_idx)), coreParams.nL2TLBWays), PriorityEncoderOH(~r_valid_vec)) else 1.U(1.W)
 
       entry := r_pte
       entry.tag := r_tag


### PR DESCRIPTION
**Related issue**: introduced by https://github.com/chipsalliance/rocket-chip/pull/2748

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
hoist `l2_plru.way(r_idx)` onto a register before L2TLB refill `wmask`