### PR TITLE
PTW: timing L2TLB valid select write way

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -224,10 +224,10 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     val valid = RegInit(Vec(Seq.fill(coreParams.nL2TLBWays)(0.U(nL2TLBSets.W))))
     val (r_tag, r_idx) = Split(r_req.addr, idxBits)
     val r_valid_vec = valid.map(_(r_idx)).asUInt
-    val r_valid_vec_q = Wire(UInt(coreParams.nL2TLBWays.W))
-    val r_l2_plru_way = Wire(UInt(log2Ceil(coreParams.nL2TLBWays max 1).W))
-    r_valid_vec_q := RegNext(r_valid_vec)
-    r_l2_plru_way := (if (coreParams.nL2TLBWays > 1) RegNext(l2_plru.way(r_idx)) else 0.U)
+    val r_valid_vec_q = Reg(UInt(coreParams.nL2TLBWays.W))
+    val r_l2_plru_way = Reg(UInt(log2Ceil(coreParams.nL2TLBWays max 1).W))
+    r_valid_vec_q := r_valid_vec
+    r_l2_plru_way := (if (coreParams.nL2TLBWays > 1) l2_plru.way(r_idx) else 0.U)
     when (l2_refill && !invalidated) {
       val entry = Wire(new L2TLBEntry(nL2TLBSets))
       entry := r_pte

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -224,12 +224,16 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     val valid = RegInit(Vec(Seq.fill(coreParams.nL2TLBWays)(0.U(nL2TLBSets.W))))
     val (r_tag, r_idx) = Split(r_req.addr, idxBits)
     val r_valid_vec = valid.map(_(r_idx)).asUInt
+    val r_valid_vec_q = Wire(UInt(coreParams.nL2TLBWays.W))
+    val r_l2_plru_way = Wire(UInt(log2Ceil(coreParams.nL2TLBWays max 1).W))
+    r_valid_vec_q := RegNext(r_valid_vec)
+    r_l2_plru_way := (if (coreParams.nL2TLBWays > 1) RegNext(l2_plru.way(r_idx)) else 0.U)
     when (l2_refill && !invalidated) {
       val entry = Wire(new L2TLBEntry(nL2TLBSets))
-      val wmask = if (coreParams.nL2TLBWays > 1) Mux(r_valid_vec.andR, UIntToOH(RegNext(l2_plru.way(r_idx)), coreParams.nL2TLBWays), PriorityEncoderOH(~r_valid_vec)) else 1.U(1.W)
-
       entry := r_pte
       entry.tag := r_tag
+
+      val wmask = if (coreParams.nL2TLBWays > 1) Mux(r_valid_vec_q.andR, UIntToOH(r_l2_plru_way, coreParams.nL2TLBWays), PriorityEncoderOH(~r_valid_vec_q)) else 1.U(1.W)
       ram.write(r_idx, Vec(Seq.fill(coreParams.nL2TLBWays)(code.encode(entry.asUInt))), wmask.asBools)
 
       val mask = UIntToOH(r_idx)


### PR DESCRIPTION
**Related issue**: my timing fix from #2856 was incomplete

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
 hoist `r_valid_vec` onto a register before L2TLB refill `wmask`