### PR TITLE
NMI spec updates: removed UNMI, added new mnie bit to mnstatus

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -112,7 +112,7 @@ class RocketLogicalTreeNode(
       interruptLatency = 4,
       nLocalInterrupts = coreParams.nLocalInterrupts,
       rnmiPresent = coreParams.useNMI,
-      unmiPresent = coreParams.useNMI,
+      unmiPresent = false,
       nBreakpoints = coreParams.nBreakpoints,
       mcontextWidth = coreParams.mcontextWidth,
       scontextWidth = coreParams.scontextWidth,

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -513,6 +513,7 @@ class CSRFile(
 
   val read_mnstatus = WireInit(0.U.asTypeOf(new MStatus()))
   read_mnstatus.mpp := io.status.mpp
+  read_mnstatus.mie := reg_rnmie
   val nmi_csrs = if (!usingNMI) LinkedHashMap() else LinkedHashMap[Int,Bits](
     CSRs.mnscratch -> reg_mnscratch,
     CSRs.mnepc -> readEPC(reg_mnepc).sextTo(xLen),
@@ -951,7 +952,10 @@ class CSRFile(
       when (decoded_addr(CSRs.mnscratch)) { reg_mnscratch := wdata }
       when (decoded_addr(CSRs.mnepc))     { reg_mnepc := formEPC(wdata) }
       when (decoded_addr(CSRs.mncause))   { reg_mncause := wdata & UInt((BigInt(1) << (xLen-1)) + BigInt(3)) }
-      when (decoded_addr(CSRs.mnstatus))  { reg_mnstatus.mpp := legalizePrivilege(new_mnstatus.mpp) }
+      when (decoded_addr(CSRs.mnstatus))  {
+        reg_mnstatus.mpp := legalizePrivilege(new_mnstatus.mpp)
+        reg_rnmie := reg_rnmie | new_mnstatus.mie  // mnie bit settable but not clearable from software
+      }
     }
 
     for (((e, c), i) <- (reg_hpmevent zip reg_hpmcounter) zipWithIndex) {

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -512,7 +512,7 @@ class CSRFile(
     reg_dscratch1.map(r => CSRs.dscratch1 -> r)
 
   val read_mnstatus = WireInit(0.U.asTypeOf(new MStatus()))
-  read_mnstatus.mpp := io.status.mpp
+  read_mnstatus.mpp := reg_mnstatus.mpp
   read_mnstatus.mie := reg_rnmie
   val nmi_csrs = if (!usingNMI) LinkedHashMap() else LinkedHashMap[Int,Bits](
     CSRs.mnscratch -> reg_mnscratch,

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -13,9 +13,6 @@ class NMI(val w: Int) extends Bundle {
   val rnmi = Bool()
   val rnmi_interrupt_vector = UInt(w.W)
   val rnmi_exception_vector = UInt(w.W)
-  val unmi = Bool()
-  val unmi_interrupt_vector = UInt(w.W)
-  val unmi_exception_vector = UInt(w.W)
 }
 
 class TileInterrupts(implicit p: Parameters) extends CoreBundle()(p) {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

**Impact**: API modification

**Development Phase**: implementation

**Release Notes**
The NMI arch spec is being prepared for submission to RISC-V International. As part of that, the UNMI feature has been removed from it.  External IO unmi_* were removed and all internal implementation referring to unmi was removed. Most changes are in the CSR modules where NMI is processed.

The latest NMI spec has added a bit `mnie` (not `nmie`) to `mnstatus`.  This bit reflects the internal `rnmie` state. `rnmie` is set at reset, is cleared when an NMI is taken, and is set by executing `mnret` at the end of the NMI handler (unchanged by this PR). Now `rnmie` can also be read and set by software so that nested NMIs can be processed. `rnmie` cannot be cleared by software, per the spec.

The mnstatus register read value was using `io.status.mpp`  (= `mstatus.mpp`) instead of `mnstatus.mpp`.