### PR TITLE
PTW: Non-leaf PTEs with D/A/U==1 are reserved

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -69,7 +69,7 @@ class PTE(implicit p: Parameters) extends CoreBundle()(p) {
   val r = Bool()
   val v = Bool()
 
-  def table(dummy: Int = 0) = v && !r && !w && !x
+  def table(dummy: Int = 0) = v && !r && !w && !x && !d && !a && !u
   def leaf(dummy: Int = 0) = v && (r || (x && !w)) && a
   def ur(dummy: Int = 0) = sr() && u
   def uw(dummy: Int = 0) = sw() && u


### PR DESCRIPTION
**Related issue**: resolves https://github.com/chipsalliance/rocket-chip/issues/2895

**Type of change**: bug report

**Impact**: API addition (no impact on existing code)

**Development Phase**: implementation

**Release Notes**
Page fault on "table" entry (RWX=0) with D/A/U bit set.
Well-behaved software should have no problem.
Software that was setting these reserved bits will start getting unexpected page faults.