### PR TITLE
Update GroundTest to use generic BuildHellaCache key

### DIFF
--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -7,7 +7,7 @@ import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.rocket.{DCache, ICacheParams, NonBlockingDCache, RocketCoreParams}
+import freechips.rocketchip.rocket.{BuildHellaCache, ICacheParams, RocketCoreParams}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 
@@ -38,10 +38,7 @@ abstract class GroundTestTile(
   val slaveNode: TLInwardNode = TLIdentityNode()
   val statusNode = BundleBridgeSource(() => new GroundTestStatus)
 
-  val dcacheOpt = params.dcache.map { dc => LazyModule(
-    if (dc.nMSHRs == 0) new DCache(staticIdForMetadataUseOnly, crossing)
-    else new NonBlockingDCache(staticIdForMetadataUseOnly)
-  )}
+  val dcacheOpt = params.dcache.map { dc => LazyModule(p(BuildHellaCache)(this)(p)) }
 
   dcacheOpt.foreach { _.hartIdSinkNodeOpt.foreach { _ := hartIdNexusNode } }
 


### PR DESCRIPTION
Makes it easier to test alternative implementations of HellaCache

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation