### PR TITLE
Add WithBootROMResetAddress config for changing reset vector of bootrom

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -326,6 +326,10 @@ class WithBootROMFile(bootROMFile: String) extends Config((site, here, up) => {
   case BootROMLocated(x) => up(BootROMLocated(x), site).map(_.copy(contentFileName = bootROMFile))
 })
 
+class WithBootROMResetAddress(resetAddress: BigInt) extends Config((site, here, up) => {
+  case BootROMLocated(x) => up(BootROMLocated(x), site).map(_.copy(hang = resetAddress))
+})
+
 class WithSynchronousRocketTiles extends Config((site, here, up) => {
   case RocketCrossingKey => up(RocketCrossingKey, site) map { r =>
     r.copy(crossingType = SynchronousCrossing())


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**

Add WithBootROMResetAddress config for changing reset vector of bootrom (e.g. _start in bootrom.S)

<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
