### PR TITLE
AmbaProt memory type for non-cacheable fetches should be "Normal Non-cacheable Bufferable"

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -166,6 +166,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   icache.io.s1_kill := s2_redirect || tlb.io.resp.miss || s2_replay
   val s2_can_speculatively_refill = s2_tlb_resp.cacheable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableSpeculativeICacheRefill
   icache.io.s2_kill := s2_speculative && !s2_can_speculatively_refill || s2_xcpt
+  icache.io.s2_cacheable := s2_tlb_resp.cacheable
   icache.io.s2_prefetch := s2_tlb_resp.prefetchable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableICachePrefetch
 
   fq.io.enq.valid := RegNext(s1_valid) && s2_valid && (icache.io.resp.valid || !s2_tlb_resp.miss && icache.io.s2_kill)

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -191,7 +191,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
         hprot(0) := !x.fetch
         hprot(1) :=  x.privileged
         hprot(2) :=  x.bufferable
-        hprot(3) :=  x.modifiable
+        hprot(3) :=  x.modifiable && (x.readalloc || x.writealloc) // cacheable
         out.hprot := Cat(hprot.reverse)
       }
 


### PR DESCRIPTION
**Related issue**: follow-up to https://github.com/chipsalliance/rocket-chip/pull/2386

**Type of change**: bug report

**Impact**: functional change

**Development Phase**: implementation

**Release Notes**
We don't believe anything inside Rocket-chip was depending on this.
If somebody was using the Cacheable bit from a Non-cacheable AXI or AHB port, then this would be an errata.
The AMBA AXI protocol specification includes a section “Mismatched memory attributes” which says:
> Multiple agents that are accessing the same area of memory, can use mismatched memory attributes. However, for functional correctness, the following rules must be obeyed:
> - All masters accessing the same area of memory must have a consistent view of the Cacheability …