### PR TITLE
Bump to Chisel 3.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,7 @@ import scala.sys.process._
 
 enablePlugins(PackPlugin)
 
-// This needs to stay in sync with the chisel3 and firrtl git submodules
-val chiselVersion = "3.4.3"
+val chiselVersion = "3.5.0"
 
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
@@ -18,7 +17,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value),
   libraryDependencies ++= Seq("org.json4s" %% "json4s-jackson" % "3.6.1"),
   libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.0" % "test"),
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),
     Resolver.sonatypeRepo("releases"),

--- a/common.sc
+++ b/common.sc
@@ -4,8 +4,8 @@ import mill.scalalib.publish._
 import coursier.maven.MavenRepository
 
 val defaultVersions = Map(
-  "chisel3" -> "3.4.3",
-  "chisel3-plugin" -> "3.4.3"
+  "chisel3" -> "3.5.0",
+  "chisel3-plugin" -> "3.5.0"
 )
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs", cross: Boolean = false) = {

--- a/src/main/scala/amba/axis/Bundles.scala
+++ b/src/main/scala/amba/axis/Bundles.scala
@@ -24,7 +24,6 @@ case class AXISDataField(width: Int) extends BundleField(AXISData) {
 }
 
 class AXISBundleBits(val params: AXISBundleParameters) extends BundleMap(AXISBundle.keys(params)) {
-  override def cloneType: this.type = (new AXISBundleBits(params)).asInstanceOf[this.type]
   def last = if (params.hasLast) apply(AXISLast) else true.B
   def id   = if (params.hasId)   apply(AXISId)   else 0.U
   def dest = if (params.hasDest) apply(AXISDest) else 0.U
@@ -34,7 +33,6 @@ class AXISBundleBits(val params: AXISBundleParameters) extends BundleMap(AXISBun
 }
 
 class AXISBundle(val params: AXISBundleParameters) extends IrrevocableIO(new AXISBundleBits(params)) {
-  override def cloneType: this.type = (new AXISBundle(params)).asInstanceOf[this.type]
 }
 
 object AXISBundle {

--- a/src/main/scala/devices/debug/DMI.scala
+++ b/src/main/scala/devices/debug/DMI.scala
@@ -42,7 +42,6 @@ class DMIReq(addrBits : Int) extends Bundle {
   val data = UInt(DMIConsts.dmiDataSize.W)
   val op   = UInt(DMIConsts.dmiOpSize.W)
 
-  override def cloneType = new DMIReq(addrBits).asInstanceOf[this.type]
 }
 
 /** Structure to define the contents of a Debug Bus Response

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -40,7 +40,6 @@ class DMIAccessUpdate(addrBits: Int) extends Bundle {
   val data = UInt(DMIConsts.dmiDataSize.W)
   val op = UInt(DMIConsts.dmiOpSize.W)
 
-  override def cloneType = new DMIAccessUpdate(addrBits).asInstanceOf[this.type]
 }
 
 class DMIAccessCapture(addrBits: Int) extends Bundle {
@@ -48,7 +47,6 @@ class DMIAccessCapture(addrBits: Int) extends Bundle {
   val data = UInt(DMIConsts.dmiDataSize.W)
   val resp = UInt(DMIConsts.dmiRespSize.W)
 
-  override def cloneType = new DMIAccessCapture(addrBits).asInstanceOf[this.type]
 
 }
 

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -7,7 +7,7 @@ import chisel3.util._
 
 import freechips.rocketchip.config._
 import freechips.rocketchip.jtag._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 
 case class JtagDTMConfig (
@@ -178,8 +178,8 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   // so that we don't consider junk in the FIFO to be an error response.
   // The current specification says that any non-zero response is an error.
   nonzeroResp := stickyNonzeroRespReg | (io.dmi.resp.valid & (io.dmi.resp.bits.resp =/= 0.U))
-  cover(!nonzeroResp, "Should see a non-zero response (e.g. when accessing most DM registers when dmactive=0)")
-  cover(!stickyNonzeroRespReg, "Should see a sticky non-zero response (e.g. when accessing most DM registers when dmactive=0)")
+  property.cover(!nonzeroResp, "Should see a non-zero response (e.g. when accessing most DM registers when dmactive=0)")
+  property.cover(!stickyNonzeroRespReg, "Should see a sticky non-zero response (e.g. when accessing most DM registers when dmactive=0)")
 
   busyResp.addr  := 0.U
   busyResp.resp  := ~(0.U(DMIConsts.dmiRespSize.W)) // Generalizing busy to 'all-F'
@@ -231,14 +231,14 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
       dmiAccessChain.io.capture.capture & !busy)
 
   // incorrect operation - not enough time was spent in JTAG Idle state after DMI Write
-  cover(dmiReqReg.op === DMIConsts.dmi_OP_WRITE & dmiAccessChain.io.capture.capture & busy, "Not enough Idle after DMI Write");
+  property.cover(dmiReqReg.op === DMIConsts.dmi_OP_WRITE & dmiAccessChain.io.capture.capture & busy, "Not enough Idle after DMI Write");
   // correct operation - enough time was spent in JTAG Idle state after DMI Write
-  cover(dmiReqReg.op === DMIConsts.dmi_OP_WRITE & dmiAccessChain.io.capture.capture & !busy, "Enough Idle after DMI Write");
+  property.cover(dmiReqReg.op === DMIConsts.dmi_OP_WRITE & dmiAccessChain.io.capture.capture & !busy, "Enough Idle after DMI Write");
 
   // incorrect operation - not enough time was spent in JTAG Idle state after DMI Read
-  cover(dmiReqReg.op === DMIConsts.dmi_OP_READ & dmiAccessChain.io.capture.capture & busy, "Not enough Idle after DMI Read");
+  property.cover(dmiReqReg.op === DMIConsts.dmi_OP_READ & dmiAccessChain.io.capture.capture & busy, "Not enough Idle after DMI Read");
   // correct operation - enough time was spent in JTAG Idle state after DMI Read
-  cover(dmiReqReg.op === DMIConsts.dmi_OP_READ & dmiAccessChain.io.capture.capture & !busy, "Enough Idle after DMI Read");
+  property.cover(dmiReqReg.op === DMIConsts.dmi_OP_READ & dmiAccessChain.io.capture.capture & !busy, "Enough Idle after DMI Read");
 
   io.dmi.req.valid := dmiReqValidReg
 

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import freechips.rocketchip.devices.debug._
 
 object SystemBusAccessState extends scala.Enumeration {
@@ -240,19 +240,19 @@ object SystemBusAccessModule
       SBCSRdData := 0.U.asTypeOf(new SBCSFields())
     }
 
-    cover(SBCSFieldsReg.sbbusyerror,    "SBCS Cover", "sberror set")
-    cover(SBCSFieldsReg.sbbusy === 3.U, "SBCS Cover", "sbbusyerror alignment error")
+    property.cover(SBCSFieldsReg.sbbusyerror,    "SBCS Cover", "sberror set")
+    property.cover(SBCSFieldsReg.sbbusy === 3.U, "SBCS Cover", "sbbusyerror alignment error")
 
-    cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 0.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "8-bit access")
-    cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 1.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "16-bit access")
-    cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 2.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "32-bit access")
-    cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 3.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "64-bit access")
-    cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 4.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "128-bit access")
+    property.cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 0.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "8-bit access")
+    property.cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 1.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "16-bit access")
+    property.cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 2.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "32-bit access")
+    property.cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 3.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "64-bit access")
+    property.cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess === 4.U && !sbAccessError && !sbAlignmentError, "SBCS Cover", "128-bit access")
 
-    cover(SBCSFieldsReg.sbautoincrement && SBCSFieldsReg.sbbusy,  "SBCS Cover", "Access with autoincrement set")
-    cover(!SBCSFieldsReg.sbautoincrement && SBCSFieldsReg.sbbusy, "SBCS Cover", "Access without autoincrement set")
+    property.cover(SBCSFieldsReg.sbautoincrement && SBCSFieldsReg.sbbusy,  "SBCS Cover", "Access with autoincrement set")
+    property.cover(!SBCSFieldsReg.sbautoincrement && SBCSFieldsReg.sbbusy, "SBCS Cover", "Access without autoincrement set")
 
-    cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess > 4.U, "SBCS Cover", "Invalid sbaccess value")
+    property.cover((sb2tl.module.io.wrEn || sb2tl.module.io.rdEn) && SBCSFieldsReg.sbaccess > 4.U, "SBCS Cover", "Invalid sbaccess value")
 
     (sbcsfields, sbaddrfields, sbdatafields)
   }
@@ -372,14 +372,14 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
             sbState === SBReadResponse.id.U ||          
             sbState === SBWriteResponse.id.U, "SBA state machine in undefined state")
 
-    cover (sbState === Idle.id.U,            "SBA State Cover", "SBA Access Idle")
-    cover (sbState === SBReadRequest.id.U,   "SBA State Cover", "SBA Access Read Req")
-    cover (sbState === SBWriteRequest.id.U,  "SBA State Cover", "SBA Access Write Req")
-    cover (sbState === SBReadResponse.id.U,  "SBA State Cover", "SBA Access Read Resp")
-    cover (sbState === SBWriteResponse.id.U, "SBA State Cover", "SBA Access Write Resp")
+    property.cover (sbState === Idle.id.U,            "SBA State Cover", "SBA Access Idle")
+    property.cover (sbState === SBReadRequest.id.U,   "SBA State Cover", "SBA Access Read Req")
+    property.cover (sbState === SBWriteRequest.id.U,  "SBA State Cover", "SBA Access Write Req")
+    property.cover (sbState === SBReadResponse.id.U,  "SBA State Cover", "SBA Access Read Resp")
+    property.cover (sbState === SBWriteResponse.id.U, "SBA State Cover", "SBA Access Write Resp")
 
-    cover (io.rdEn && !io.rdLegal, "SB Legality Cover", "SBA Rd Address Illegal")
-    cover (io.wrEn && !io.wrLegal, "SB Legality Cover", "SBA Wr Address Illegal")
+    property.cover (io.rdEn && !io.rdLegal, "SB Legality Cover", "SBA Rd Address Illegal")
+    property.cover (io.wrEn && !io.wrLegal, "SB Legality Cover", "SBA Wr Address Illegal")
  
   }
 }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import freechips.rocketchip.prci.{ClockSinkDomain}
 import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.diplomaticobjectmodel.model._
@@ -311,13 +311,13 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     if (nDevices >= 2) {
       val claimed = claimer(0) && maxDevs(0) > 0
       val completed = completer(0)
-      cover(claimed && RegEnable(claimed, false.B, claimed || completed), "TWO_CLAIMS", "two claims with no intervening complete")
-      cover(completed && RegEnable(completed, false.B, claimed || completed), "TWO_COMPLETES", "two completes with no intervening claim")
+      property.cover(claimed && RegEnable(claimed, false.B, claimed || completed), "TWO_CLAIMS", "two claims with no intervening complete")
+      property.cover(completed && RegEnable(completed, false.B, claimed || completed), "TWO_COMPLETES", "two completes with no intervening claim")
 
       val ep = enables(0).asUInt & pending.asUInt
       val ep2 = RegNext(ep)
       val diff = ep & ~ep2
-      cover((diff & (diff - 1)) =/= 0, "TWO_INTS_PENDING", "two enabled interrupts became pending on same cycle")
+      property.cover((diff & (diff - 1)) =/= 0, "TWO_INTS_PENDING", "two enabled interrupts became pending on same cycle")
 
       if (nPriorities > 0)
         ccover(maxDevs(0) > (UInt(1) << priority(0).getWidth) && maxDevs(0) <= Cat(UInt(1), threshold(0)),
@@ -325,7 +325,7 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     }
 
     def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
-      cover(cond, s"PLIC_$label", "Interrupts;;" + desc)
+      property.cover(cond, s"PLIC_$label", "Interrupts;;" + desc)
   }
 }
 

--- a/src/main/scala/jtag/JtagShifter.scala
+++ b/src/main/scala/jtag/JtagShifter.scala
@@ -36,7 +36,6 @@ trait ChainIO extends Bundle {
 class Capture[+T <: Data](gen: T) extends Bundle {
   val bits = Input(gen)  // data to capture, should be always valid
   val capture = Output(Bool())  // will be high in capture state (single cycle), captured on following rising edge
-  override def cloneType = Capture(gen).asInstanceOf[this.type]
 }
 
 object Capture {

--- a/src/main/scala/jtag/JtagShifter.scala
+++ b/src/main/scala/jtag/JtagShifter.scala
@@ -8,7 +8,7 @@ import chisel3.internal.firrtl.KnownWidth
 import chisel3.util.{Cat, Valid}
 
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 /** Base JTAG shifter IO, viewed from input to shift register chain.
   * Can be chained together.
@@ -63,7 +63,7 @@ class JtagBypassChain(implicit val p: Parameters) extends Chain {
 
   io.chainOut.data := reg
 
-  cover(io.chainIn.capture, "bypass_chain_capture", "JTAG; bypass_chain_capture; This Bypass Chain captured data")
+  property.cover(io.chainIn.capture, "bypass_chain_capture", "JTAG; bypass_chain_capture; This Bypass Chain captured data")
 
   when (io.chainIn.capture) {
     reg := false.B  // 10.1.1b capture logic 0 on TCK rising
@@ -103,7 +103,7 @@ class CaptureChain[+T <: Data](gen: T)(implicit val p: Parameters) extends Chain
 
   io.chainOut.data := regs(0)
 
-  cover(io.chainIn.capture, "chain_capture", "JTAG; chain_capture; This Chain captured data")
+  property.cover(io.chainIn.capture, "chain_capture", "JTAG; chain_capture; This Chain captured data")
   
   when (io.chainIn.capture) {
     (0 until n) map (x => regs(x) := io.capture.bits.asUInt()(x))
@@ -161,8 +161,8 @@ class CaptureUpdateChain[+T <: Data, +V <: Data](genCapture: T, genUpdate: V)(im
 
   val captureBits = io.capture.bits.asUInt()
 
-  cover(io.chainIn.capture, "chain_capture", "JTAG;chain_capture; This Chain captured data")
-  cover(io.chainIn.capture, "chain_update",  "JTAG;chain_update; This Chain updated data")
+  property.cover(io.chainIn.capture, "chain_capture", "JTAG;chain_capture; This Chain captured data")
+  property.cover(io.chainIn.capture, "chain_update",  "JTAG;chain_update; This Chain updated data")
 
   when (io.chainIn.capture) {
     (0 until math.min(n, captureWidth)) map (x => regs(x) := captureBits(x))

--- a/src/main/scala/jtag/JtagStateMachine.scala
+++ b/src/main/scala/jtag/JtagStateMachine.scala
@@ -4,8 +4,8 @@ package freechips.rocketchip.jtag
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.config.{Parameters}
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.util.property
 
 object JtagState {
   sealed abstract class State(val id: Int) {
@@ -131,10 +131,10 @@ class JtagStateMachine(implicit val p: Parameters) extends Module() {
   io.currState := currState
 
   // Generate Coverate Points
-  JtagState.State.all.foreach { s => 
-    cover (currState === s.U && io.tms === true.B,  s"${s.toString}_tms_1", s"JTAG; ${s.toString} with TMS = 1; State Transition from ${s.toString} with TMS = 1")
-    cover (currState === s.U && io.tms === false.B, s"${s.toString}_tms_0", s"JTAG; ${s.toString} with TMS = 0; State Transition from ${s.toString} with TMS = 0")
-   cover (currState === s.U && reset.asBool === true.B, s"${s.toString}_reset", s"JTAG; ${s.toString} with reset; JTAG Reset asserted during ${s.toString}")
+  JtagState.State.all.foreach { s =>
+    property.cover (currState === s.U && io.tms === true.B,  s"${s.toString}_tms_1", s"JTAG; ${s.toString} with TMS = 1; State Transition from ${s.toString} with TMS = 1")
+    property.cover (currState === s.U && io.tms === false.B, s"${s.toString}_tms_0", s"JTAG; ${s.toString} with TMS = 0; State Transition from ${s.toString} with TMS = 0")
+    property.cover (currState === s.U && reset.asBool === true.B, s"${s.toString}_reset", s"JTAG; ${s.toString} with reset; JTAG Reset asserted during ${s.toString}")
  
   }
 

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -16,7 +16,6 @@ class JTAGIO(hasTRSTn: Boolean = false) extends Bundle {
   val TDI   = Output(Bool())
   val TDO   = Input(new Tristate())
 
-  override def cloneType = new JTAGIO(hasTRSTn).asInstanceOf[this.type]
 }
 
 /** JTAG block output signals.
@@ -26,7 +25,6 @@ class JtagOutput(irLength: Int) extends Bundle {
   val instruction = Output(UInt(irLength.W))  // current active instruction
   val tapIsInTestLogicReset = Output(Bool())  // synchronously asserted in Test-Logic-Reset state, should NOT hold the FSM in reset
 
-  override def cloneType = new JtagOutput(irLength).asInstanceOf[this.type]
 }
 
 class JtagControl extends Bundle {
@@ -42,7 +40,6 @@ class JtagBlockIO(irLength: Int, hasIdcode:Boolean = true) extends Bundle {
   val output = new JtagOutput(irLength)
   val idcode = if (hasIdcode) Some(Input(new JTAGIdcodeBundle())) else None
 
-  override def cloneType = new JtagBlockIO(irLength, hasIdcode).asInstanceOf[this.type]
 }
 
 /** Internal controller block IO with data shift outputs.
@@ -51,7 +48,6 @@ class JtagControllerIO(irLength: Int) extends JtagBlockIO(irLength, false) {
   val dataChainOut = Output(new ShifterIO)
   val dataChainIn = Input(new ShifterIO)
 
-  override def cloneType = new JtagControllerIO(irLength).asInstanceOf[this.type]
 }
 
 /** JTAG TAP controller internal block, responsible for instruction decode and data register chain

--- a/src/main/scala/regmapper/RegMapper.scala
+++ b/src/main/scala/regmapper/RegMapper.scala
@@ -6,7 +6,7 @@ import Chisel._
 
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import chisel3.internal.sourceinfo.SourceInfo
 
 // A bus agnostic register interface to a register-based device
@@ -154,12 +154,12 @@ object RegMapper
 
       val facct = field.desc.map{_.access}.getOrElse("")
       if((facct == RegFieldAccessType.R) || (facct == RegFieldAccessType.RW)) {
-        cover(f_rivalid && f_riready, fname + "_Reg_read_start",  fdesc + " RegField Read Request Initiate")
-        cover(f_rovalid && f_roready, fname + "_Reg_read_out",    fdesc + " RegField Read Request Complete")
+        property.cover(f_rivalid && f_riready, fname + "_Reg_read_start",  fdesc + " RegField Read Request Initiate")
+        property.cover(f_rovalid && f_roready, fname + "_Reg_read_out",    fdesc + " RegField Read Request Complete")
       }
       if((facct == RegFieldAccessType.W) || (facct == RegFieldAccessType.RW)) {
-        cover(f_wivalid && f_wiready, fname + "_Reg_write_start", fdesc + " RegField Write Request Initiate")
-        cover(f_wovalid && f_woready, fname + "_Reg_write_out",   fdesc + " RegField Write Request Complete")
+        property.cover(f_wivalid && f_wiready, fname + "_Reg_write_start", fdesc + " RegField Write Request Initiate")
+        property.cover(f_wovalid && f_woready, fname + "_Reg_write_out",   fdesc + " RegField Write Request Complete")
       }
 
       def litOR(x: Bool, y: Bool) = if (x.isLit && x.litValue == 1) Bool(true) else x || y

--- a/src/main/scala/regmapper/RegisterCrossing.scala
+++ b/src/main/scala/regmapper/RegisterCrossing.scala
@@ -53,7 +53,6 @@ class RegisterWriteIO[T <: Data](gen: T) extends Bundle {
   val request  = Decoupled(gen).flip
   val response = Irrevocable(Bool()) // ignore .bits
 
-  override def cloneType = new RegisterWriteIO(gen).asInstanceOf[this.type]
 }
 
 // To turn off=>on a domain:
@@ -129,7 +128,6 @@ class RegisterReadIO[T <: Data](gen: T) extends Bundle {
   val request  = Decoupled(Bool()).flip // ignore .bits
   val response = Irrevocable(gen)
 
-  override def cloneType = new RegisterReadIO(gen).asInstanceOf[this.type]
 }
 
 class RegisterReadCrossingIO[T <: Data](gen: T) extends Bundle {

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import scala.collection.mutable.LinkedHashMap
 import Instructions._
 
@@ -1025,8 +1025,8 @@ class CSRFile(
   for (i <- 0 until supported_interrupts.getWidth) {
     val en = exception && (supported_interrupts & (BigInt(1) << i).U) =/= 0 && cause === (BigInt(1) << (xLen - 1)).U + i
     val delegable = (delegable_interrupts & (BigInt(1) << i).U) =/= 0
-    cover(en && !delegate, s"INTERRUPT_M_$i")
-    cover(en && delegable && delegate, s"INTERRUPT_S_$i")
+    property.cover(en && !delegate, s"INTERRUPT_M_$i")
+    property.cover(en && delegable && delegate, s"INTERRUPT_S_$i")
   }
   for (i <- 0 until xLen) {
     val supported_exceptions: BigInt = 0x8fe |
@@ -1037,8 +1037,8 @@ class CSRFile(
     if (((supported_exceptions >> i) & 1) != 0) {
       val en = exception && cause === i
       val delegable = (delegable_exceptions & (BigInt(1) << i).U) =/= 0
-      cover(en && !delegate, s"EXCEPTION_M_$i")
-      cover(en && delegable && delegate, s"EXCEPTION_S_$i")
+      property.cover(en && !delegate, s"EXCEPTION_M_$i")
+      property.cover(en && delegable && delegate, s"EXCEPTION_S_$i")
     }
   }
 
@@ -1106,9 +1106,9 @@ class CSRFile(
   }
   coverable_counters.foreach( {case (k, v) => {
     when (!k(11,10).andR) {  // Cover points for RW CSR registers
-      cover(io.rw.cmd.isOneOf(CSR.W, CSR.S, CSR.C) && io.rw.addr===k, "CSR_access_"+k.toString, "Cover Accessing Core CSR field")
+      property.cover(io.rw.cmd.isOneOf(CSR.W, CSR.S, CSR.C) && io.rw.addr===k, "CSR_access_"+k.toString, "Cover Accessing Core CSR field")
     } .otherwise { // Cover points for RO CSR registers
-      cover(io.rw.cmd===CSR.R && io.rw.addr===k, "CSR_access_"+k.toString, "Cover Accessing Core CSR field")
+      property.cover(io.rw.cmd===CSR.R && io.rw.addr===k, "CSR_access_"+k.toString, "Cover Accessing Core CSR field")
     }
   }})
 

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.diplomaticobjectmodel.model.OMSRAM
 import freechips.rocketchip.tile.{CoreBundle, LookupByHartId}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import chisel3.{DontCare, WireInit, dontTouch, withClock}
 import chisel3.experimental.{chiselName, NoChiselNamePrefix}
 import chisel3.internal.sourceinfo.SourceInfo
@@ -1109,38 +1109,38 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
 
   if (usingDataScratchpad) {
     val data_error_cover = Seq(
-      CoverBoolean(!data_error, Seq("no_data_error")),
-      CoverBoolean(data_error && !data_error_uncorrectable, Seq("data_correctable_error")),
-      CoverBoolean(data_error && data_error_uncorrectable, Seq("data_uncorrectable_error")))
+      property.CoverBoolean(!data_error, Seq("no_data_error")),
+      property.CoverBoolean(data_error && !data_error_uncorrectable, Seq("data_correctable_error")),
+      property.CoverBoolean(data_error && data_error_uncorrectable, Seq("data_uncorrectable_error")))
     val request_source = Seq(
-      CoverBoolean(s2_isSlavePortAccess, Seq("from_TL")),
-      CoverBoolean(!s2_isSlavePortAccess, Seq("from_CPU")))
+      property.CoverBoolean(s2_isSlavePortAccess, Seq("from_TL")),
+      property.CoverBoolean(!s2_isSlavePortAccess, Seq("from_CPU")))
 
-    cover(new CrossProperty(
+    property.cover(new property.CrossProperty(
       Seq(data_error_cover, request_source),
       Seq(),
       "MemorySystem;;Scratchpad Memory Bit Flip Cross Covers"))
   } else {
 
     val data_error_type = Seq(
-      CoverBoolean(!s2_valid_data_error, Seq("no_data_error")),
-      CoverBoolean(s2_valid_data_error && !s2_data_error_uncorrectable, Seq("data_correctable_error")),
-      CoverBoolean(s2_valid_data_error && s2_data_error_uncorrectable, Seq("data_uncorrectable_error")))
+      property.CoverBoolean(!s2_valid_data_error, Seq("no_data_error")),
+      property.CoverBoolean(s2_valid_data_error && !s2_data_error_uncorrectable, Seq("data_correctable_error")),
+      property.CoverBoolean(s2_valid_data_error && s2_data_error_uncorrectable, Seq("data_uncorrectable_error")))
     val data_error_dirty = Seq(
-      CoverBoolean(!s2_victim_dirty, Seq("data_clean")),
-      CoverBoolean(s2_victim_dirty, Seq("data_dirty")))
+      property.CoverBoolean(!s2_victim_dirty, Seq("data_clean")),
+      property.CoverBoolean(s2_victim_dirty, Seq("data_dirty")))
     val request_source = if (supports_flush) {
         Seq(
-          CoverBoolean(!flushing, Seq("access")),
-          CoverBoolean(flushing, Seq("during_flush")))
+          property.CoverBoolean(!flushing, Seq("access")),
+          property.CoverBoolean(flushing, Seq("during_flush")))
       } else {
-        Seq(CoverBoolean(true.B, Seq("never_flush")))
+        Seq(property.CoverBoolean(true.B, Seq("never_flush")))
       }
     val tag_error_cover = Seq(
-      CoverBoolean( !s2_meta_error, Seq("no_tag_error")),
-      CoverBoolean( s2_meta_error && !s2_meta_error_uncorrectable, Seq("tag_correctable_error")),
-      CoverBoolean( s2_meta_error && s2_meta_error_uncorrectable, Seq("tag_uncorrectable_error")))
-    cover(new CrossProperty(
+      property.CoverBoolean( !s2_meta_error, Seq("no_tag_error")),
+      property.CoverBoolean( s2_meta_error && !s2_meta_error_uncorrectable, Seq("tag_correctable_error")),
+      property.CoverBoolean( s2_meta_error && s2_meta_error_uncorrectable, Seq("tag_uncorrectable_error")))
+    property.cover(new property.CrossProperty(
       Seq(data_error_type, data_error_dirty, request_source, tag_error_cover),
       Seq(),
       "MemorySystem;;Cache Memory Bit Flip Cross Covers"))
@@ -1165,7 +1165,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     (isWrite(req.cmd) && (req.cmd === M_PWR || req.size < log2Ceil(eccBytes)))
 
   def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
-    cover(cond, s"DCACHE_$label", "MemorySystem;;" + desc)
+    property.cover(cond, s"DCACHE_$label", "MemorySystem;;" + desc)
   def ccoverNotScratchpad(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
     if (!usingDataScratchpad) ccover(cond, label, desc)
 

--- a/src/main/scala/rocket/Events.scala
+++ b/src/main/scala/rocket/Events.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.rocket
 
 import Chisel._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 class EventSet(val gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bool)]) {
   def size = events.size
@@ -20,7 +20,7 @@ class EventSet(val gate: (UInt, UInt) => Bool, val events: Seq[(String, () => Bo
   }
   def withCovers: Unit = {
     events.zipWithIndex.foreach {
-      case ((name, func), i) => cover(gate((1.U << i), (func() << i)), name)
+      case ((name, func), i) => property.cover(gate((1.U << i), (func() << i)), name)
     }
   }
 }

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.ICacheLogicalTreeNode
 
 class FrontendReq(implicit p: Parameters) extends CoreBundle()(p) {
@@ -362,7 +362,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   def alignPC(pc: UInt) = ~(~pc | (coreInstBytes - 1))
 
   def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
-    cover(cond, s"FRONTEND_$label", "Rocket;;" + desc)
+    property.cover(cond, s"FRONTEND_$label", "Rocket;;" + desc)
 }
 
 /** Mix-ins for constructing tiles that have an ICache-based pipeline frontend */

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -104,7 +104,6 @@ class ICacheResp(outer: ICache) extends Bundle {
   val replay = Bool()
   val ae = Bool()
 
-  override def cloneType = new ICacheResp(outer).asInstanceOf[this.type]
 }
 
 class ICachePerfEvents extends Bundle {

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.{DescribedSRAM, _}
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.dontTouch
 import chisel3.util.random.LFSR
@@ -492,27 +492,27 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   ccover(invalidate && refill_valid, "FLUSH_DURING_MISS", "I$ flushed during miss")
 
   def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
-    cover(cond, s"ICACHE_$label", "MemorySystem;;" + desc)
+    property.cover(cond, s"ICACHE_$label", "MemorySystem;;" + desc)
 
-  val mem_active_valid = Seq(CoverBoolean(s2_valid, Seq("mem_active")))
+  val mem_active_valid = Seq(property.CoverBoolean(s2_valid, Seq("mem_active")))
   val data_error = Seq(
-    CoverBoolean(!s2_data_decoded.correctable && !s2_data_decoded.uncorrectable, Seq("no_data_error")),
-    CoverBoolean(s2_data_decoded.correctable, Seq("data_correctable_error")),
-    CoverBoolean(s2_data_decoded.uncorrectable, Seq("data_uncorrectable_error")))
+    property.CoverBoolean(!s2_data_decoded.correctable && !s2_data_decoded.uncorrectable, Seq("no_data_error")),
+    property.CoverBoolean(s2_data_decoded.correctable, Seq("data_correctable_error")),
+    property.CoverBoolean(s2_data_decoded.uncorrectable, Seq("data_uncorrectable_error")))
   val request_source = Seq(
-    CoverBoolean(!s2_slaveValid, Seq("from_CPU")),
-    CoverBoolean(s2_slaveValid, Seq("from_TL"))
+    property.CoverBoolean(!s2_slaveValid, Seq("from_CPU")),
+    property.CoverBoolean(s2_slaveValid, Seq("from_TL"))
   )
   val tag_error = Seq(
-    CoverBoolean(!s2_tag_disparity, Seq("no_tag_error")),
-    CoverBoolean(s2_tag_disparity, Seq("tag_error"))
+    property.CoverBoolean(!s2_tag_disparity, Seq("no_tag_error")),
+    property.CoverBoolean(s2_tag_disparity, Seq("tag_error"))
   )
   val mem_mode = Seq(
-    CoverBoolean(s2_scratchpad_hit, Seq("ITIM_mode")),
-    CoverBoolean(!s2_scratchpad_hit, Seq("cache_mode"))
+    property.CoverBoolean(s2_scratchpad_hit, Seq("ITIM_mode")),
+    property.CoverBoolean(!s2_scratchpad_hit, Seq("cache_mode"))
   )
 
-  val error_cross_covers = new CrossProperty(
+  val error_cross_covers = new property.CrossProperty(
     Seq(mem_active_valid, data_error, tag_error, request_source, mem_mode),
     Seq(
       // tag error cannot occur in ITIM mode
@@ -522,5 +522,5 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
     ),
     "MemorySystem;;Memory Bit Flip Cross Covers")
 
-  cover(error_cross_covers)
+  property.cover(error_cross_covers)
 }

--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -15,13 +15,11 @@ class MultiplierReq(dataBits: Int, tagBits: Int) extends Bundle {
   val in1 = Bits(dataBits.W)
   val in2 = Bits(dataBits.W)
   val tag = UInt(tagBits.W)
-  override def cloneType = new MultiplierReq(dataBits, tagBits).asInstanceOf[this.type]
 }
 
 class MultiplierResp(dataBits: Int, tagBits: Int) extends Bundle {
   val data = Bits(dataBits.W)
   val tag = UInt(tagBits.W)
-  override def cloneType = new MultiplierResp(dataBits, tagBits).asInstanceOf[this.type]
 }
 
 class MultiplierIO(val dataBits: Int, val tagBits: Int) extends Bundle {

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -48,7 +48,6 @@ class WritebackReq(params: TLBundleParameters)(implicit p: Parameters) extends L
   val way_en = Bits(width = nWays)
   val voluntary = Bool()
 
-  override def cloneType = new WritebackReq(params)(p).asInstanceOf[this.type]
 }
 
 class IOMSHR(id: Int)(implicit edge: TLEdgeOut, p: Parameters) extends L1HellaCacheModule()(p) {

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -8,7 +8,6 @@ import Chisel.ImplicitConversions._
 import freechips.rocketchip.config._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
 
 class PMPConfig extends Bundle {
   val l = Bool()
@@ -166,17 +165,17 @@ class PMPChecker(lgMaxSize: Int)(implicit val p: Parameters) extends Module
     val aligned = pmp.aligned(io.addr, io.size, lgMaxSize, prevPMP)
 
     for ((name, idx) <- Seq("no", "TOR", if (pmpGranularity <= 4) "NA4" else "", "NAPOT").zipWithIndex; if name.nonEmpty)
-        cover(pmp.cfg.a === idx, s"The cfg access is set to ${name} access ", "Cover PMP access mode setting")
+      property.cover(pmp.cfg.a === idx, s"The cfg access is set to ${name} access ", "Cover PMP access mode setting")
 
-    cover(pmp.cfg.l === 0x1, s"The cfg lock is set to high ", "Cover PMP lock mode setting")
+    property.cover(pmp.cfg.l === 0x1, s"The cfg lock is set to high ", "Cover PMP lock mode setting")
    
     // Not including Write and no Read permission as the combination is reserved
     for ((name, idx) <- Seq("no", "RO", "", "RW", "X", "RX", "", "RWX").zipWithIndex; if name.nonEmpty)
-      cover((Cat(pmp.cfg.x, pmp.cfg.w, pmp.cfg.r) === idx), s"The permission is set to ${name} access ", "Cover PMP access permission setting") 
+      property.cover((Cat(pmp.cfg.x, pmp.cfg.w, pmp.cfg.r) === idx), s"The permission is set to ${name} access ", "Cover PMP access permission setting")
 
     for ((name, idx) <- Seq("", "TOR", if (pmpGranularity <= 4) "NA4" else "", "NAPOT").zipWithIndex; if name.nonEmpty) {
-        cover(!ignore && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode ", "Cover PMP access")
-        cover(pmp.cfg.l && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode with lock bit high", "Cover PMP access with lock bit")
+      property.cover(!ignore && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode ", "Cover PMP access")
+      property.cover(pmp.cfg.l && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode with lock bit high", "Cover PMP access with lock bit")
     }
 
     val cur = WireInit(pmp)

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -110,7 +110,6 @@ class L2TLBEntry(nSets: Int)(implicit p: Parameters) extends CoreBundle()(p)
   val w = Bool()
   val r = Bool()
 
-  override def cloneType = new L2TLBEntry(nSets).asInstanceOf[this.type]
 }
 
 @chiselName

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.subsystem.CacheBlockBytes
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import freechips.rocketchip.diplomaticobjectmodel.model.OMSRAM
 import scala.collection.mutable.ListBuffer
 
@@ -573,7 +573,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   } // leaving gated-clock domain
 
   private def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
-    if (usingVM) cover(cond, s"PTW_$label", "MemorySystem;;" + desc)
+    if (usingVM) property.cover(cond, s"PTW_$label", "MemorySystem;;" + desc)
 
   private def makePTE(ppn: UInt, default: PTE) = {
     val pte = Wire(init = default)

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -10,7 +10,7 @@ import chisel3.experimental.{chiselName, NoChiselNamePrefix}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import freechips.rocketchip.scie._
 import scala.collection.mutable.ArrayBuffer
 
@@ -1022,7 +1022,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
 
   def coverExceptions(exceptionValid: Bool, cause: UInt, labelPrefix: String, coverCausesLabels: Seq[(Int, String)]): Unit = {
     for ((coverCause, label) <- coverCausesLabels) {
-      cover(exceptionValid && (cause === UInt(coverCause)), s"${labelPrefix}_${label}")
+      property.cover(exceptionValid && (cause === UInt(coverCause)), s"${labelPrefix}_${label}")
     }
   }
 

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -38,7 +38,6 @@ class TLBReq(lgMaxSize: Int)(implicit p: Parameters) extends CoreBundle()(p) {
   val prv = UInt(PRV.SZ.W)
   val v = Bool()
 
-  override def cloneType = new TLBReq(lgMaxSize).asInstanceOf[this.type]
 }
 
 class TLBExceptions(implicit p: Parameters) extends CoreBundle()(p) {

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.diplomacy.RegionType
 import freechips.rocketchip.tile.{CoreModule, CoreBundle}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 import freechips.rocketchip.devices.debug.DebugModuleKey
 import chisel3.internal.sourceinfo.SourceInfo
 
@@ -509,7 +509,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   }
 
   def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
-    cover(cond, s"${if (instruction) "I" else "D"}TLB_$label", "MemorySystem;;" + desc)
+    property.cover(cond, s"${if (instruction) "I" else "D"}TLB_$label", "MemorySystem;;" + desc)
 
   def replacementEntry(set: Seq[TLBEntry], alt: UInt) = {
     val valids = set.map(_.valid.orR).asUInt

--- a/src/main/scala/tile/BusErrorUnit.scala
+++ b/src/main/scala/tile/BusErrorUnit.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{BusErrorLogicalTr
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 trait BusErrors extends Bundle {
   def toErrorList: List[Option[(Valid[UInt], String, String)]]
@@ -97,7 +97,7 @@ class BusErrorUnit[T <: BusErrors](t: => T, params: BusErrorUnitParams, logicalT
           new_cause := i
           new_value := s.get.bits
         }
-        cover(en, s"BusErrorCause_$i", s"Core;;BusErrorCause $i covered")
+        property.cover(en, s"BusErrorCause_$i", s"Core;;BusErrorCause $i covered")
       }
     }
 

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -231,7 +231,6 @@ class FPInput(implicit p: Parameters) extends CoreBundle()(p) with HasFPUCtrlSig
   val in2 = Bits(width = fLen+1)
   val in3 = Bits(width = fLen+1)
 
-  override def cloneType = new FPInput().asInstanceOf[this.type]
 }
 
 case class FType(exp: Int, sig: Int) {
@@ -283,7 +282,6 @@ case class FType(exp: Int, sig: Int) {
       val sign = Bool()
       val exp = UInt(expWidth.W)
       val sig = UInt((ieeeWidth-expWidth-1).W)
-      override def cloneType = new IEEEBundle().asInstanceOf[this.type]
     }
     new IEEEBundle
   }
@@ -452,7 +450,6 @@ class FPToInt(implicit p: Parameters) extends FPUModule()(p) with ShouldBeRetime
     val store = Bits(width = fLen)
     val toint = Bits(width = xLen)
     val exc = Bits(width = FPConstants.FLAGS_SZ)
-    override def cloneType = new Output().asInstanceOf[this.type]
   }
   val io = new Bundle {
     val in = Valid(new FPInput).flip
@@ -903,7 +900,6 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
     val typeTag = UInt(width = log2Up(floatTypes.size))
     val cp = Bool()
     val pipeid = UInt(width = log2Ceil(pipes.size))
-    override def cloneType: this.type = new WBInfo().asInstanceOf[this.type]
   }
 
   val wen = Reg(init=Bits(0, maxLatency-1))

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.rocket.Instructions._
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 case class FPUParams(
   minFLen: Int = 32,
@@ -1020,5 +1020,5 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
   val fpuImpl = withClock (gated_clock) { new FPUImpl }
 
   def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
-    cover(cond, s"FPU_$label", "Core;;" + desc)
+    property.cover(cond, s"FPU_$label", "Core;;" + desc)
 }

--- a/src/main/scala/tilelink/AsyncCrossing.scala
+++ b/src/main/scala/tilelink/AsyncCrossing.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.CrossingWrapper
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 class TLAsyncCrossingSource(sync: Option[Int])(implicit p: Parameters) extends LazyModule
 {
@@ -24,16 +24,16 @@ class TLAsyncCrossingSource(sync: Option[Int])(implicit p: Parameters) extends L
 
       out.a <> ToAsyncBundle(in.a, params)
       in.d <> FromAsyncBundle(out.d, psync)
-      cover(in.a, "TL_ASYNC_CROSSING_SOURCE_A", "MemorySystem;;TLAsyncCrossingSource Channel A")
-      cover(in.d, "TL_ASYNC_CROSSING_SOURCE_D", "MemorySystem;;TLAsyncCrossingSource Channel D")
+      property.cover(in.a, "TL_ASYNC_CROSSING_SOURCE_A", "MemorySystem;;TLAsyncCrossingSource Channel A")
+      property.cover(in.d, "TL_ASYNC_CROSSING_SOURCE_D", "MemorySystem;;TLAsyncCrossingSource Channel D")
 
       if (bce) {
         in.b <> FromAsyncBundle(out.b, psync)
         out.c <> ToAsyncBundle(in.c, params)
         out.e <> ToAsyncBundle(in.e, params)
-        cover(in.b, "TL_ASYNC_CROSSING_SOURCE_B", "MemorySystem;;TLAsyncCrossingSource Channel B")
-        cover(in.c, "TL_ASYNC_CROSSING_SOURCE_C", "MemorySystem;;TLAsyncCrossingSource Channel C")
-        cover(in.e, "TL_ASYNC_CROSSING_SOURCE_E", "MemorySystem;;TLAsyncCrossingSource Channel E")
+        property.cover(in.b, "TL_ASYNC_CROSSING_SOURCE_B", "MemorySystem;;TLAsyncCrossingSource Channel B")
+        property.cover(in.c, "TL_ASYNC_CROSSING_SOURCE_C", "MemorySystem;;TLAsyncCrossingSource Channel C")
+        property.cover(in.e, "TL_ASYNC_CROSSING_SOURCE_E", "MemorySystem;;TLAsyncCrossingSource Channel E")
       } else {
         in.b.valid := Bool(false)
         in.c.ready := Bool(true)
@@ -56,16 +56,16 @@ class TLAsyncCrossingSink(params: AsyncQueueParams = AsyncQueueParams())(implici
 
       out.a <> FromAsyncBundle(in.a, params.sync)
       in.d <> ToAsyncBundle(out.d, params)
-      cover(out.a, "TL_ASYNC_CROSSING_SINK_A", "MemorySystem;;TLAsyncCrossingSink Channel A")
-      cover(out.d, "TL_ASYNC_CROSSING_SINK_D", "MemorySystem;;TLAsyncCrossingSink Channel D")
+      property.cover(out.a, "TL_ASYNC_CROSSING_SINK_A", "MemorySystem;;TLAsyncCrossingSink Channel A")
+      property.cover(out.d, "TL_ASYNC_CROSSING_SINK_D", "MemorySystem;;TLAsyncCrossingSink Channel D")
 
       if (bce) {
         in.b <> ToAsyncBundle(out.b, params)
         out.c <> FromAsyncBundle(in.c, params.sync)
         out.e <> FromAsyncBundle(in.e, params.sync)
-        cover(out.b, "TL_ASYNC_CROSSING_SINK_B", "MemorySystem;;TLAsyncCrossingSinkChannel B")
-        cover(out.c, "TL_ASYNC_CROSSING_SINK_C", "MemorySystem;;TLAsyncCrossingSink Channel C")
-        cover(out.e, "TL_ASYNC_CROSSING_SINK_E", "MemorySystem;;TLAsyncCrossingSink Channel E")
+        property.cover(out.b, "TL_ASYNC_CROSSING_SINK_B", "MemorySystem;;TLAsyncCrossingSinkChannel B")
+        property.cover(out.c, "TL_ASYNC_CROSSING_SINK_C", "MemorySystem;;TLAsyncCrossingSink Channel C")
+        property.cover(out.e, "TL_ASYNC_CROSSING_SINK_E", "MemorySystem;;TLAsyncCrossingSink Channel E")
       } else {
         in.b.widx := UInt(0)
         in.c.ridx := UInt(0)

--- a/src/main/scala/tilelink/FIFOFixer.scala
+++ b/src/main/scala/tilelink/FIFOFixer.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.tilelink
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Parameters) extends LazyModule
 {
@@ -102,7 +102,7 @@ class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Para
 
 //Functional cover properties
      
-      cover(in.a.valid && stall, "COVER FIFOFIXER STALL", "Cover: Stall occured for a valid transaction")
+      property.cover(in.a.valid && stall, "COVER FIFOFIXER STALL", "Cover: Stall occured for a valid transaction")
 
       val SourceIdFIFOed = RegInit(UInt(0, width = edgeIn.client.endSourceId))
       val SourceIdSet = Wire(init = UInt(0, width = edgeIn.client.endSourceId))
@@ -118,11 +118,11 @@ class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Para
       SourceIdFIFOed := SourceIdFIFOed | SourceIdSet
       val allIDs_FIFOed = SourceIdFIFOed===Fill(SourceIdFIFOed.getWidth, 1.U)
 
-      cover(allIDs_FIFOed, "COVER all sources", "Cover: FIFOFIXER covers all Source IDs")
-    //cover(flight.reduce(_ && _), "COVER full", "Cover: FIFO is full with all Source IDs")
-      cover(!(flight.reduce(_ || _)), "COVER empty", "Cover: FIFO is empty")
-      cover(SourceIdSet > 0.U, "COVER at least one push", "Cover: At least one Source ID is pushed")
-      cover(SourceIdClear > 0.U, "COVER at least one pop", "Cover: At least one Source ID is popped")
+      property.cover(allIDs_FIFOed, "COVER all sources", "Cover: FIFOFIXER covers all Source IDs")
+    //property.cover(flight.reduce(_ && _), "COVER full", "Cover: FIFO is full with all Source IDs")
+      property.cover(!(flight.reduce(_ || _)), "COVER empty", "Cover: FIFO is empty")
+      property.cover(SourceIdSet > 0.U, "COVER at least one push", "Cover: At least one Source ID is pushed")
+      property.cover(SourceIdClear > 0.U, "COVER at least one pop", "Cover: At least one Source ID is popped")
 
     }
   }

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{BusMemoryLogicalTreeNode, LogicalModuleTree, LogicalTreeNode}
 import freechips.rocketchip.diplomaticobjectmodel.model.{OMECC, TL_UL}
 import freechips.rocketchip.util._
-import freechips.rocketchip.util.property._
+import freechips.rocketchip.util.property
 
 class TLRAMErrors(val params: ECCParams, val addrBits: Int) extends Bundle with CanHaveErrors {
   val correctable   = (params.code.canCorrect && params.notifyErrors).option(Valid(UInt(addrBits.W)))
@@ -215,13 +215,13 @@ class TLRAM(
     in.d.bits.data    := Mux(d_mux, d_corrected, r_uncorrected)
     in.d.bits.corrupt := Mux(d_mux, d_error, r_error) && out_aad
 
-    val mem_active_valid = Seq(CoverBoolean(in.d.valid, Seq("mem_active")))
+    val mem_active_valid = Seq(property.CoverBoolean(in.d.valid, Seq("mem_active")))
     val data_error = Seq(
-      CoverBoolean(!d_need_fix && !d_error , Seq("no_data_error")),
-      CoverBoolean(d_need_fix && !in.d.bits.corrupt, Seq("data_correctable_error_not_reported")),
-      CoverBoolean(d_error && in.d.bits.corrupt, Seq("data_uncorrectable_error_reported")))
+      property.CoverBoolean(!d_need_fix && !d_error , Seq("no_data_error")),
+      property.CoverBoolean(d_need_fix && !in.d.bits.corrupt, Seq("data_correctable_error_not_reported")),
+      property.CoverBoolean(d_error && in.d.bits.corrupt, Seq("data_uncorrectable_error_reported")))
 
-    val error_cross_covers = new CrossProperty(Seq(mem_active_valid, data_error), Seq(), "Ecc Covers")
+    val error_cross_covers = new property.CrossProperty(Seq(mem_active_valid, data_error), Seq(), "Ecc Covers")
     property.cover(error_cross_covers)
 
     // Does the D stage want to perform a write?

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -222,7 +222,7 @@ class TLRAM(
       CoverBoolean(d_error && in.d.bits.corrupt, Seq("data_uncorrectable_error_reported")))
 
     val error_cross_covers = new CrossProperty(Seq(mem_active_valid, data_error), Seq(), "Ecc Covers")
-    cover(error_cross_covers)
+    property.cover(error_cross_covers)
 
     // Does the D stage want to perform a write?
     // It's important this reduce to false.B when eccBytes=1 && atomics=false && canCorrect=false

--- a/src/main/scala/util/CreditedIO.scala
+++ b/src/main/scala/util/CreditedIO.scala
@@ -37,7 +37,6 @@ case class CreditedDelay(debit: Int, credit: Int)
   */
 final class CreditedIO[T <: Data](gen: T) extends Bundle
 {
-  override def cloneType: this.type = new CreditedIO(genType).asInstanceOf[this.type]
   def genType: T = gen
 
   val credit = Input (Bool()) // 1: a credit is given to the sender by the receiver

--- a/src/main/scala/util/HeterogeneousBag.scala
+++ b/src/main/scala/util/HeterogeneousBag.scala
@@ -12,7 +12,6 @@ final case class HeterogeneousBag[T <: Data](elts: Seq[T]) extends Record with c
 
   val elements = ListMap(elts.zipWithIndex.map { case (n,i) => (i.toString, n) }:_*)
   override def cloneType: this.type = (new HeterogeneousBag(elts.map(_.chiselCloneType))).asInstanceOf[this.type]
-
   // IndexedSeq has its own hashCode/equals that we must not use
   override def hashCode: Int = super[Record].hashCode
   override def equals(that: Any): Boolean = super[Record].equals(that)

--- a/src/main/scala/util/RationalCrossing.scala
+++ b/src/main/scala/util/RationalCrossing.scala
@@ -57,7 +57,6 @@ final class RationalIO[T <: Data](gen: T) extends Bundle
   val ready  = Input(Bool())
   val sink   = Input(UInt(2.W))
 
-  override def cloneType: this.type = new RationalIO(gen).asInstanceOf[this.type]
 }
 
 object RationalIO

--- a/src/main/scala/util/ReadyValidCancel.scala
+++ b/src/main/scala/util/ReadyValidCancel.scala
@@ -19,7 +19,6 @@ class ValidCancel[+T <: Data](gen: T) extends Bundle {
   val lateCancel = Output(Bool())
   val bits       = Output(gen)
   def validQual(): Bool = earlyValid && !lateCancel
-  override def cloneType: this.type = ValidCancel(gen).asInstanceOf[this.type]
 
   /** Down-converts a ValidCancel output to a Valid bundle, dropping early/late timing split. */
   def andNotCancel(): Valid[T] = {
@@ -48,7 +47,6 @@ class ReadyValidCancel[+T <: Data](gen: T) extends ValidCancel(gen)
   val ready = Input(Bool())
   def mightFire(): Bool = ready && earlyValid
   def fire():      Bool = ready && validQual()
-  override def cloneType: this.type = ReadyValidCancel(gen).asInstanceOf[this.type]
 
   /** Down-converts a ReadyValidCancel output to a DecoupledIO bundle, dropping early/late timing split. */
   def asDecoupled(): DecoupledIO[T] = {

--- a/src/main/scala/util/ReorderQueue.scala
+++ b/src/main/scala/util/ReorderQueue.scala
@@ -9,15 +9,11 @@ class ReorderQueueWrite[T <: Data](dType: T, tagWidth: Int) extends Bundle {
   val data = dType.cloneType
   val tag = UInt(width = tagWidth)
 
-  override def cloneType =
-    new ReorderQueueWrite(dType, tagWidth).asInstanceOf[this.type]
 }
 
 class ReorderEnqueueIO[T <: Data](dType: T, tagWidth: Int)
   extends DecoupledIO(new ReorderQueueWrite(dType, tagWidth)) {
 
-  override def cloneType =
-    new ReorderEnqueueIO(dType, tagWidth).asInstanceOf[this.type]
 }
 
 class ReorderDequeueIO[T <: Data](dType: T, tagWidth: Int) extends Bundle {
@@ -26,8 +22,6 @@ class ReorderDequeueIO[T <: Data](dType: T, tagWidth: Int) extends Bundle {
   val data = dType.cloneType.asOutput
   val matches = Bool(OUTPUT)
 
-  override def cloneType =
-    new ReorderDequeueIO(dType, tagWidth).asInstanceOf[this.type]
 }
 
 class ReorderQueue[T <: Data](dType: T, tagWidth: Int, size: Option[Int] = None)


### PR DESCRIPTION
This pulls in all the necessary changes from currently open PRs to complete a bump to Chisel 3.5. For various reasons, some of those earlier PRs cannot pass CI standalone, so it was easiest (for me) to bundle them together. 
These PRs include:
Bumping hardfloat (closes #2930)
Removing clonetype (closes #2889)
Removing the old property and updating cover (closes #2890)

Other notes: 
- I bumped macro paradise to 2.1.1 so that a published version could be found for scala 2.12.15. We already do this in the mill build, it appears. If that is undesired, can someone point me at a place where it is published and we can update the resolvers?
- I tried to update the mill files. @sequencer how should i test them?

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**

Bump to Chisel 3.5.

