### PR TITLE
Fix Fuzzer over-aggressively reusing source ids

### DIFF
--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -198,7 +198,7 @@ class TLFuzzer(
     val a_gen = if (nOperations>0) num_reqs =/= UInt(0) else Bool(true)
     out.a.valid := !reset && a_gen && legal && (!a_first || idMap.io.alloc.valid)
     idMap.io.alloc.ready := a_gen && legal && a_first && out.a.ready
-    idMap.io.free.valid := d_first && out.d.fire()
+    idMap.io.free.valid := d_last && out.d.fire()
     idMap.io.free.bits := out.d.bits.source
 
     out.a.bits  := bits


### PR DESCRIPTION
From the following excerpts of the tilelink spec:

> Each inflight request identifier of a channel in a particular link must be unique

>  An identifier is said to be inflight if an outstanding request using it has not yet received a response.

> A burst is said to be in progress after the first beat has been accepted and until the last beat has been accepted

If I interpret "received a response" to mean "the response burst is no longer in progress", then re-using source IDs before the response burst has completed is illegal, and thus the TLFuzzer is nonconformant.


<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: functional change

<!-- choose one -->
**Development Phase**: proposal 

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
