### PR TITLE
Fix decoding of unimplemented CSR addresses

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -795,7 +795,7 @@ class CSRFile(
     val addr = Cat(io.status.v, io.rw.addr)
     val pats = for (((k, _), i) <- read_mapping.zipWithIndex)
       yield (BitPat(k.U), (0 until read_mapping.size).map(j => BitPat((i == j).B)))
-    val decoded = DecodeLogic(addr, Seq.fill(read_mapping.size)(X), pats)
+    val decoded = DecodeLogic(addr, Seq.fill(read_mapping.size)(N), pats)
     val unvirtualized_mapping = for (((k, _), v) <- read_mapping zip decoded) yield k -> v.asBool
 
     for ((k, v) <- unvirtualized_mapping) yield k -> {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**:

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

For instance, with `nPMPs = 0`, writes to PMP CSRs were observed to modify unrelated CSRs.
