### PR TITLE
bump json-jackson to 4.0.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val commonSettings = Seq(
   traceLevel   := 15,
   scalacOptions ++= Seq("-deprecation","-unchecked"),
   libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value),
-  libraryDependencies ++= Seq("org.json4s" %% "json4s-jackson" % "3.6.6"),
+  libraryDependencies ++= Seq("org.json4s" %% "json4s-jackson" % "4.0.5"),
   libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.0" % "test"),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),

--- a/common.sc
+++ b/common.sc
@@ -84,7 +84,7 @@ trait CommonRocketChip extends SbtModule with PublishModule {
   override def ivyDeps = T {
     Agg(
       ivy"${scalaOrganization()}:scala-reflect:${scalaVersion()}",
-      ivy"org.json4s::json4s-jackson:3.6.6",
+      ivy"org.json4s::json4s-jackson:4.0.5",
       ivy"org.scalatest::scalatest:3.2.0"
     ) ++ chisel3IvyDeps
   }


### PR DESCRIPTION
this PR make RC be able to compile against FIRRTL 1.6.X after chipsalliance/firrtl#2519 merged.
This should be merged as a part of 1.6.X bumping.
**Type of change**: other enhancement
**Impact**: no functional change
**Development Phase**: implementation
**Release Notes**
bumping jackson to 4.0.5 