### PR TITLE
Bind Verilog path with EICG_wrapper

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -330,6 +330,10 @@ class WithBootROMFile(bootROMFile: String) extends Config((site, here, up) => {
   case BootROMLocated(x) => up(BootROMLocated(x), site).map(_.copy(contentFileName = bootROMFile))
 })
 
+class WithClockGateModel(file: String = "/vsrc/EICG_wrapper.v") extends Config((site, here, up) => {
+  case ClockGateModelFile => Some(file)
+})
+
 class WithSynchronousRocketTiles extends Config((site, here, up) => {
   case RocketCrossingKey => up(RocketCrossingKey, site) map { r =>
     r.copy(crossingType = SynchronousCrossing())

--- a/src/main/scala/util/ClockGate.scala
+++ b/src/main/scala/util/ClockGate.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.util
 
 import chisel3._
+import chisel3.util.HasBlackBoxResource
 import freechips.rocketchip.config.{Field, Parameters}
 
 case object ClockGateImpl extends Field[() => ClockGate](() => new EICG_wrapper)
@@ -37,4 +38,6 @@ object ClockGate {
 }
 
 // behavioral model of Integrated Clock Gating cell
-class EICG_wrapper extends ClockGate
+class EICG_wrapper extends ClockGate with HasBlackBoxResource {
+  addResource("/vsrc/EICG_wrapper.v")
+}

--- a/src/main/scala/util/ClockGate.scala
+++ b/src/main/scala/util/ClockGate.scala
@@ -3,18 +3,29 @@
 package freechips.rocketchip.util
 
 import chisel3._
-import chisel3.util.HasBlackBoxResource
+import chisel3.util.{HasBlackBoxResource, HasBlackBoxPath}
 import freechips.rocketchip.config.{Field, Parameters}
 
-case object ClockGateImpl extends Field[() => ClockGate](() => new EICG_wrapper)
+import java.nio.file.{Files, Paths}
 
-abstract class ClockGate extends BlackBox {
+case object ClockGateImpl extends Field[() => ClockGate](() => new EICG_wrapper)
+case object ClockGateModelFile extends Field[Option[String]](None)
+
+abstract class ClockGate extends BlackBox
+  with HasBlackBoxResource with HasBlackBoxPath {
   val io = IO(new Bundle{
     val in = Input(Clock())
     val test_en = Input(Bool())
     val en = Input(Bool())
     val out = Output(Clock())
   })
+
+  def addVerilogResource(vsrc: String): Unit = {
+    if (Files.exists(Paths.get(vsrc)))
+      addPath(vsrc)
+    else
+      addResource(vsrc)
+  }
 }
 
 object ClockGate {
@@ -24,6 +35,8 @@ object ClockGate {
       name: Option[String] = None)(implicit p: Parameters): Clock = {
     val cg = Module(p(ClockGateImpl)())
     name.foreach(cg.suggestName(_))
+    p(ClockGateModelFile).map(cg.addVerilogResource(_))
+
     cg.io.in := in
     cg.io.test_en := false.B
     cg.io.en := en
@@ -38,6 +51,4 @@ object ClockGate {
 }
 
 // behavioral model of Integrated Clock Gating cell
-class EICG_wrapper extends ClockGate with HasBlackBoxResource {
-  addResource("/vsrc/EICG_wrapper.v")
-}
+class EICG_wrapper extends ClockGate


### PR DESCRIPTION
I found the EICG_wrapper.v file was not copied to the build directory automatically, the original flow works because it uses rc_resource_dir as the include path.