### PR TITLE
[AXISBundleBits] re-add clonetype override

### DIFF
--- a/src/main/scala/amba/axis/Bundles.scala
+++ b/src/main/scala/amba/axis/Bundles.scala
@@ -24,6 +24,7 @@ case class AXISDataField(width: Int) extends BundleField(AXISData) {
 }
 
 class AXISBundleBits(val params: AXISBundleParameters) extends BundleMap(AXISBundle.keys(params)) {
+  override def cloneType: this.type = (new AXISBundleBits(params)).asInstanceOf[this.type]
   def last = if (params.hasLast) apply(AXISLast) else true.B
   def id   = if (params.hasId)   apply(AXISId)   else 0.U
   def dest = if (params.hasDest) apply(AXISDest) else 0.U


### PR DESCRIPTION
* AXISBundleBits extends off BundleMap which is of type Record and therefore needs cloneType
* resolves a user issue that can be seen at the repo in this post after compiling the current main's rocket-jar:
* https://stackoverflow.com/questions/72043687/implementing-a-diplomatic-axi-stream-interface-in-chisel-bundlemap-clonetype-e

* git repo: https://github.com/jurevreca12/temp_dspblock_example
* git commit: aca81ab9df437e8cea7fa8abd361b6bab7f40326
* note: replace `lib/rocketchip.jar` with a compiled `rocketchip.jar` from main
* bug fixed by using a `rocketchip.jar` generated from this PR's branch

Signed-off-by: Michael Etzkorn <michael-etzkorn@sage.micro.com>

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
https://stackoverflow.com/questions/72043687/implementing-a-diplomatic-axi-stream-interface-in-chisel-bundlemap-clonetype-e
<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Notes to be added to version release:
- Fixed an issue where AXIS nodes reliance on AXISBundleBits would throw BundleMap's IllegalArgumentException due to removal of cloneType override. 

Though because we've yet to add release notes for updating to 3.5. The version notes can simply read:
- removed cloneType from Bundles for bumping to Chisel 3.5.x (still required by custom Bundles inheriting BundleMap)
