### PR TITLE
[TestDriver.v] Set initial `clock = 1'b1;`

### DIFF
--- a/src/main/resources/vsrc/TestDriver.v
+++ b/src/main/resources/vsrc/TestDriver.v
@@ -8,8 +8,8 @@
 `endif
 
 module TestDriver;
-
-  reg clock = 1'b0;
+  // Set `clock = 1'b1;` to avoid the first reset signal only using half of the clock cycle.
+  reg clock = 1'b1;
   reg reset = 1'b1;
 
   always #(`CLOCK_PERIOD/2.0) clock = ~clock;


### PR DESCRIPTION


<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Potential timing violation in the initial condition.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Set `clock = 1'b1;` to avoid the first reset signal only using half of the clock cycle.
If want to avoid the first reset cycle using only half clock period causing timing violation, modify `TestDriver.v` like this:
![image](https://user-images.githubusercontent.com/20642651/175191673-3447a393-b064-4dc5-8584-9fd30480d166.png)

The waveform will be:
![image](https://user-images.githubusercontent.com/20642651/175193123-431b326b-e706-4f40-ab6b-71150b49065a.png)

The original testbench will look like this:
![image](https://user-images.githubusercontent.com/20642651/175190617-b13a16eb-2187-4cf1-8bc5-c6d5c9d23c8b.png)
The waveform will be
![image](https://user-images.githubusercontent.com/20642651/175191639-2ae13e6b-ef4b-4026-8282-2dd4f03bd8b5.png)