### PR TITLE
Bump mill's Chisel to 3.5.3

### DIFF
--- a/common.sc
+++ b/common.sc
@@ -4,8 +4,8 @@ import mill.scalalib.publish._
 import coursier.maven.MavenRepository
 
 val defaultVersions = Map(
-  "chisel3" -> "3.5.0",
-  "chisel3-plugin" -> "3.5.0"
+  "chisel3" -> "3.5.3",
+  "chisel3-plugin" -> "3.5.3"
 )
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs", cross: Boolean = false) = {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Bump mill's Chisel from 3.5.0 to 3.5.3 (sbt has already bumped Chisel to 3.5.2) which includes a [Chisel decoder update](https://github.com/chipsalliance/chisel3/commit/28eef17430d8bbca2765b5a2b0ab0337f7484840), so the tests related to Chisel's decoder ([generatorTests.StageGeneratorSpec](https://github.com/chipsalliance/rocket-chip/blob/master/src/test/scala/generatorTests/StageGeneratorSpec.scala) and [#2991 sanitytests.VerilatorTest](https://github.com/chipsalliance/rocket-chip/pull/2991)) can be performed correctly.

Otherwise, the test would fail like below:
```
StageGeneratorSpec:
Test
- should pass *** FAILED ***
  java.lang.reflect.InvocationTargetException:
  at ... ()
  at freechips.rocketchip.stage.phases.PreElaboration.$anonfun$transform$1(PreElaboration.scala:36)
  at ... ()
  at ... (Stack trace trimmed to user code only. Rerun with --full-stacktrace to see the full stack trace)
  ...
  Cause: java.lang.IllegalArgumentException: requirement failed: input width not equal.
  at scala.Predef$.require(Predef.scala:281)
  at chisel3.util.experimental.decode.TruthTable$.apply(TruthTable.scala:34)
  at freechips.rocketchip.rocket.DecodeLogic$.apply(Decode.scala:24)
  at freechips.rocketchip.rocket.DecodeLogic$.$anonfun$apply$12(Decode.scala:47)
  at chisel3.internal.prefix$.apply(prefix.scala:48)
  at freechips.rocketchip.rocket.DecodeLogic$.$anonfun$apply$11(Decode.scala:47)
  at chisel3.internal.plugin.package$.autoNameRecursively(package.scala:33)
  at freechips.rocketchip.rocket.DecodeLogic$.apply(Decode.scala:47)
  at freechips.rocketchip.rocket.CSRFile.$anonfun$decoded_addr$7(CSR.scala:799)
  at chisel3.internal.prefix$.apply(prefix.scala:48)
  ...
1 targets failed
rocketchip.test.testOnly 1 tests failed: 
  generatorTests.StageGeneratorSpec Test should pass
```

<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
