### PR TITLE
[ptw/fix] fix bit width mismatch when Sv57 is enabled

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -1357,7 +1357,7 @@ class CSRFile(
           reg_vsatp.mode := new_vsatp.mode & satp_valid_modes.reduce(_|_)
         }
         when (mode_ok || !reg_mstatus.v) {
-          reg_vsatp.ppn := new_vsatp.ppn(vpnBits-1,0)
+          reg_vsatp.ppn := new_vsatp.ppn(vpnBits.min(new_vsatp.ppn.getWidth)-1,0)
         }
         if (asIdBits > 0) reg_vsatp.asid := new_vsatp.asid(asIdBits-1,0)
       }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Fix the bit-width out of range when both Sv57 and hypervisor are enabled, causing vpnBits/vaddrBits can be larger than the actual width of signal. A simple fix is maxing out the width when LSBs is being extracted. 

<!-- choose one -->
**Type of change**: bug report/fix

<!-- choose one -->
**Impact**: bug fix

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
