### PR TITLE
fix XLen breakage in `WithRV32` after CDE 1.2

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -254,14 +254,19 @@ class WithIncoherentTiles extends Config((site, here, up) => {
   )
 })
 
-class WithRV32 extends Config((site, here, up) => {
-  case XLen => 32
-  case RocketTilesKey => up(RocketTilesKey, site) map { r =>
-    r.copy(core = r.core.copy(
-      fpu = r.core.fpu.map(_.copy(fLen = 32)),
-      mulDiv = Some(MulDivParams(mulUnroll = 8))))
-  }
-})
+class WithRV32 extends Config(
+  new Config((site, here, up) => {
+    case RocketTilesKey => up(RocketTilesKey) map { r =>
+      r.copy(core = r.core.copy(
+        fpu = r.core.fpu.map(_.copy(fLen = 32)),
+        mulDiv = Some(MulDivParams(mulUnroll = 8))
+      ))
+    }
+  }) ++
+    new Config((site, here, up) => {
+      case XLen => 32
+    })
+)
 
 class WithNonblockingL1(nMSHRs: Int) extends Config((site, here, up) => {
   case RocketTilesKey => up(RocketTilesKey, site) map { r =>


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #3013

In CDE 1.2, the behavior of `up` query was changed. The documentation states that `up` gives the value prior to current `Parameter` layer; however, before 1.2, if a `site` query is encountered, then the value of the whole `Parameter`, instead of the value prior to current layer, is given. CDE 1.2 changed this to match documentation.

It turns out there is some code rely on old (presumably incorrect) behavior. In `WithRV32` layer, the `up` query to change FPU configuration cannot see `XLen => 32` assignment anymore. This PR introduces makes `WithRV32` a two `Config` stack so that `up` query can see new `XLen`.

In the long term, we probably need another solution. AFAIK, we can

- change documentation of CDE and revert back to old behavior, or
- rearrange current `Config`s in `subsystem` so its use of `site(XLen)` and `site(CacheBlockBits)` more easy to override


<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

