### PR TITLE
change debug module name to tlDM.

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -80,21 +80,21 @@ trait HasPeripheryDebug { this: BaseSubsystem =>
     domain
   }
   val debugOpt = p(DebugModuleKey).map { params =>
-    val debug = LazyModule(new TLDebugModule(tlbus.beatBytes))
+    val tlDM = LazyModule(new TLDebugModule(tlbus.beatBytes))
 
-    debug.node := tlbus.coupleTo("debug"){ TLFragmenter(tlbus) := _ }
-    debug.dmInner.dmInner.customNode := debugCustomXbarOpt.get.node
+    tlDM.node := tlbus.coupleTo("debug"){ TLFragmenter(tlbus) := _ }
+    tlDM.dmInner.dmInner.customNode := debugCustomXbarOpt.get.node
 
-    (apbDebugNodeOpt zip debug.apbNodeOpt) foreach { case (master, slave) =>
+    (apbDebugNodeOpt zip tlDM.apbNodeOpt) foreach { case (master, slave) =>
       slave := master
     }
 
-    debug.dmInner.dmInner.sb2tlOpt.foreach { sb2tl  =>
+    tlDM.dmInner.dmInner.sb2tlOpt.foreach { sb2tl  =>
       locateTLBusWrapper(p(ExportDebug).masterWhere).coupleFrom("debug_sb") {
         _ := TLWidthWidget(1) := sb2tl.node
       }
     }
-    debug
+    tlDM
   }
 }
 


### PR DESCRIPTION
**Related issue**: chipsalliance/chisel3#2567

**Type of change**: bug fix

**Impact**: no functional change

**Development Phase**: implementation

calcify the name of TileLink Debug Module to fix bug since chipsalliance/chisel3#2567 get merged.

For detail bug report, see: https://github.com/chipsalliance/playground/runs/7890002567