### PR TITLE
add CI check for chisel3_port branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - master
+      - chisel3_port
 
 
 jobs:


### PR DESCRIPTION
**Related issue**:  #3025

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**:  implementation

This PR open the check for chisel3_port branch, the upcoming chisel3 port PR will be opened against which. After LEC is done, it will be pushed to master.