### PR TITLE
Remove RocketTilesKey, RocketCrossingKey

### DIFF
--- a/src/main/scala/stage/phases/AddDefaultTests.scala
+++ b/src/main/scala/stage/phases/AddDefaultTests.scala
@@ -9,8 +9,8 @@ import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.{Dependency, Phase, PreservesAll, Unserializable}
 import firrtl.options.Viewer.view
 import freechips.rocketchip.stage.RocketChipOptions
-import freechips.rocketchip.subsystem.RocketTilesKey
 import freechips.rocketchip.system.{DefaultTestSuites, RegressionTestSuite, RocketTestSuite}
+import freechips.rocketchip.subsystem.{TilesLocated, InSubsystem, RocketTileAttachParams}
 import freechips.rocketchip.tile.XLen
 import freechips.rocketchip.util.HasRocketChipStageUtils
 import freechips.rocketchip.system.DefaultTestSuites._
@@ -72,7 +72,8 @@ class AddDefaultTests extends Phase with PreservesAll[Phase] with HasRocketChipS
       "rv32ui-p-sll")
 
     // TODO: for now only generate tests for the first core in the first subsystem
-    params(RocketTilesKey).headOption.map { tileParams =>
+    val rocketTileParams = params(TilesLocated(InSubsystem)).collect { case n: RocketTileAttachParams => n }.map(_.tileParams)
+    rocketTileParams.headOption.map { tileParams =>
       val coreParams = tileParams.core
       val vm = coreParams.useVM
       val env = if (vm) List("p", "v") else List("p")

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.subsystem
 
-import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing}
 import freechips.rocketchip.tile._
@@ -18,12 +18,8 @@ case class RocketCrossingParams(
 
 case class RocketTileAttachParams(
   tileParams: RocketTileParams,
-  crossingParams: RocketCrossingParams,
-  lookup: LookupByHartIdImpl
+  crossingParams: RocketCrossingParams
 ) extends CanAttachTile { type TileType = RocketTile }
-
-case object RocketTilesKey extends Field[Seq[RocketTileParams]](Nil)
-case object RocketCrossingKey extends Field[Seq[RocketCrossingParams]](List(RocketCrossingParams()))
 
 trait HasRocketTiles extends HasTiles { this: BaseSubsystem =>
   val rocketTiles = tiles.collect { case r: RocketTile => r }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

`RocketTilesKey` and `RocketCrossingKey` are legacy `Fields`, the new `TilesLocated` and `InstantiableTileParams` API is more generalized for multi-tile systems.

This PR removes those keys.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
