### PR TITLE
Support LazyModule cloning

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -100,7 +100,8 @@ CONFIGS=\
 	$(PROJECT).EightChannelConfig \
 	$(PROJECT).DualCoreConfig \
 	$(PROJECT).MemPortOnlyConfig \
-	$(PROJECT).MMIOPortOnlyConfig
+	$(PROJECT).MMIOPortOnlyConfig \
+	$(PROJECT).CloneTileConfig
 endif
 
 # These are the named regression targets.  While it's expected you run them in

--- a/src/main/scala/diplomacy/Clone.scala
+++ b/src/main/scala/diplomacy/Clone.scala
@@ -4,6 +4,8 @@ package freechips.rocketchip.diplomacy
 
 import Chisel._
 import chisel3.shim.CloneModule
+import chisel3.internal.sourceinfo.{SourceInfo}
+
 
 final class CloneLazyModule private (val base: LazyModule)
 {
@@ -17,5 +19,21 @@ final class CloneLazyModule private (val base: LazyModule)
 
 object CloneLazyModule
 {
+  /** The old API **/
   def apply(base: LazyModule) = new CloneLazyModule(base)
+
+
+  /** Constructs a [[LazyModule]], but replaces its [[LazyModuleImp]] with a cloned [[LazyModuleImp]]
+    * from another source. The user of [[CloneLazyModule]] must be careful to guarantee that
+    * bc and cloneProto have equivalent [[LazyModuleImp]]'s.
+    *
+    * @param bc         [[LazyModule]] instance to wrap, this instance will not evaluate its own [[LazyModuleImp]]
+    * @param cloneProto [[LazyModule]] instance which will provide the [[LazyModuleImp]] implementation for bc
+    */
+  def apply[A <: LazyModule, B <: LazyModule](bc: A, cloneProto: B)(implicit valName: ValName, sourceInfo: SourceInfo): A = {
+    require(LazyModule.scope.isDefined, s"CloneLazyModule ${bc.name} ${sourceLine(sourceInfo)} can only exist as the child of a parent LazyModule")
+    LazyModule(bc)
+    bc.cloneProto = Some(cloneProto)
+    bc
+  }
 }

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -526,3 +526,17 @@ class WithControlBusFrequency(freqMHz: Double) extends Config((site, here, up) =
 class WithDontDriveBusClocksFromSBus extends Config((site, here, up) => {
   case DriveClocksFromSBus => false
 })
+
+class WithCloneRocketTiles(n: Int = 1, cloneHart: Int = 0, overrideIdOffset: Option[Int] = None) extends Config((site, here, up) => {
+  case TilesLocated(InSubsystem) => {
+    val prev = up(TilesLocated(InSubsystem), site)
+    val idOffset = overrideIdOffset.getOrElse(prev.size)
+    val tileAttachParams = prev(cloneHart).asInstanceOf[RocketTileAttachParams]
+    (0 until n).map { i =>
+      CloneTileAttachParams(cloneHart, tileAttachParams.copy(
+        tileParams = tileAttachParams.tileParams.copy(hartId = i + idOffset)
+      ))
+    } ++ prev
+  }
+})
+

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -86,3 +86,5 @@ class MMIOPortOnlyConfig extends Config(
 
 class BaseFPGAConfig extends Config(new BaseConfig ++ new WithCoherentBusTopology)
 class DefaultFPGAConfig extends Config(new WithNSmallCores(1) ++ new BaseFPGAConfig)
+
+class CloneTileConfig extends Config(new WithCloneRocketTiles(7) ++ new WithNBigCores(1) ++ new WithCoherentBusTopology ++ new BaseConfig)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

This PR implements support for cloning arbitrary LazyModules. The cloned module still performs diplomatic elaboration, but its `LazyModuleImp` is not evaluated. The empty `Dangle`s from diplomatic elaboration are matched with the IOs of the `AutoBundle` from the cloned record of the prototype module.


**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
