### PR TITLE
Replace deprecated rtos riscv in openocd cfg

### DIFF
--- a/scripts/RocketSim.cfg
+++ b/scripts/RocketSim.cfg
@@ -9,7 +9,7 @@ set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5
 
 set _TARGETNAME $_CHIPNAME.cpu
-target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos hwthread
 
 riscv set_reset_timeout_sec 120
 riscv set_command_timeout_sec 120


### PR DESCRIPTION
`-rtos riscv` is deprecated. It works with the openocd in rocket-tools but the latest openocd and riscv-openocd both do not recognize this option.

The openocd in rocket-tools points to a version after this commit
https://github.com/riscv/riscv-openocd/commit/50d0c2f67c1c32cb58d0a28f88e49e15623dcdc7
but it is before the removal of rtos riscv
https://github.com/riscv/riscv-openocd/commit/d52e4668a60212524b3d29b92b47cc21c5317b66

When I was migrating the CI (see https://github.com/chipsalliance/playground/pull/46) to the latest openocd, it will not recognize this option. The openocd from `riscv-openocd` also does not work with this option.

This commit still works with the current CI as rocket-tools support this option.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: Implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Replace deprecated rtos riscv in openocd cfg to rtos hwthread