### PR TITLE
[fix] missing PTE Cache tag MSB caused by width mismatch

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -372,8 +372,10 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
       if (s2) do_both_stages && !stage2 && !stage2_final
       else can_hit
     val tag =
-      if (s2) Cat(true.B, stage2_pte_cache_addr.padTo(tags.head.getWidth - 1))
-      else Cat(r_req.vstage1, pte_cache_addr.padTo(tags.head.getWidth - 1))
+      if (s2) Cat(true.B, 
+        {if (tags.head.getWidth > stage2_pte_cache_addr.getWidth) stage2_pte_cache_addr.padTo(tags.head.getWidth - 1) else stage2_pte_cache_addr})
+      else Cat(r_req.vstage1, 
+        {if (tags.head.getWidth > pte_cache_addr.getWidth) pte_cache_addr.padTo(tags.head.getWidth - 1) else pte_cache_addr})
 
     val hits = tags.map(_ === tag).asUInt & valid
     val hit = hits.orR && can_hit

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -372,8 +372,8 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
       if (s2) do_both_stages && !stage2 && !stage2_final
       else can_hit
     val tag =
-      if (s2) Cat(true.B, stage2_pte_cache_addr)
-      else Cat(r_req.vstage1, pte_cache_addr)
+      if (s2) Cat(true.B, stage2_pte_cache_addr.padTo(tags.head.getWidth - 1))
+      else Cat(r_req.vstage1, pte_cache_addr.padTo(tags.head.getWidth - 1))
 
     val hits = tags.map(_ === tag).asUInt & valid
     val hit = hits.orR && can_hit

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -372,10 +372,8 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
       if (s2) do_both_stages && !stage2 && !stage2_final
       else can_hit
     val tag =
-      if (s2) Cat(true.B, 
-        {if (tags.head.getWidth > stage2_pte_cache_addr.getWidth) stage2_pte_cache_addr.padTo(tags.head.getWidth - 1) else stage2_pte_cache_addr})
-      else Cat(r_req.vstage1, 
-        {if (tags.head.getWidth > pte_cache_addr.getWidth) pte_cache_addr.padTo(tags.head.getWidth - 1) else pte_cache_addr})
+      if (s2) Cat(true.B, stage2_pte_cache_addr.padTo(vaddrBits))
+      else Cat(r_req.vstage1, pte_cache_addr.padTo(if (usingHypervisor) vaddrBits else paddrBits))
 
     val hits = tags.map(_ === tag).asUInt & valid
     val hit = hits.orR && can_hit


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: Using same explicit bit-width for page cache reference/assignment to avoid incorrect MSB /reference assignment

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Bug fix: Missing MSB assignment of page cache tag result in hfence.gvma has no ability to invalidate corresponding page cache entry which tag with v bit set. Padding the pte_cache_addr to `tag width - 1` fixs this problem