### PR TITLE
Tieoff atomics bundle in DCache.

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -570,7 +570,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   } else {
     // If no managers support atomics, assert fail if processor asks for them
     assert (!(tl_out_a.valid && s2_read && s2_write && s2_uncached))
-    Wire(new TLBundleA(edge.bundle))
+    WireDefault(new TLBundleA(edge.bundle), DontCare)
   }
 
   tl_out_a.valid := !io.cpu.s2_kill &&


### PR DESCRIPTION
On systems without atomics a dummy bundle is created. After switching to chisel3 the explicit tieoff is required to prevent an unconnected wire error during verilog generation.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change
