### PR TITLE
[WIP] Remove rowBits/cacheBlockBytes params from cache | add tile-level masterPortBeatBytes

### DIFF
--- a/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
+++ b/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
@@ -5,6 +5,7 @@ package freechips.rocketchip.devices.tilelink
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
+import freechips.rocketchip.subsystem.CacheBlockBytes
 
 case class BuiltInZeroDeviceParams(
   addr: AddressSet,
@@ -50,7 +51,7 @@ object BuiltInDevices {
         address = zeroParams.addr,
         beatBytes = params.beatBytes))
       (zero.node
-        := TLFragmenter(params.beatBytes, params.blockBytes)
+        := TLFragmenter(params.beatBytes, p(CacheBlockBytes))
         := zeroParams.buffer.map { params => TLBuffer(params) }.getOrElse { TLTempNode() }
         := zeroParams.cacheCork.map { params => TLCacheCork(params) }.getOrElse { TLTempNode() }
         := outwardNode)

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.devices.tilelink
 import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.subsystem.{Attachable, HierarchicalLocation, TLBusWrapperLocation}
+import freechips.rocketchip.subsystem.{Attachable, HierarchicalLocation, TLBusWrapperLocation, CacheBlockBytes}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
@@ -65,7 +65,7 @@ object MaskROM {
     val bus = subsystem.locateTLBusWrapper(where)
     val maskROM = LazyModule(new TLMaskROM(params))
     maskROM.node := bus.coupleTo("MaskROM") {
-      TLFragmenter(maskROM.beatBytes, bus.blockBytes) :*= TLWidthWidget(bus) := _
+      TLFragmenter(maskROM.beatBytes, p(CacheBlockBytes)) :*= TLWidthWidget(bus) := _
     }
     InModuleBody { maskROM.module.clock := bus.module.clock }
     InModuleBody { maskROM.module.reset := bus.module.reset }

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -3,6 +3,7 @@
 
 package freechips.rocketchip.groundtest
 
+import chisel3.util.{log2Ceil}
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.devices.tilelink.{CLINTKey, PLICKey}
 import freechips.rocketchip.devices.debug.{DebugModuleKey}
@@ -55,8 +56,8 @@ class WithTraceGen(
           addrBag = {
             val nSets = dcp.nSets
             val nWays = dcp.nWays
-            val blockOffset = site(SystemBusKey).blockOffset
-            val nBeats = site(SystemBusKey).blockBeats
+            val blockOffset = log2Ceil(site(CacheBlockBytes))
+            val nBeats = site(CacheBlockBytes) / site(SystemBusKey).beatBytes
             List.tabulate(nWays) { i =>
               Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
             }.flatten

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -78,6 +78,7 @@ case class TraceGenParams(
   val blockerCtrlAddr = None
   val name = None
   val clockSinkParams = ClockSinkParameters()
+  val masterPortBeatBytes = 8
 }
 
 trait HasTraceGenParams {

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -17,7 +17,6 @@ import scala.collection.mutable.ListBuffer
 case class DCacheParams(
     nSets: Int = 64,
     nWays: Int = 4,
-    rowBits: Int = 64,
     subWordBits: Option[Int] = None,
     replacementPolicy: String = "random",
     nTLBSets: Int = 1,
@@ -58,7 +57,7 @@ case class DCacheParams(
 trait HasL1HellaCacheParameters extends HasL1CacheParameters with HasCoreParameters {
   val cacheParams = tileParams.dcache.get
   val cfg = cacheParams
-
+  def rowBits: Int
   def wordBits = coreDataBits
   def wordBytes = coreDataBytes
   def subWordBits = cacheParams.subWordBits.getOrElse(wordBits)

--- a/src/main/scala/subsystem/BankedL2Params.scala
+++ b/src/main/scala/subsystem/BankedL2Params.scala
@@ -34,7 +34,6 @@ case class BankedL2Params(
 }
 
 case class CoherenceManagerWrapperParams(
-    blockBytes: Int,
     beatBytes: Int,
     nBanks: Int,
     name: String,
@@ -62,7 +61,7 @@ class CoherenceManagerWrapper(params: CoherenceManagerWrapperParams, context: Ha
   val prefixNode = None
 
   private def banked(node: TLOutwardNode): TLOutwardNode =
-    if (params.nBanks == 0) node else { TLTempNode() :=* BankBinder(params.nBanks, params.blockBytes) :*= node }
+    if (params.nBanks == 0) node else { TLTempNode() :=* BankBinder(params.nBanks, p(CacheBlockBytes)) :*= node }
   val outwardNode = banked(tempOut)
 }
 

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -97,7 +97,7 @@ case class CoherentBusTopologyParams(
 ) extends TLBusWrapperTopology(
   instantiations = (if (l2.nBanks == 0) Nil else List(
     (MBUS, mbus),
-    (L2, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, l2.nBanks, L2.name, sbus.dtsFrequency)(l2.coherenceManager)))),
+    (L2, CoherenceManagerWrapperParams(mbus.beatBytes, l2.nBanks, L2.name, sbus.dtsFrequency)(l2.coherenceManager)))),
   connections = if (l2.nBanks == 0) Nil else List(
     (SBUS, L2,   TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_STAR)()),
     (L2,  MBUS,  TLBusWrapperConnection.crossTo(

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -101,11 +101,9 @@ class WithNBigCores(
         mulEarlyOut = true,
         divEarlyOut = true))),
       dcache = Some(DCacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         nMSHRs = 0,
         blockBytes = site(CacheBlockBytes))),
       icache = Some(ICacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         blockBytes = site(CacheBlockBytes))))
     List.tabulate(n)(i => RocketTileAttachParams(
       big.copy(hartId = i + idOffset),
@@ -126,7 +124,6 @@ class WithNMedCores(
       core = RocketCoreParams(fpu = None),
       btb = None,
       dcache = Some(DCacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,
@@ -134,7 +131,6 @@ class WithNMedCores(
         nMSHRs = 0,
         blockBytes = site(CacheBlockBytes))),
       icache = Some(ICacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,
@@ -159,7 +155,6 @@ class WithNSmallCores(
       core = RocketCoreParams(useVM = false, fpu = None),
       btb = None,
       dcache = Some(DCacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,
@@ -167,7 +162,6 @@ class WithNSmallCores(
         nMSHRs = 0,
         blockBytes = site(CacheBlockBytes))),
       icache = Some(ICacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,
@@ -190,7 +184,6 @@ class With1TinyCore extends Config((site, here, up) => {
         mulDiv = Some(MulDivParams(mulUnroll = 8))),
       btb = None,
       dcache = Some(DCacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         nSets = 256, // 16Kb scratchpad
         nWays = 1,
         nTLBSets = 1,
@@ -199,7 +192,6 @@ class With1TinyCore extends Config((site, here, up) => {
         blockBytes = site(CacheBlockBytes),
         scratch = Some(0x80000000L))),
       icache = Some(ICacheParams(
-        rowBits = site(SystemBusKey).beatBits,
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -19,23 +19,18 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   case MaxHartIdBits => log2Up(site(TilesLocated(InSubsystem)).map(_.tileParams.hartId).max+1)
   // Interconnect parameters
   case SystemBusKey => SystemBusParams(
-    beatBytes = site(XLen)/8,
-    blockBytes = site(CacheBlockBytes))
+    beatBytes = site(XLen)/8)
   case ControlBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
-    blockBytes = site(CacheBlockBytes),
     errorDevice = Some(BuiltInErrorDeviceParams(
       errorParams = DevNullParams(List(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096))))
   case PeripheryBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
-    blockBytes = site(CacheBlockBytes),
     dtsFrequency = Some(100000000)) // Default to 100 MHz pbus clock
   case MemoryBusKey => MemoryBusParams(
-    beatBytes = site(XLen)/8,
-    blockBytes = site(CacheBlockBytes))
+    beatBytes = site(XLen)/8)
   case FrontBusKey => FrontBusParams(
-    beatBytes = site(XLen)/8,
-    blockBytes = site(CacheBlockBytes))
+    beatBytes = site(XLen)/8)
   // Additional device Parameters
   case BootROMLocated(InSubsystem) => Some(BootROMParams(contentFileName = "./bootrom/bootrom.img"))
   case SubsystemExternalResetVectorKey => false
@@ -100,11 +95,8 @@ class WithNBigCores(
         mulUnroll = 8,
         mulEarlyOut = true,
         divEarlyOut = true))),
-      dcache = Some(DCacheParams(
-        nMSHRs = 0,
-        blockBytes = site(CacheBlockBytes))),
-      icache = Some(ICacheParams(
-        blockBytes = site(CacheBlockBytes))))
+      dcache = Some(DCacheParams(nMSHRs = 0)),
+      icache = Some(ICacheParams()))
     List.tabulate(n)(i => RocketTileAttachParams(
       big.copy(hartId = i + idOffset),
       crossing
@@ -128,14 +120,12 @@ class WithNMedCores(
         nWays = 1,
         nTLBSets = 1,
         nTLBWays = 4,
-        nMSHRs = 0,
-        blockBytes = site(CacheBlockBytes))),
+        nMSHRs = 0)),
       icache = Some(ICacheParams(
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,
-        nTLBWays = 4,
-        blockBytes = site(CacheBlockBytes))))
+        nTLBWays = 4)))
     List.tabulate(n)(i => RocketTileAttachParams(
       med.copy(hartId = i + idOffset),
       crossing
@@ -159,14 +149,12 @@ class WithNSmallCores(
         nWays = 1,
         nTLBSets = 1,
         nTLBWays = 4,
-        nMSHRs = 0,
-        blockBytes = site(CacheBlockBytes))),
+        nMSHRs = 0)),
       icache = Some(ICacheParams(
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,
-        nTLBWays = 4,
-        blockBytes = site(CacheBlockBytes))))
+        nTLBWays = 4)))
     List.tabulate(n)(i => RocketTileAttachParams(
       small.copy(hartId = i + idOffset),
       crossing
@@ -189,14 +177,12 @@ class With1TinyCore extends Config((site, here, up) => {
         nTLBSets = 1,
         nTLBWays = 4,
         nMSHRs = 0,
-        blockBytes = site(CacheBlockBytes),
         scratch = Some(0x80000000L))),
       icache = Some(ICacheParams(
         nSets = 64,
         nWays = 1,
         nTLBSets = 1,
-        nTLBWays = 4,
-        blockBytes = site(CacheBlockBytes)))
+        nTLBWays = 4))
     )
     List(RocketTileAttachParams(
       tiny,

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -10,7 +10,6 @@ import freechips.rocketchip.util.{Location}
 
 case class FrontBusParams(
     beatBytes: Int,
-    blockBytes: Int,
     dtsFrequency: Option[BigInt] = None,
     zeroDevice: Option[BuiltInZeroDeviceParams] = None,
     errorDevice: Option[BuiltInErrorDeviceParams] = None)

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -268,7 +268,7 @@ trait CanAttachTile {
     implicit val p = context.p
     val dataBus = context.locateTLBusWrapper(crossingParams.master.where)
     dataBus.coupleFrom(tileParams.name.getOrElse("tile")) { bus =>
-      bus :=* crossingParams.master.injectNode(context) :=* domain.crossMasterPort(crossingParams.crossingType)
+      bus :=* TLWidthWidget(tileParams.masterPortBeatBytes) :=* crossingParams.master.injectNode(context) :=* domain.crossMasterPort(crossingParams.crossingType)
     }
   }
 

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -11,7 +11,6 @@ import freechips.rocketchip.util._
 /** Parameterization of the memory-side bus created for each memory channel */
 case class MemoryBusParams(
   beatBytes: Int,
-  blockBytes: Int,
   dtsFrequency: Option[BigInt] = None,
   zeroDevice: Option[BuiltInZeroDeviceParams] = None,
   errorDevice: Option[BuiltInErrorDeviceParams] = None,

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -16,7 +16,6 @@ case class BusAtomics(
 
 case class PeripheryBusParams(
     beatBytes: Int,
-    blockBytes: Int,
     atomics: Option[BusAtomics] = Some(BusAtomics()),
     dtsFrequency: Option[BigInt] = None,
     zeroDevice: Option[BuiltInZeroDeviceParams] = None,

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -10,7 +10,6 @@ import freechips.rocketchip.util._
 
 case class SystemBusParams(
     beatBytes: Int,
-    blockBytes: Int,
     policy: TLArbiter.Policy = TLArbiter.roundRobin,
     dtsFrequency: Option[BigInt] = None,
     zeroDevice: Option[BuiltInZeroDeviceParams] = None,

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -28,6 +28,7 @@ trait TileParams {
   val blockerCtrlAddr: Option[BigInt]
   val name: Option[String]
   val clockSinkParams: ClockSinkParameters
+  val masterPortBeatBytes: Int
 }
 
 abstract class InstantiableTileParams[TileType <: BaseTile] extends TileParams {
@@ -89,7 +90,7 @@ trait HasNonDiplomaticTileParameters {
 
   def cacheBlockBytes = p(CacheBlockBytes)
   def lgCacheBlockBytes = log2Up(cacheBlockBytes)
-  def masterPortBeatBytes = p(SystemBusKey).beatBytes
+  def masterPortBeatBytes = tileParams.masterPortBeatBytes
 
   // TODO make HellaCacheIO diplomatic and remove this brittle collection of hacks
   //                  Core   PTW                DTIM                    coprocessors           
@@ -163,6 +164,7 @@ trait HasTileParameters extends HasNonDiplomaticTileParameters {
     require(bits <= maxPAddrBits, s"Requested $bits paddr bits, but since xLen is $xLen only $maxPAddrBits will fit")
     bits
   }
+  def rowBits = tlBundleParams.dataBits
   def vaddrBits: Int =
     if (usingVM) {
       val v = maxHVAddrBits

--- a/src/main/scala/tile/L1Cache.scala
+++ b/src/main/scala/tile/L1Cache.scala
@@ -9,10 +9,8 @@ import freechips.rocketchip.config.Parameters
 trait L1CacheParams {
   def nSets:         Int
   def nWays:         Int
-  def rowBits:       Int
   def nTLBSets:      Int
   def nTLBWays:      Int
-  def blockBytes:    Int // TODO this is ignored in favor of p(CacheBlockBytes) in BaseTile
 }
 
 trait HasL1CacheParameters extends HasTileParameters {
@@ -27,7 +25,6 @@ trait HasL1CacheParameters extends HasTileParameters {
   def nWays = cacheParams.nWays
   def wayBits = log2Up(nWays)
   def isDM = nWays == 1
-  def rowBits = cacheParams.rowBits
   def rowBytes = rowBits/8
   def rowOffBits = log2Up(rowBytes)
   def nTLBSets = cacheParams.nTLBSets

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -26,6 +26,7 @@ case class RocketTileParams(
     beuAddr: Option[BigInt] = None,
     blockerCtrlAddr: Option[BigInt] = None,
     clockSinkParams: ClockSinkParameters = ClockSinkParameters(),
+    masterPortBeatBytes: Int = 8,
     boundaryBuffers: Boolean = false // if synthesized with hierarchical PnR, cut feed-throughs?
     ) extends InstantiableTileParams[RocketTile] {
   require(icache.isDefined)

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -6,6 +6,7 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
+import freechips.rocketchip.subsystem.CacheBlockBytes
 import scala.math.min
 
 object EarlyAck {
@@ -335,7 +336,7 @@ object TLFragmenter
     } else { TLEphemeralNode()(ValName("no_fragmenter")) }
   }
 
-  def apply(wrapper: TLBusWrapper)(implicit p: Parameters): TLNode = apply(wrapper.beatBytes, wrapper.blockBytes)
+  def apply(wrapper: TLBusWrapper)(implicit p: Parameters): TLNode = apply(wrapper.beatBytes, p(CacheBlockBytes))
 }
 
 // Synthesizable unit tests


### PR DESCRIPTION
We want to move towards decoupling tile-local port widths from the global interconnect widths.
This adds `masterPortBeatBytes` to `BaseTile`. At tile instantiation and connection, a `WidthWidget` is inserted such that the internal bus width of the tile is `masterPortBeatBytes`. `rowBits` in L1Cache params are now effectively references to this, so explicitly setting `rowBits = p(SystemBusKey).beatBits` is no longer necessary.

This PR also removes many local instances of `blockBytes` params. It seems exceedingly unlikely that someone will need to build a system with varying cache block size, so we should just rely on the global variable.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
