### PR TITLE
Fix "dump-start" in FSDB-mode

### DIFF
--- a/src/main/resources/vsrc/TestDriver.v
+++ b/src/main/resources/vsrc/TestDriver.v
@@ -65,6 +65,7 @@ module TestDriver;
       $fsdbDumpfile(fsdbfile);
       $fsdbDumpvars("+all");
       //$fsdbDumpSVA;
+      $fsdbDumpoff ;
 `else
       $fdisplay(stderr, "Error: +fsdbfile is FSDB-only; use +vcdfile/+vcdplus instead or recompile with FSDB=1");
       $fatal;


### PR DESCRIPTION
When `USE_FSDB=1`, `+dump-start` doesn't do anything. It seems VCS just begins dumping signals as soon `fsdbDumpfile`/`fsdbDumpVars` is called, rather than waiting for `fsdbDumpon`.

My simple workaround is to just call  `fsdbDumpOff` explicitly right away. The waveform dumping can resume when `fsdbDumpOn` is called.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change (a bug fix)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
