### PR TITLE
rvc: allow decode C.MV to ADDI with useAddiForMv

### DIFF
--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -16,7 +16,7 @@ class ExpandedInstruction extends Bundle {
   val rs3 = UInt(5.W)
 }
 
-class RVCDecoder(x: UInt, xLen: Int) {
+class RVCDecoder(x: UInt, xLen: Int, useAddiForMv: Boolean = false) {
   def inst(bits: UInt, rd: UInt = x(11,7), rs1: UInt = x(19,15), rs2: UInt = x(24,20), rs3: UInt = x(31,27)) = {
     val res = Wire(new ExpandedInstruction)
     res.bits := bits
@@ -127,7 +127,10 @@ class RVCDecoder(x: UInt, xLen: Int) {
       else sdsp
     }
     def jalr = {
-      val mv = inst(Cat(rs2, x0, 0.U(3.W), rd, 0x33.U(7.W)), rd, x0, rs2)
+      val mv = {
+        if (useAddiForMv) inst(Cat(rs2, 0.U(3.W), rd, 0x13.U(7.W)), rd, rs2, x0)
+        else inst(Cat(rs2, x0, 0.U(3.W), rd, 0x33.U(7.W)), rd, x0, rs2)
+      }
       val add = inst(Cat(rs2, rd, 0.U(3.W), rd, 0x33.U(7.W)), rd, rd, rs2)
       val jr = Cat(rs2, rd, 0.U(3.W), x0, 0x67.U(7.W))
       val reserved = Cat(jr >> 7, 0x1F.U(7.W))
@@ -152,7 +155,7 @@ class RVCDecoder(x: UInt, xLen: Int) {
   }
 }
 
-class RVCExpander(implicit val p: Parameters) extends Module with HasCoreParameters {
+class RVCExpander(useAddiForMv: Boolean = false)(implicit val p: Parameters) extends Module with HasCoreParameters {
   val io = IO(new Bundle {
     val in = Input(UInt(32.W))
     val out = Output(new ExpandedInstruction)
@@ -161,9 +164,9 @@ class RVCExpander(implicit val p: Parameters) extends Module with HasCoreParamet
 
   if (usingCompressed) {
     io.rvc := io.in(1,0) =/= 3.U
-    io.out := new RVCDecoder(io.in, p(XLen)).decode
+    io.out := new RVCDecoder(io.in, p(XLen), useAddiForMv).decode
   } else {
     io.rvc := false.B
-    io.out := new RVCDecoder(io.in, p(XLen)).passthrough
+    io.out := new RVCDecoder(io.in, p(XLen), useAddiForMv).passthrough
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This commit changes how compressed move instructions are decoded. It adds an useAddiForMv argument to RVCDecoder to allow the user to specify how C.MV is decoded.

From RISC-V spec, C.MV expands to a different instruction than the canonical MV pseudoinstruction, which instead uses ADDI. Implementations that handle MV specially, e.g. using register-renaming hardware, may find it more convenient to expand C.MV to MV instead of ADD, at slight additional hardware cost.

We add a configuration option for decoding C.MV to ADDI.
