### PR TITLE
Add riscv-tests/riscv-arch-tests framework based on mill

### DIFF
--- a/arch-test/emulator/emulator_isa_rv32i.yaml
+++ b/arch-test/emulator/emulator_isa_rv32i.yaml
@@ -1,0 +1,6 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32I
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]

--- a/arch-test/emulator/emulator_platform.yaml
+++ b/arch-test/emulator/emulator_platform.yaml
@@ -1,0 +1,10 @@
+mtime:
+  implemented: true
+  address: 0xbff8
+mtimecmp:
+  implemented: true
+  address: 0x4000
+nmi:
+  label: nmi_vector
+reset:
+  label: reset_vector

--- a/arch-test/emulator/env/link.ld
+++ b/arch-test/emulator/env/link.ld
@@ -1,0 +1,18 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(rvtest_entry_point)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  .bss : { *(.bss) }
+  _end = .;
+}
+

--- a/arch-test/emulator/env/model_test.h
+++ b/arch-test/emulator/env/model_test.h
@@ -1,0 +1,53 @@
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+#define RVMODEL_DATA_SECTION \
+        .pushsection .tohost,"aw",@progbits;                            \
+        .align 8; .global tohost; tohost: .dword 0;                     \
+        .align 8; .global fromhost; fromhost: .dword 0;                 \
+        .popsection;                                                    \
+        .align 8; .global begin_regstate; begin_regstate:               \
+        .word 128;                                                      \
+        .align 8; .global end_regstate; end_regstate:                   \
+        .word 4;
+
+//RV_COMPLIANCE_HALT
+#define RVMODEL_HALT                                              \
+  li x1, 1;                                                                   \
+  write_tohost:                                                               \
+    sw x1, tohost, t5;                                                        \
+    j write_tohost;
+
+#define RVMODEL_BOOT
+
+//RV_COMPLIANCE_DATA_BEGIN
+#define RVMODEL_DATA_BEGIN                                              \
+  .align 4; .global begin_signature; begin_signature:
+
+//RV_COMPLIANCE_DATA_END
+#define RVMODEL_DATA_END                                                      \
+  .align 4; .global end_signature; end_signature:  \
+  RVMODEL_DATA_SECTION                                                        \
+
+//RVTEST_IO_INIT
+#define RVMODEL_IO_INIT
+//RVTEST_IO_WRITE_STR
+#define RVMODEL_IO_WRITE_STR(_R, _STR)
+//RVTEST_IO_CHECK
+#define RVMODEL_IO_CHECK()
+//RVTEST_IO_ASSERT_GPR_EQ
+#define RVMODEL_IO_ASSERT_GPR_EQ(_S, _R, _I)
+//RVTEST_IO_ASSERT_SFPR_EQ
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+//RVTEST_IO_ASSERT_DFPR_EQ
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+#define RVMODEL_SET_MSW_INT
+
+#define RVMODEL_CLEAR_MSW_INT
+
+#define RVMODEL_CLEAR_MTIMER_INT
+
+#define RVMODEL_CLEAR_MEXT_INT
+
+
+#endif // _COMPLIANCE_MODEL_H

--- a/arch-test/emulator/riscof_emulator.py
+++ b/arch-test/emulator/riscof_emulator.py
@@ -1,0 +1,183 @@
+import os
+import re
+import shutil
+import subprocess
+import shlex
+import logging
+import random
+import string
+from string import Template
+import sys
+
+import riscof.utils as utils
+import riscof.constants as constants
+from riscof.pluginTemplate import pluginTemplate
+
+logger = logging.getLogger()
+
+class emulator(pluginTemplate):
+    __model__ = "emulator"
+
+    #TODO: please update the below to indicate family, version, etc of your DUT.
+    __version__ = "XXX"
+
+    def __init__(self, *args, **kwargs):
+        sclass = super().__init__(*args, **kwargs)
+
+        config = kwargs.get('config')
+
+        # If the config node for this DUT is missing or empty. Raise an error. At minimum we need
+        # the paths to the ispec and pspec files
+        if config is None:
+            print("Please enter input file paths in configuration.")
+            raise SystemExit(1)
+
+        # In case of an RTL based DUT, this would be point to the final binary executable of your
+        # test-bench produced by a simulator (like verilator, vcs, incisive, etc). In case of an iss or
+        # emulator, this variable could point to where the iss binary is located. If 'PATH variable
+        # is missing in the config.ini we can hardcode the alternate here.
+        self.dut_exe = os.path.join(config['PATH'] if 'PATH' in config else "","emulator")
+
+        # Number of parallel jobs that can be spawned off by RISCOF
+        # for various actions performed in later functions, specifically to run the tests in
+        # parallel on the DUT executable. Can also be used in the build function if required.
+        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
+
+        # Path to the directory where this python file is located. Collect it from the config.ini
+        self.pluginpath=os.path.abspath(config['pluginpath'])
+
+        # Collect the paths to the  riscv-config absed ISA and platform yaml files. One can choose
+        # to hardcode these here itself instead of picking it from the config.ini file.
+        self.isa_spec = os.path.abspath(config['ispec'])
+        self.platform_spec = os.path.abspath(config['pspec'])
+
+        #We capture if the user would like the run the tests on the target or
+        #not. If you are interested in just compiling the tests and not running
+        #them on the target, then following variable should be set to False
+        if 'target_run' in config and config['target_run']=='0':
+            self.target_run = False
+        else:
+            self.target_run = True
+
+        # Return the parameters set above back to RISCOF for further processing.
+        return sclass
+
+    def initialise(self, suite, work_dir, archtest_env):
+
+       # capture the working directory. Any artifacts that the DUT creates should be placed in this
+       # directory. Other artifacts from the framework and the Reference plugin will also be placed
+       # here itself.
+       self.work_dir = work_dir
+
+       # capture the architectural test-suite directory.
+       self.suite_dir = suite
+
+       # Note the march is not hardwired here, because it will change for each
+       # test. Similarly the output elf name and compile macros will be assigned later in the
+       # runTests function
+       self.compile_cmd = 'riscv64-none-elf-gcc -march={0} \
+         -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g\
+         -T '+self.pluginpath+'/env/link.ld\
+         -I '+self.pluginpath+'/env/\
+         -I ' + archtest_env + ' {1} -o {2} {3}'
+
+       # add more utility snippets here
+
+    def build(self, isa_yaml, platform_yaml):
+
+      # load the isa yaml as a dictionary in python.
+      ispec = utils.load_yaml(isa_yaml)['hart0']
+
+      # capture the XLEN value by picking the max value in 'supported_xlen' field of isa yaml. This
+      # will be useful in setting integer value in the compiler string (if not already hardcoded);
+      self.xlen = '64'#('64' if 64 in ispec['supported_xlen'] else '32')
+
+      # for spike start building the '--isa' argument. the self.isa is dutnmae specific and may not be
+      # useful for all DUTs
+      self.isa = 'rv' + self.xlen
+      if "I" in ispec["ISA"]:
+          self.isa += 'i'
+      if "M" in ispec["ISA"]:
+          self.isa += 'm'
+      if "F" in ispec["ISA"]:
+          self.isa += 'f'
+      if "D" in ispec["ISA"]:
+          self.isa += 'd'
+      if "C" in ispec["ISA"]:
+          self.isa += 'c'
+
+      #TODO: The following assumes you are using the riscv-gcc toolchain. If
+      #      not please change appropriately
+      self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else 'ilp32 ')
+
+    def runTests(self, testList):
+
+      # Delete Makefile if it already exists.
+      if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
+      # create an instance the makeUtil class that we will use to create targets.
+      make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
+
+      # set the make command that will be used. The num_jobs parameter was set in the __init__
+      # function earlier
+      make.makeCommand = 'make -j' + self.num_jobs
+
+      # we will iterate over each entry in the testList. Each entry node will be refered to by the
+      # variable testname.
+      for testname in testList:
+
+          # for each testname we get all its fields (as described by the testList format)
+          testentry = testList[testname]
+
+          # we capture the path to the assembly file of this test
+          test = testentry['test_path']
+
+          # capture the directory where the artifacts of this test will be dumped/created. RISCOF is
+          # going to look into this directory for the signature files
+          test_dir = testentry['work_dir']
+
+          # name of the elf file after compilation of the test
+          elf = 'my.elf'
+
+          # name of the signature file as per requirement of RISCOF. RISCOF expects the signature to
+          # be named as DUT-<dut-name>.signature. The below variable creates an absolute path of
+          # signature file.
+          sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+
+          # for each test there are specific compile macros that need to be enabled. The macros in
+          # the testList node only contain the macros/values. For the gcc toolchain we need to
+          # prefix with "-D". The following does precisely that.
+          compile_macros= ' -D' + " -D".join(testentry['macros'])
+
+          # substitute all variables in the compile command that we created in the initialize
+          # function
+          cmd = self.compile_cmd.format(testentry['isa'].lower(), test, elf, compile_macros)
+
+	  # if the user wants to disable running the tests and only compile the tests, then
+	  # the "else" clause is executed below assigning the sim command to simple no action
+	  # echo statement.
+          if self.target_run:
+            # set up the simulation command. Template is for spike. Please change.
+            simcmd = self.dut_exe + ' +signature={0} +signature-granularity=4 {1}'.format(sig_file, elf)
+          else:
+            simcmd = 'echo "NO RUN"'
+
+          # concatenate all commands that need to be executed within a make-target.
+          execute = '@cd {0}; {1}; {2};'.format(testentry['work_dir'], cmd, simcmd)
+
+          # create a target. The makeutil will create a target with the name "TARGET<num>" where num
+          # starts from 0 and increments automatically for each new target that is added
+          make.add_target(execute)
+
+      # if you would like to exit the framework once the makefile generation is complete uncomment the
+      # following line. Note this will prevent any signature checking or report generation.
+      #raise SystemExit
+
+      # once the make-targets are done and the makefile has been created, run all the targets in
+      # parallel using the make command set above.
+      make.execute_all(self.work_dir)
+
+      # if target runs are not required then we simply exit as this point after running all
+      # the makefile targets.
+      if not self.target_run:
+          raise SystemExit(0)

--- a/arch-test/spike/env/link.ld
+++ b/arch-test/spike/env/link.ld
@@ -1,0 +1,18 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(rvtest_entry_point)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  .bss : { *(.bss) }
+  _end = .;
+}
+

--- a/arch-test/spike/env/model_test.h
+++ b/arch-test/spike/env/model_test.h
@@ -1,0 +1,53 @@
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+#define RVMODEL_DATA_SECTION \
+        .pushsection .tohost,"aw",@progbits;                            \
+        .align 8; .global tohost; tohost: .dword 0;                     \
+        .align 8; .global fromhost; fromhost: .dword 0;                 \
+        .popsection;                                                    \
+        .align 8; .global begin_regstate; begin_regstate:               \
+        .word 128;                                                      \
+        .align 8; .global end_regstate; end_regstate:                   \
+        .word 4;
+
+//RV_COMPLIANCE_HALT
+#define RVMODEL_HALT                                              \
+  li x1, 1;                                                                   \
+  write_tohost:                                                               \
+    sw x1, tohost, t5;                                                        \
+    j write_tohost;
+
+#define RVMODEL_BOOT
+
+//RV_COMPLIANCE_DATA_BEGIN
+#define RVMODEL_DATA_BEGIN                                              \
+  .align 4; .global begin_signature; begin_signature:
+
+//RV_COMPLIANCE_DATA_END
+#define RVMODEL_DATA_END                                                      \
+  .align 4; .global end_signature; end_signature:  \
+  RVMODEL_DATA_SECTION                                                        \
+
+//RVTEST_IO_INIT
+#define RVMODEL_IO_INIT
+//RVTEST_IO_WRITE_STR
+#define RVMODEL_IO_WRITE_STR(_R, _STR)
+//RVTEST_IO_CHECK
+#define RVMODEL_IO_CHECK()
+//RVTEST_IO_ASSERT_GPR_EQ
+#define RVMODEL_IO_ASSERT_GPR_EQ(_S, _R, _I)
+//RVTEST_IO_ASSERT_SFPR_EQ
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+//RVTEST_IO_ASSERT_DFPR_EQ
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+#define RVMODEL_SET_MSW_INT
+
+#define RVMODEL_CLEAR_MSW_INT
+
+#define RVMODEL_CLEAR_MTIMER_INT
+
+#define RVMODEL_CLEAR_MEXT_INT
+
+
+#endif // _COMPLIANCE_MODEL_H

--- a/arch-test/spike/riscof_spike.py
+++ b/arch-test/spike/riscof_spike.py
@@ -1,0 +1,183 @@
+import os
+import re
+import shutil
+import subprocess
+import shlex
+import logging
+import random
+import string
+from string import Template
+import sys
+
+import riscof.utils as utils
+import riscof.constants as constants
+from riscof.pluginTemplate import pluginTemplate
+
+logger = logging.getLogger()
+
+class spike(pluginTemplate):
+    __model__ = "spike"
+
+    #TODO: please update the below to indicate family, version, etc of your DUT.
+    __version__ = "XXX"
+
+    def __init__(self, *args, **kwargs):
+        sclass = super().__init__(*args, **kwargs)
+
+        config = kwargs.get('config')
+
+        # If the config node for this DUT is missing or empty. Raise an error. At minimum we need
+        # the paths to the ispec and pspec files
+        if config is None:
+            print("Please enter input file paths in configuration.")
+            raise SystemExit(1)
+
+        # In case of an RTL based DUT, this would be point to the final binary executable of your
+        # test-bench produced by a simulator (like verilator, vcs, incisive, etc). In case of an iss or
+        # emulator, this variable could point to where the iss binary is located. If 'PATH variable
+        # is missing in the config.ini we can hardcode the alternate here.
+        self.dut_exe = os.path.join(config['PATH'] if 'PATH' in config else "","spike")
+
+        # Number of parallel jobs that can be spawned off by RISCOF
+        # for various actions performed in later functions, specifically to run the tests in
+        # parallel on the DUT executable. Can also be used in the build function if required.
+        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
+
+        # Path to the directory where this python file is located. Collect it from the config.ini
+        self.pluginpath=os.path.abspath(config['pluginpath'])
+
+        # Collect the paths to the  riscv-config absed ISA and platform yaml files. One can choose
+        # to hardcode these here itself instead of picking it from the config.ini file.
+        self.isa_spec = os.path.abspath(config['ispec'])
+        self.platform_spec = os.path.abspath(config['pspec'])
+
+        #We capture if the user would like the run the tests on the target or
+        #not. If you are interested in just compiling the tests and not running
+        #them on the target, then following variable should be set to False
+        if 'target_run' in config and config['target_run']=='0':
+            self.target_run = False
+        else:
+            self.target_run = True
+
+        # Return the parameters set above back to RISCOF for further processing.
+        return sclass
+
+    def initialise(self, suite, work_dir, archtest_env):
+
+       # capture the working directory. Any artifacts that the DUT creates should be placed in this
+       # directory. Other artifacts from the framework and the Reference plugin will also be placed
+       # here itself.
+       self.work_dir = work_dir
+
+       # capture the architectural test-suite directory.
+       self.suite_dir = suite
+
+       # Note the march is not hardwired here, because it will change for each
+       # test. Similarly the output elf name and compile macros will be assigned later in the
+       # runTests function
+       self.compile_cmd = 'riscv64-none-elf-gcc -march={0} \
+         -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g\
+         -T '+self.pluginpath+'/env/link.ld\
+         -I '+self.pluginpath+'/env/\
+         -I ' + archtest_env + ' {1} -o {2} {3}'
+
+       # add more utility snippets here
+
+    def build(self, isa_yaml, platform_yaml):
+
+      # load the isa yaml as a dictionary in python.
+      ispec = utils.load_yaml(isa_yaml)['hart0']
+
+      # capture the XLEN value by picking the max value in 'supported_xlen' field of isa yaml. This
+      # will be useful in setting integer value in the compiler string (if not already hardcoded);
+      self.xlen = '64'#('64' if 64 in ispec['supported_xlen'] else '32')
+
+      # for spike start building the '--isa' argument. the self.isa is dutnmae specific and may not be
+      # useful for all DUTs
+      self.isa = 'rv' + self.xlen
+      if "I" in ispec["ISA"]:
+          self.isa += 'i'
+      if "M" in ispec["ISA"]:
+          self.isa += 'm'
+      if "F" in ispec["ISA"]:
+          self.isa += 'f'
+      if "D" in ispec["ISA"]:
+          self.isa += 'd'
+      if "C" in ispec["ISA"]:
+          self.isa += 'c'
+
+      #TODO: The following assumes you are using the riscv-gcc toolchain. If
+      #      not please change appropriately
+      self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else 'ilp32 ')
+
+    def runTests(self, testList):
+
+      # Delete Makefile if it already exists.
+      if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
+      # create an instance the makeUtil class that we will use to create targets.
+      make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
+
+      # set the make command that will be used. The num_jobs parameter was set in the __init__
+      # function earlier
+      make.makeCommand = 'make -j' + self.num_jobs
+
+      # we will iterate over each entry in the testList. Each entry node will be refered to by the
+      # variable testname.
+      for testname in testList:
+
+          # for each testname we get all its fields (as described by the testList format)
+          testentry = testList[testname]
+
+          # we capture the path to the assembly file of this test
+          test = testentry['test_path']
+
+          # capture the directory where the artifacts of this test will be dumped/created. RISCOF is
+          # going to look into this directory for the signature files
+          test_dir = testentry['work_dir']
+
+          # name of the elf file after compilation of the test
+          elf = 'my.elf'
+
+          # name of the signature file as per requirement of RISCOF. RISCOF expects the signature to
+          # be named as DUT-<dut-name>.signature. The below variable creates an absolute path of
+          # signature file.
+          sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+
+          # for each test there are specific compile macros that need to be enabled. The macros in
+          # the testList node only contain the macros/values. For the gcc toolchain we need to
+          # prefix with "-D". The following does precisely that.
+          compile_macros= ' -D' + " -D".join(testentry['macros'])
+
+          # substitute all variables in the compile command that we created in the initialize
+          # function
+          cmd = self.compile_cmd.format(testentry['isa'].lower(), test, elf, compile_macros)
+
+	  # if the user wants to disable running the tests and only compile the tests, then
+	  # the "else" clause is executed below assigning the sim command to simple no action
+	  # echo statement.
+          if self.target_run:
+            # set up the simulation command. Template is for spike. Please change.
+            simcmd = self.dut_exe + ' --isa={0} +signature={1} +signature-granularity=4 {2}'.format(self.isa, sig_file, elf)
+          else:
+            simcmd = 'echo "NO RUN"'
+
+          # concatenate all commands that need to be executed within a make-target.
+          execute = '@cd {0}; {1}; {2};'.format(testentry['work_dir'], cmd, simcmd)
+
+          # create a target. The makeutil will create a target with the name "TARGET<num>" where num
+          # starts from 0 and increments automatically for each new target that is added
+          make.add_target(execute)
+
+      # if you would like to exit the framework once the makefile generation is complete uncomment the
+      # following line. Note this will prevent any signature checking or report generation.
+      #raise SystemExit
+
+      # once the make-targets are done and the makefile has been created, run all the targets in
+      # parallel using the make command set above.
+      make.execute_all(self.work_dir)
+
+      # if target runs are not required then we simply exit as this point after running all
+      # the makefile targets.
+      if not self.target_run:
+          raise SystemExit(0)

--- a/arch-test/spike/spike_isa_rv32i.yaml
+++ b/arch-test/spike/spike_isa_rv32i.yaml
@@ -1,0 +1,6 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64I
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]

--- a/arch-test/spike/spike_isa_rv64i.yaml
+++ b/arch-test/spike/spike_isa_rv64i.yaml
@@ -1,0 +1,6 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64I
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]

--- a/arch-test/spike/spike_platform.yaml
+++ b/arch-test/spike/spike_platform.yaml
@@ -1,0 +1,10 @@
+mtime:
+  implemented: true
+  address: 0xbff8
+mtimecmp:
+  implemented: true
+  address: 0x4000
+nmi:
+  label: nmi_vector
+reset:
+  label: reset_vector

--- a/build.sc
+++ b/build.sc
@@ -48,3 +48,376 @@ object rocketchip extends common.CommonRocketChip {
 
   def configModule = configRocket
 }
+
+object spike extends Module {
+  def commit = T { "adfaef00e5cd57bef0aa6a9909b4bff5b3863c40" }
+
+  def src = T.persistent {
+    if (!os.exists(T.dest / "riscv-isa-sim")) {
+      os.proc("git", "clone", "--depth=1", "https://github.com/riscv-software-src/riscv-isa-sim").call(T.dest)
+    }
+    os.proc("git", "checkout", "-f", commit()).call(T.dest / "riscv-isa-sim")
+    PathRef(T.dest / "riscv-isa-sim")
+  }
+
+  def compile = T.persistent {
+    os.proc(src().path / "configure", "--prefix", "/usr", "--without-boost", "--without-boost-asio", "--without-boost-regex").call(
+      T.ctx.dest, Map(
+        "CC" -> "clang",
+        "CXX" -> "clang++",
+        "AR" -> "llvm-ar",
+        "RANLIB" -> "llvm-ranlib",
+        "LD" -> "lld",
+      )
+    )
+    os.proc("make", "-j", Runtime.getRuntime().availableProcessors()).call(T.ctx.dest)
+    PathRef(T.dest)
+  }
+
+  def install = T.persistent {
+    os.proc("make", "install", s"DESTDIR=${T.dest}").call(compile().path)
+    PathRef(T.dest)
+  }
+}
+
+trait Emulator extends ScalaModule {
+  override def moduleDeps = Seq(rocketchip)
+
+  override def scalaVersion: T[String] = T {
+    "2.13.10"
+  }
+
+  def top = T { "freechips.rocketchip.system.TestHarness" };
+  def config = T { "freechips.rocketchip.system.DefaultConfig" };
+
+  def generator = T {
+    mill.modules.Jvm.runSubprocess(
+      "freechips.rocketchip.system.Generator",
+      runClasspath().map(_.path),
+      forkArgs(),
+      forkEnv(),
+      Seq(
+        "-td", T.dest.toString,
+        "-T", top(),
+        "-C", config(),
+      ),
+      workingDir = forkWorkingDir()
+    )
+    PathRef(T.dest)
+  }
+
+  def firrtl = T {
+    val input = generator().path / (config() + ".fir")
+    val output = T.dest / (top() + "-" + config() + ".v")
+    mill.modules.Jvm.runSubprocess(
+      "firrtl.stage.FirrtlMain",
+      runClasspath().map(_.path),
+      forkArgs(),
+      forkEnv(),
+      Seq(
+        "-i", input.toString,
+        "-o", output.toString,
+      ),
+      workingDir = forkWorkingDir()
+    )
+    PathRef(output)
+  }
+
+  object verilator extends Module {
+    def csrcDir = T {
+      PathRef(os.pwd / "src" / "main" / "resources" / "csrc")
+    }
+    def vsrcDir = T {
+      PathRef(os.pwd / "src" / "main" / "resources" / "vsrc")
+    }
+
+    def allCSourceFiles = T {
+      Seq(
+        "SimDTM.cc",
+        "SimJTAG.cc",
+        "emulator.cc",
+        "remote_bitbang.cc",
+        ).map(c => PathRef(csrcDir().path / c))
+    }
+
+    def allVSourceFiles = T {
+      Seq(
+        "plusarg_reader.v",
+        "SimDTM.v",
+        "SimJTAG.v",
+        "EICG_wrapper.v",
+        ).map(v => PathRef(vsrcDir().path / v))
+    }
+
+    def CMakeListsString = T {
+      // format: off
+      s"""cmake_minimum_required(VERSION 3.20)
+         |project(emulator)
+         |include_directories(${csrcDir().path})
+         |# plusarg is here
+         |include_directories(${generator().path})
+         |link_directories(${spike.install().path / "usr" / "lib"})
+         |include_directories(${spike.install().path / "usr" / "include"})
+         |
+         |set(CMAKE_BUILD_TYPE Release)
+         |set(CMAKE_CXX_STANDARD 17)
+         |set(CMAKE_C_COMPILER "clang")
+         |set(CMAKE_CXX_COMPILER "clang++")
+         |set(CMAKE_CXX_FLAGS
+         |"$${CMAKE_CXX_FLAGS} -DVERILATOR -DTEST_HARNESS=VTestHarness -include VTestHarness.h -include ${generator().path / config() + ".plusArgs"}")
+         |set(THREADS_PREFER_PTHREAD_FLAG ON)
+         |
+         |find_package(verilator)
+         |find_package(Threads)
+         |
+         |add_executable(emulator
+         |${allCSourceFiles().map(_.path).mkString("\n")}
+         |)
+         |
+         |target_link_libraries(emulator PRIVATE $${CMAKE_THREAD_LIBS_INIT})
+         |target_link_libraries(emulator PRIVATE fesvr)
+         |verilate(emulator
+         |  SOURCES
+         |${allVSourceFiles().map(_.path).mkString("\n")}
+         |${firrtl().path}
+         |  TOP_MODULE TestHarness
+         |  PREFIX VTestHarness
+         |  VERILATOR_ARGS ${verilatorArgs().mkString(" ")}
+         |)
+         |""".stripMargin
+      // format: on
+    }
+
+    def verilatorArgs = T.input {
+      Seq(
+        // format: off
+        "-Wno-UNOPTTHREADS", "-Wno-STMTDLY", "-Wno-LATCH", "-Wno-WIDTH",
+        "--x-assign unique",
+        "+define+RANDOMIZE_GARBAGE_ASSIGN",
+        "--output-split 20000",
+        "--output-split-cfuncs 20000",
+        "--max-num-width 1048576"
+        // format: on
+      )
+    }
+
+    def cmakefileLists = T.persistent {
+      val path = T.dest / "CMakeLists.txt"
+      os.write.over(path, CMakeListsString())
+      PathRef(T.dest)
+    }
+
+    def elf = T.persistent {
+      mill.modules.Jvm.runSubprocess(Seq("cmake", "-G", "Ninja", "-S", cmakefileLists().path, "-B", T.dest.toString).map(_.toString), Map[String, String](), T.dest)
+      mill.modules.Jvm.runSubprocess(Seq("ninja", "-C", T.dest).map(_.toString), Map[String, String](), T.dest)
+      PathRef(T.dest / "emulator")
+    }
+  }
+
+  def elf = T {
+    verilator.elf()
+  }
+}
+
+object `emulator-default` extends Emulator {
+  override def config = T {
+    "freechips.rocketchip.system.DefaultConfig"
+  }
+}
+
+object `emulator-default32` extends Emulator {
+  override def config = T {
+    "freechips.rocketchip.system.DefaultRV32Config"
+  }
+}
+
+// riscv-tests
+object `riscv-tests` extends Module {
+  def commit = T { "907f1e5b67daedef0acbefb2102b82a23f9abfad" }
+
+  def CC = T {
+    "riscv64-none-elf-gcc"
+    // FIXME: handle riscv64-unknown-elf-gcc
+  }
+
+  def src = T.persistent {
+    if (!os.exists(T.dest / "riscv-tests")) {
+      os.proc("git", "clone", "--depth=1", "https://github.com/riscv-software-src/riscv-tests").call(T.dest)
+    }
+    os.proc("git", "checkout", "-f", commit()).call(T.dest / "riscv-tests")
+    os.proc("git", "submodule", "update", "--init", "--recursive").call(T.dest / "riscv-tests")
+    os.proc("sed", "-i", "s/unknown-elf/none-elf/g", "benchmarks/Makefile").call(T.dest / "riscv-tests")
+    os.proc("sed", "-i", "s/unknown-elf/none-elf/g", "isa/Makefile").call(T.dest / "riscv-tests")
+    PathRef(T.dest / "riscv-tests")
+  }
+
+  def compile = T.persistent {
+    os.proc("autoconf").call(src().path)
+    os.proc(src().path / "configure").call(
+      T.dest, Map(
+        "CC" -> "riscv64-none-elf-gcc",
+      )
+    )
+    os.proc("make", "-j", Runtime.getRuntime().availableProcessors(), "isa").call(T.dest)
+    PathRef(T.dest)
+  }
+
+  def install = T.persistent {
+    // TODO: handle benchmark
+    os.proc("make", "install", s"DESTDIR=${T.dest}").call(compile().path)
+    PathRef(T.dest)
+  }
+
+  object cases extends Module {
+    trait SuiteCommon extends Module {
+      def name: T[String]
+
+      def description: T[String]
+
+      def binaries: T[Seq[PathRef]]
+    }
+
+    lazy val allCases = T {
+      val root = install().path / "usr" / "local" / "share" / "riscv-tests" / "isa"
+      os.walk(root).filterNot(p => p.last.endsWith("dump"))
+    }
+
+    trait Suite extends SuiteCommon {
+      def name = T {
+        millSourcePath.last
+      }
+
+      def description = T {
+        s"test suite ${name} from riscv-tests"
+      }
+
+      def binaries = T {
+        allCases().filter(p => p.last.startsWith(name())).map(PathRef(_))
+      }
+    }
+
+    object `rv32` extends Suite
+
+    object `rv64` extends Suite
+  }
+}
+
+trait RunableTest extends Module {
+  def emulator: Emulator
+
+  def testcases: T[Seq[PathRef]]
+
+  def run = T {
+    testcases().map { bin =>
+      val name = bin.path.last
+      System.out.println(s"Running: ${emulator.elf().path} ${bin.path}")
+      val p = os.proc(emulator.elf().path, bin.path).call(stdout = T.dest / s"$name.running.log", mergeErrIntoOut = true)
+      PathRef(if(p.exitCode != 0) {
+        os.move(T.dest / s"$name.running.log", T.dest / s"$name.failed.log")
+        System.err.println(s"Test $name failed with exit code ${p.exitCode}")
+        T.dest / s"$name.failed.log"
+      } else {
+        os.move(T.dest / s"$name.running.log", T.dest / s"$name.passed.log")
+        T.dest / s"$name.passed.log"
+      })
+    }
+  }
+
+  def report = T {
+    val failed = run().filter(_.path.last.endsWith("failed.log"))
+    assert(failed.isEmpty, s"tests failed in ${failed.map(_.path.last).mkString(", ")}")
+  }
+}
+
+object `emulator-default-rv64` extends RunableTest {
+  override def emulator = `emulator-default`
+  override def testcases = `riscv-tests`.cases.`rv64`.binaries()
+}
+
+object `emulator-default32-rv32` extends RunableTest {
+  override def emulator = `emulator-default32`
+  override def testcases = `riscv-tests`.cases.`rv32`.binaries()
+}
+
+// riscv-arch-test
+trait `Arch-test` extends Module {
+  def emulator: Emulator
+
+  def spikeISpec: String = "spike_isa.yaml"
+
+  def emulatorISpec: String = "emulator_isa.yaml"
+
+  def spikePSpec: String = "spike_platform.yaml"
+
+  def emulatorPSpec: String = "emulator_platform.yaml"
+
+  def configString = T {
+    // format: off
+    s"""[RISCOF]
+       |ReferencePlugin=spike
+       |ReferencePluginPath=spike
+       |DUTPlugin=emulator
+       |DUTPluginPath=emulator
+       |
+       |[spike]
+       |pluginpath=spike
+       |ispec=spike/${spikeISpec}
+       |pspec=spike/${spikePSpec}
+       |target_run=1
+       |jobs=${Runtime.getRuntime().availableProcessors()}
+       |PATH=${spike.compile().path}
+       |
+       |[emulator]
+       |pluginpath=emulator
+       |ispec=emulator/${emulatorISpec}
+       |pspec=emulator/${emulatorPSpec}
+       |target_run=1
+       |jobs=${Runtime.getRuntime().availableProcessors()}
+       |PATH=${emulator.elf().path / os.up}
+       |""".stripMargin
+    // format: on
+  }
+
+  def config = T.persistent {
+    val path = T.dest / "config.ini"
+    os.write.over(path, configString())
+    PathRef(T.dest)
+  }
+
+  def home = T { config() }
+
+  def src = T {
+    // FIXME: pin to specific commit
+    if (!os.exists(home().path / "riscv-arch-test")) {
+      os.proc("riscof", "--verbose", "info", "arch-test", "--clone").call(home().path)
+    }
+    PathRef(T.dest)
+  }
+
+  def copy = T {
+    os.copy.over(os.pwd / "arch-test" / "spike", home().path / "spike")
+    os.copy.over(os.pwd / "arch-test" / "emulator", home().path / "emulator")
+  }
+
+  def run = T {
+    src()
+    copy()
+    os.proc("riscof", "run",
+      s"--config=${config().path / "config.ini"}",
+      "--suite=riscv-arch-test/riscv-test-suite/",
+      "--env=riscv-arch-test/riscv-test-suite/env"
+    ).call(home().path)
+  }
+}
+
+object `emulator-default-arch-test-rv64i` extends `Arch-test` {
+  override def emulator = `emulator-default`
+  override def spikeISpec: String = "spike_isa_rv64i.yaml"
+  override def emulatorISpec: String = "emulator_isa_rv64i.yaml"
+}
+
+object `emulator-default32-arch-test-rv32i` extends `Arch-test` {
+  override def emulator = `emulator-default32`
+  override def spikeISpec: String = "spike_isa_rv32i.yaml"
+  override def emulatorISpec: String = "emulator_isa_rv32i.yaml"
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,85 @@
+with import (fetchTarball {
+  url    = "https://github.com/NixOS/nixpkgs/archive/b3adce1542df29dd5a35077a3d42bcc47100e74e.tar.gz";
+  sha256 = "0356xngf3wvmi7qdzdwvxb87lnwmlkn3bsds3qqn3gdxhigs6mgc";
+}) {
+  config = {
+    packageOverrides = pkgs: with pkgs; {
+      llvmPackages = llvmPackages_14;
+      clang = clang_14;
+      lld = lld_14;
+      jdk = if stdenv.isDarwin then jdk11_headless else graalvm11-ce;
+      python = python39Full;
+      pythonPexpect = python39Packages.pexpect;
+      pythonPip = python39Packages.bootstrapped-pip;
+    };
+  };
+};
+
+let
+  clang-multiple-target =
+    pkgs.writeScriptBin "clang" ''
+      #!${pkgs.bash}/bin/bash
+      if [[ "$*" == *--target=riscv64* || "$*" == *-target\ riscv64* ]]; then
+        # works partially, namely no ld
+        ${pkgs.pkgsCross.riscv64.buildPackages.clang}/bin/riscv64-unknown-linux-gnu-clang \
+          --target=riscv64 \
+          $@
+      else
+        # works fully
+        ${pkgs.clang}/bin/clang $@
+      fi
+    '';
+  clangpp-multiple-target =
+    pkgs.writeScriptBin "clang++" ''
+      #!${pkgs.bash}/bin/bash
+      if [[ "$*" == *--target=riscv64* || "$*" == *-target\ riscv64* ]]; then
+        # works partially, namely no ld
+        ${pkgs.pkgsCross.riscv64.buildPackages.clang}/bin/riscv64-unknown-linux-gnu-clang++ \
+          --target=riscv64 \
+          $@
+      else
+        # works fully
+        ${pkgs.clang}/bin/clang++ $@
+      fi
+    '';
+  cpp-multiple-target = pkgs.writeScriptBin "cpp" ''
+    #!${pkgs.bash}/bin/bash
+    ${pkgs.clang}/bin/cpp $@
+  '';
+  cc = if stdenv.isDarwin then [clang] else [
+    clang-multiple-target
+    clangpp-multiple-target
+    cpp-multiple-target
+  ];
+in pkgs.callPackage (
+  {
+    mkShellNoCC,
+    jdk,
+    python, pythonPexpect,
+    gnumake, git, mill, wget, parallel, dtc, protobuf, antlr4,
+    llvmPackages, clang, lld, verilator, cmake, ninja, rcs,
+    autoconf, automake, openocd
+  }:
+
+  mkShellNoCC {
+    name = "sequencer-playground";
+    depsBuildBuild = [
+      jdk gnumake git mill wget parallel dtc protobuf antlr4
+      verilator cmake ninja rcs autoconf automake openocd
+      llvmPackages.llvm lld
+      python pythonPexpect pythonPip
+      cc
+      pkgs.pkgsCross.riscv64-embedded.buildPackages.gdb
+      pkgs.pkgsCross.riscv64-embedded.buildPackages.gcc
+    ];
+    shellHook = ''
+      # Tells pip to put packages into $PIP_PREFIX instead of the usual locations.
+      # See https://pip.pypa.io/en/stable/user_guide/#environment-variables.
+      export PIP_PREFIX=$(pwd)/venv/pip_packages
+      export PYTHONPATH="$PIP_PREFIX/${pkgs.python39.sitePackages}:$PYTHONPATH"
+      export PATH="$PIP_PREFIX/bin:$PATH"
+      unset SOURCE_DATE_EPOCH
+      pip3 install importlib-metadata typing-extensions riscof
+    '';
+  }
+) {}


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #2953

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

This PR enhances the original mill build system to support automatic tests. This PR features

* emulator generation with different config
* test building
* flexible combination of tests via trait
* `shell.nix` as the replacement of the original `rocket-tools`, which could be used in CI and is deterministic, see [workflow.yml in playground](https://github.com/chipsalliance/playground/blob/5994344ba065f160011531ad7dda6b85615fee66/.github/workflows/bump.yml#L51)

This has been inspired by #2991, https://github.com/chipsalliance/playground/pull/46 and [sequencer/rocket CI](https://github.com/sequencer/rocket/blob/master/build.sc)

One thing worth mentioning is that with Zk/Zb test in arch-test, #2950 can be automatically tested.