### PR TITLE
download ubuntu from 22.04 to 20.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   prepare-riscv-tools-cache:
     name: Prepare riscv-tools Cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Recently CI failed due to https://github.com/actions/runner-images/issues/6399. This is just a temporary fix.
**Related issue**: actions/runner-images#6399

**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation