### PR TITLE
Add interface for setting custom ISA strings in DTS

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -598,7 +598,7 @@ class CSRFile(
     (if (usingCompressed) "C" else "")
   val isaString = (if (coreParams.useRVE) "E" else "I") +
     isaMaskString +
-    "X" + // Custom extensions always present (e.g. CEASE instruction)
+    (if (customIsaExt.isDefined) "X" else "") +
     (if (usingSupervisor) "S" else "") +
     (if (usingHypervisor) "H" else "") +
     (if (usingUser) "U" else "")

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -59,6 +59,7 @@ case class RocketCoreParams(
   val retireWidth: Int = 1
   val instBits: Int = if (useCompressed) 16 else 32
   val lrscCycles: Int = 80 // worst case is 14 mispredicted branches + slop
+  override val customIsaExt = Some("Xrocket") // CEASE instruction
   override def minFLen: Int = fpu.map(_.minFLen).getOrElse(32)
   override def customCSRs(implicit p: Parameters) = new RocketCustomCSRs
 }

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -105,7 +105,8 @@ trait HasNonDiplomaticTileParameters {
     val c = if (tileParams.core.useCompressed) "c" else ""
     val b = if (tileParams.core.useBitManip) "b" else ""
     val v = if (tileParams.core.useVector) "v" else ""
-    s"rv${p(XLen)}$ie$m$a$f$d$c$b$v"
+    val x = tileParams.core.customIsaExt.map(s => s"_$s").getOrElse("")
+    s"rv${p(XLen)}$ie$m$a$f$d$c$b$v$x"
   }
 
   def tileProperties: PropertyMap = {

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -50,6 +50,7 @@ trait CoreParams {
   val nPTECacheEntries: Int
   val mtvecInit: Option[BigInt]
   val mtvecWritable: Boolean
+  def customIsaExt: Option[String] = None
   def customCSRs(implicit p: Parameters): CustomCSRs = new CustomCSRs
 
   def hasSupervisorMode: Boolean = useSupervisor || useVM
@@ -100,6 +101,7 @@ trait HasCoreParameters extends HasTileParameters {
   val nPerfCounters = coreParams.nPerfCounters
   val mtvecInit = coreParams.mtvecInit
   val mtvecWritable = coreParams.mtvecWritable
+  val customIsaExt = coreParams.customIsaExt
 
   def vLen = coreParams.vLen
   def sLen = coreParams.sLen


### PR DESCRIPTION
Previously misa always reported `rv64gcx`. Now misa will have the 'X' field set only if customIsaExt is defined, and the DTS string will contain custom extensions. Rocket is now `rv64gc_Xrocket` in the DTS. Could this cause any issues in  DTS-parsing code?

