### PR TITLE
Generate correct lazyscope name

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -401,7 +401,7 @@ object LazyScope {
     * @param p       [[Parameters]] propagated to [[SimpleLazyModule]].
     */
   def apply[T](body: => T)(implicit valName: ValName, p: Parameters): T = {
-    apply(valName.toString, "SimpleLazyModule", None)(body)(p)
+    apply(valName.name, "SimpleLazyModule", None)(body)(p)
   }
 
   /** Create a [[LazyScope]] with an explicitly defined instance name.


### PR DESCRIPTION
**Type of change**: bug report

**Impact**: no functional change 

**Development Phase**: implementation

The original design directly calls toString method, which generates strange wire/module name.
For example:
```scala
new SimpleLazyModule {
  val scop = LazyScope {
    LazyModule(new SimpleLazyModule())
  }
}
```
```verilog
module SimpleLazyModule_2(
  input   clock,
  input   reset
);
  wire  ValNamescop_clock; // @[LazyModule.scala 436:27]
  wire  ValNamescop_reset; // @[LazyModule.scala 436:27]
  SimpleLazyModule_1 ValNamescop ( // @[LazyModule.scala 436:27]
    .clock(ValNamescop_clock),
    .reset(ValNamescop_reset)
  );
  assign ValNamescop_clock = clock;
  assign ValNamescop_reset = reset;
endmodule
```
This patch will generate the real name of the lazyscope:
```verilog
module SimpleLazyModule_2(
  input   clock,
  input   reset
);
  wire  scop_clock; // @[LazyModule.scala 436:27]
  wire  scop_reset; // @[LazyModule.scala 436:27]
  SimpleLazyModule_1 scop ( // @[LazyModule.scala 436:27]
    .clock(scop_clock),
    .reset(scop_reset)
  );
  assign scop_clock = clock;
  assign scop_reset = reset;
endmodule
```