### PR TITLE
Populate tval with pc when ebreak

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -966,6 +966,7 @@ class CSRFile(
   assert(!reg_singleStepped || io.retire === 0.U)
 
   val epc = formEPC(io.pc)
+  val tval = Mux(insn_break, epc, io.tval)
 
   when (exception) {
     when (trapToDebug) {
@@ -993,7 +994,7 @@ class CSRFile(
       reg_vsstatus.spp := reg_mstatus.prv
       reg_vsepc := epc
       reg_vscause := Mux(cause(xLen-1), Cat(cause(xLen-1, 2), 1.U(2.W)), cause)
-      reg_vstval := io.tval
+      reg_vstval := tval
       reg_vsstatus.spie := reg_vsstatus.sie
       reg_vsstatus.sie := false.B
       new_prv := PRV.S.U
@@ -1004,7 +1005,7 @@ class CSRFile(
       reg_hstatus.spv := reg_mstatus.v
       reg_sepc := epc
       reg_scause := cause
-      reg_stval := io.tval
+      reg_stval := tval
       reg_htval := io.htval
       reg_mstatus.spie := reg_mstatus.sie
       reg_mstatus.spp := reg_mstatus.prv
@@ -1016,7 +1017,7 @@ class CSRFile(
       reg_mstatus.gva := io.gva
       reg_mepc := epc
       reg_mcause := cause
-      reg_mtval := io.tval
+      reg_mtval := tval
       reg_mtval2 := io.htval
       reg_mstatus.mpie := reg_mstatus.mie
       reg_mstatus.mpp := trimPrivilege(reg_mstatus.prv)


### PR DESCRIPTION
Ref to https://github.com/riscv/riscv-isa-manual/commit/51522f98b5cae989c7d161e00b20a08483a2301e

However this change does not only affect `ebreak` so I need to check further.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/chipsalliance/rocket-chip/pull/3191#issuecomment-1367788856

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Populate tval with pc when ebreak
