### PR TITLE
Don't check probeacks in TLMonitor.legalizeCDSource

### DIFF
--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -766,6 +766,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       monAssert(!inflight(bundle.c.bits.source), "'C' channel re-used a source ID" + extra)
     }
 
+    val c_probe_ack    = bundle.c.bits.opcode === TLMessages.ProbeAck || bundle.c.bits.opcode === TLMessages.ProbeAckData
+
     val d_clr          = WireInit(0.U(edge.client.endSourceId.W))
     val d_clr_wo_ready = WireInit(0.U(edge.client.endSourceId.W))
     val d_opcodes_clr  = WireInit(0.U((edge.client.endSourceId << log_c_opcode_bus_size).W))
@@ -796,7 +798,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       }
     }
 
-    when(bundle.d.valid && d_first && c_first && bundle.c.valid && (bundle.c.bits.source === bundle.d.bits.source) && d_release_ack) {
+    when(bundle.d.valid && d_first && c_first && bundle.c.valid && (bundle.c.bits.source === bundle.d.bits.source) && d_release_ack && !c_probe_ack) {
       assume((!bundle.d.ready) || bundle.c.ready, "ready check")
     }
 


### PR DESCRIPTION
Bug fix. Per the spec: 

> Because Channel C responses to Channel B requests are routed to a single slave and uniquely
identified to an ongoing operation based on c address, we can further relax the uniqueness
restriction on Channel B requests, requiring only that the combination of b source and b address
be uniquely inflight. This relaxation is necessary in order to simultaneously probe multiple masters
on the same address, while also probing the same master on multiple addresses. Channel C 
responses may use any c source associated with the sender; this signal is ignored for those
message types.

