### PR TITLE
Remove chisel3 deprecated code

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1111,7 +1111,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
           hgTrigFiring(hg) := (trigInReq & ~RegNext(trigInReq) & hgParticipateTrig.map(_ === hg.U)).reduce(_ | _)
           hgTrigsAllAcked(hg) := (trigOutAck | hgParticipateTrig.map(_ =/= hg.U)).reduce(_ & _)
         }
-        extTrigger.in.ack := trigInReq.asUInt()
+        extTrigger.in.ack := trigInReq.asUInt
       }
 
       for (hg <- 1 to nHaltGroups) {
@@ -1138,7 +1138,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         for (trig <- 0 until nExtTriggers) {
           extTriggerOutReq(trig) := hgFired(hgParticipateTrig(trig))
         }
-        extTrigger.out.req := extTriggerOutReq.asUInt()
+        extTrigger.out.req := extTriggerOutReq.asUInt
       }
     }
     io.hgDebugInt := hgDebugInt | hrDebugInt
@@ -1411,9 +1411,9 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       //TODO (DMI_CFGSTRADDR0 << 2) -> cfgStrAddrFields,
       (DMI_DMCS2       << 2) -> (if (nHaltGroups > 0) dmcs2RegFields else Nil),
       (DMI_HALTSUM0    << 2) -> RegFieldGroup("dmi_haltsum0", Some("Halt Summary 0"),
-         Seq(RegField.r(32, HALTSUM0RdData.asUInt(), RegFieldDesc("dmi_haltsum0", "halt summary 0")))),
+         Seq(RegField.r(32, HALTSUM0RdData.asUInt, RegFieldDesc("dmi_haltsum0", "halt summary 0")))),
       (DMI_HALTSUM1    << 2) -> RegFieldGroup("dmi_haltsum1", Some("Halt Summary 1"),
-         Seq(RegField.r(32, HALTSUM1RdData.asUInt(), RegFieldDesc("dmi_haltsum1", "halt summary 1")))),
+         Seq(RegField.r(32, HALTSUM1RdData.asUInt, RegFieldDesc("dmi_haltsum1", "halt summary 1")))),
       (DMI_ABSTRACTCS  << 2) -> abstractcsRegFields,
       (DMI_ABSTRACTAUTO<< 2) -> RegFieldGroup("dmi_abstractauto", Some("abstract command autoexec"), Seq(
         WNotifyVal(cfg.nAbstractDataWords, ABSTRACTAUTORdData.autoexecdata, ABSTRACTAUTOWrData.autoexecdata, autoexecdataWrEnMaybe,
@@ -1422,7 +1422,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         WNotifyVal(cfg.nProgramBufferWords, ABSTRACTAUTORdData.autoexecprogbuf, ABSTRACTAUTOWrData.autoexecprogbuf, autoexecprogbufWrEnMaybe,
           RegFieldDesc("autoexecprogbuf", "abstract command progbuf autoexec", reset=Some(0))))),
       (DMI_COMMAND     << 2) -> RegFieldGroup("dmi_command", Some("Abstract Command Register"),
-        Seq(RWNotify(32, COMMANDRdData.asUInt(), COMMANDWrDataVal, COMMANDRdEn, COMMANDWrEnMaybe,
+        Seq(RWNotify(32, COMMANDRdData.asUInt, COMMANDWrDataVal, COMMANDRdEn, COMMANDWrEnMaybe,
         Some(RegFieldDesc("dmi_command", "abstract command register", reset=Some(0), volatile=true))))),
       (DMI_DATA0       << 2) -> RegFieldGroup("dmi_data", Some("abstract command data registers"), abstractDataMem.zipWithIndex.map{case (x, i) =>
         RWNotify(8, Mux(dmAuthenticated, x, 0.U), abstractDataNxt(i),
@@ -1518,9 +1518,9 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     // Abstract Command Decoding & Generation
     //----------------------------
 
-    val accessRegisterCommandWr  = WireInit(COMMANDWrData.asUInt().asTypeOf(new ACCESS_REGISTERFields()))
+    val accessRegisterCommandWr  = WireInit(COMMANDWrData.asUInt.asTypeOf(new ACCESS_REGISTERFields()))
     /** real COMMAND*/
-    val accessRegisterCommandReg = WireInit(COMMANDReg.asUInt().asTypeOf(new ACCESS_REGISTERFields()))
+    val accessRegisterCommandReg = WireInit(COMMANDReg.asUInt.asTypeOf(new ACCESS_REGISTERFields()))
 
     // TODO: Quick Access
 
@@ -1564,10 +1564,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         val immWire = WireInit(imm.S(21.W))
         val immBits = WireInit(VecInit(immWire.asBools))
 
-        imm0 := immBits.slice(1,  1  + 10).asUInt()
-        imm1 := immBits.slice(11, 11 + 11).asUInt()
-        imm2 := immBits.slice(12, 12 + 8).asUInt()
-        imm3 := immBits.slice(20, 20 + 1).asUInt()
+        imm0 := immBits.slice(1,  1  + 10).asUInt
+        imm1 := immBits.slice(11, 11 + 11).asUInt
+        imm2 := immBits.slice(12, 12 + 8).asUInt
+        imm3 := immBits.slice(20, 20 + 1).asUInt
       }
     }
 
@@ -1629,10 +1629,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         // ABSTRACT(1): Postexec: NOP       else EBREAK
         abstractGeneratedMem(0) := Mux(accessRegisterCommandReg.transfer,
           Mux(accessRegisterCommandReg.write, abstractGeneratedI(cfg), abstractGeneratedS(cfg)),
-          nop.asUInt()
+          nop.asUInt
         )
         abstractGeneratedMem(1) := Mux(accessRegisterCommandReg.postexec,
-          nop.asUInt(),
+          nop.asUInt,
           Instructions.EBREAK.value.U)
       } else {
         // Entry: All regs in GPRs, dscratch1=offset 0x800 in DM
@@ -1641,15 +1641,15 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         // ABSTRACT(2): Transfer: LW, SW, LD, SD else NOP
         // ABSTRACT(3):           CSRRW s1,dscratch1,s1 or CSRRW s0,dscratch1,s0
         // ABSTRACT(4): Postexec: NOP else EBREAK
-        abstractGeneratedMem(0) := Mux(accessRegisterCommandReg.transfer && accessRegisterCommandReg.size =/= 2.U, isa.asUInt(), nop.asUInt())
+        abstractGeneratedMem(0) := Mux(accessRegisterCommandReg.transfer && accessRegisterCommandReg.size =/= 2.U, isa.asUInt, nop.asUInt)
         abstractGeneratedMem(1) := abstractGeneratedCSR
         abstractGeneratedMem(2) := Mux(accessRegisterCommandReg.transfer,
           Mux(accessRegisterCommandReg.write, abstractGeneratedI(cfg), abstractGeneratedS(cfg)),
-          nop.asUInt()
+          nop.asUInt
         )
         abstractGeneratedMem(3) := abstractGeneratedCSR
         abstractGeneratedMem(4) := Mux(accessRegisterCommandReg.postexec,
-          nop.asUInt(),
+          nop.asUInt,
           Instructions.EBREAK.value.U)
       }
     }
@@ -1689,9 +1689,9 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         abstractGeneratedMem.zipWithIndex.map{ case (x,i) => RegField.r(32, x, RegFieldDesc(s"debug_abstract_$i", "", volatile=true))}),
       FLAGS         -> RegFieldGroup("debug_flags", Some("Memory region used to control hart going/resuming in Debug Mode"),
         if (nComponents == 1) {
-          Seq.tabulate(1024) { i => RegField.r(8, flags(0).asUInt(), RegFieldDesc(s"debug_flags_$i", "", volatile=true)) }
+          Seq.tabulate(1024) { i => RegField.r(8, flags(0).asUInt, RegFieldDesc(s"debug_flags_$i", "", volatile=true)) }
         } else {
-          flags.zipWithIndex.map{case(x, i) => RegField.r(8, x.asUInt(), RegFieldDesc(s"debug_flags_$i", "", volatile=true))}
+          flags.zipWithIndex.map{case(x, i) => RegField.r(8, x.asUInt, RegFieldDesc(s"debug_flags_$i", "", volatile=true))}
         }),
       ROMBASE       -> RegFieldGroup("debug_rom", Some("Debug ROM"),
         (if (cfg.atzero) DebugRomContents() else DebugRomNonzeroContents()).zipWithIndex.map{case (x, i) =>

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -134,7 +134,7 @@ case class AddressSet(base: BigInt, mask: BigInt) extends Ordered[AddressSet]
   // We do allow negative mask (=> ignore all high bits)
 
   def contains(x: BigInt) = ((x ^ base) & ~mask) == 0
-  def contains(x: UInt) = ((x ^ UInt(base)).zext() & SInt(~mask)) === SInt(0)
+  def contains(x: UInt) = ((x ^ UInt(base)).zext & SInt(~mask)) === SInt(0)
 
   // turn x into an address contained in this set
   def legalize(x: UInt): UInt = base.U | (mask.U & x)

--- a/src/main/scala/jtag/JtagShifter.scala
+++ b/src/main/scala/jtag/JtagShifter.scala
@@ -105,7 +105,7 @@ class CaptureChain[+T <: Data](gen: T)(implicit val p: Parameters) extends Chain
   property.cover(io.chainIn.capture, "chain_capture", "JTAG; chain_capture; This Chain captured data")
   
   when (io.chainIn.capture) {
-    (0 until n) map (x => regs(x) := io.capture.bits.asUInt()(x))
+    (0 until n) map (x => regs(x) := io.capture.bits.asUInt(x))
     io.capture.capture := true.B
   } .elsewhen (io.chainIn.shift) {
     regs(n-1) := io.chainIn.data
@@ -158,7 +158,7 @@ class CaptureUpdateChain[+T <: Data, +V <: Data](genCapture: T, genUpdate: V)(im
   val updateBits = Cat(regs.reverse)(updateWidth-1, 0)
   io.update.bits := updateBits.asTypeOf(io.update.bits)
 
-  val captureBits = io.capture.bits.asUInt()
+  val captureBits = io.capture.bits.asUInt
 
   property.cover(io.chainIn.capture, "chain_capture", "JTAG;chain_capture; This Chain captured data")
   property.cover(io.chainIn.capture, "chain_update",  "JTAG;chain_update; This Chain updated data")

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -180,7 +180,7 @@ object JtagTapGenerator {
         require(!(instructions contains icode), "instructions may not contain IDCODE")
         val idcodeChain = Module(CaptureChain(new JTAGIdcodeBundle()))
         idcodeChain.suggestName("idcodeChain")
-        val i = internalIo.idcode.get.asUInt()
+        val i = internalIo.idcode.get.asUInt
         assert(i % 2.U === 1.U, "LSB must be set in IDCODE, see 12.1.1d")
         assert(((i >> 1) & ((1.U << 11) - 1.U)) =/= JtagIdcode.dummyMfrId.U,
           "IDCODE must not have 0b00001111111 as manufacturer identity, see 12.2.1b")

--- a/src/main/scala/regmapper/RegMapper.scala
+++ b/src/main/scala/regmapper/RegMapper.scala
@@ -136,10 +136,10 @@ object RegMapper
       val high = low + field.width - 1
       // Confirm that no register is too big
       require (high < 8*bytes)
-      val rimask = frontMask(high, low).orR()
-      val wimask = frontMask(high, low).andR()
-      val romask = backMask(high, low).orR()
-      val womask = backMask(high, low).andR()
+      val rimask = frontMask(high, low).orR
+      val wimask = frontMask(high, low).andR
+      val romask = backMask(high, low).orR
+      val womask = backMask(high, low).andR
       val data = if (field.write.combinational) back.bits.data else front.bits.data
       val f_rivalid = rivalid(i) && rimask
       val f_roready = roready(i) && romask

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -604,7 +604,7 @@ class CSRFile(
     (if (usingUser) "U" else "")
   val isaMax = (BigInt(log2Ceil(xLen) - 4) << (xLen-2)) | isaStringToMask(isaString)
   val reg_misa = RegInit(isaMax.U)
-  val read_mstatus = io.status.asUInt()(xLen-1,0)
+  val read_mstatus = io.status.asUInt.extract(xLen-1,0)
   val read_mtvec = formTVec(reg_mtvec).padTo(xLen)
   val read_stvec = formTVec(reg_stvec).sextTo(xLen)
 
@@ -719,7 +719,7 @@ class CSRFile(
     read_sstatus.spie := io.status.spie
     read_sstatus.sie := io.status.sie
 
-    read_mapping += CSRs.sstatus -> (read_sstatus.asUInt())(xLen-1,0)
+    read_mapping += CSRs.sstatus -> (read_sstatus.asUInt)(xLen-1,0)
     read_mapping += CSRs.sip -> read_sip.asUInt
     read_mapping += CSRs.sie -> read_sie.asUInt
     read_mapping += CSRs.sscratch -> reg_sscratch
@@ -757,7 +757,7 @@ class CSRFile(
     read_mapping += CSRs.mtinst -> 0.U
     read_mapping += CSRs.mtval2 -> reg_mtval2
 
-    val read_hstatus = io.hstatus.asUInt()(xLen-1,0)
+    val read_hstatus = io.hstatus.asUInt.extract(xLen-1,0)
 
     read_mapping += CSRs.hstatus -> read_hstatus
     read_mapping += CSRs.hedeleg -> read_hedeleg
@@ -776,7 +776,7 @@ class CSRFile(
     val read_vsip = (read_hip & read_hideleg) >> 1
     val read_vsepc = readEPC(reg_vsepc).sextTo(xLen)
     val read_vstval = reg_vstval.sextTo(xLen)
-    val read_vsstatus = io.gstatus.asUInt()(xLen-1,0)
+    val read_vsstatus = io.gstatus.asUInt.extract(xLen-1,0)
 
     read_mapping += CSRs.vsstatus -> read_vsstatus
     read_mapping += CSRs.vsip -> read_vsip

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -849,7 +849,7 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
   val s2_data_corrected = s2_data_decoded.map(_.corrected).asUInt
   val s2_data_uncorrected = s2_data_decoded.map(_.uncorrected).asUInt
   val s2_word_idx = if(doNarrowRead) 0.U else s2_req.addr(log2Up(rowWords*coreDataBytes)-1,log2Up(wordBytes))
-  val s2_data_correctable = s2_data_decoded.map(_.correctable).asUInt()(s2_word_idx)
+  val s2_data_correctable = s2_data_decoded.map(_.correctable).asUInt(s2_word_idx)
 
   // store/amo hits
   s3_valid := (s2_valid_masked && s2_hit || s2_replay) && !s2_sc_fail && isWrite(s2_req.cmd)

--- a/src/main/scala/tilelink/Atomics.scala
+++ b/src/main/scala/tilelink/Atomics.scala
@@ -23,7 +23,7 @@ class Atomics(params: TLBundleParameters) extends Module
   val signBit = io.a.mask & Cat(UInt(1), ~io.a.mask >> 1)
   val inv_d = Mux(adder, io.data_in, ~io.data_in)
   val sum = (FillInterleaved(8, io.a.mask) & io.a.data) + inv_d
-  def sign(x: UInt): Bool = (Cat(x.asBools.grouped(8).map(_.last).toList.reverse) & signBit).orR()
+  def sign(x: UInt): Bool = (Cat(x.asBools.grouped(8).map(_.last).toList.reverse) & signBit).orR
   val sign_a = sign(io.a.data)
   val sign_d = sign(io.data_in)
   val sign_s = sign(sum)

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -135,7 +135,7 @@ class TLBroadcast(params: TLBroadcastParams)(implicit p: Parameters) extends Laz
       }
       val d_mshr = OHToUInt(d_trackerOH)
       d_normal.bits.sink := d_mshr
-      assert (!d_normal.valid || (d_trackerOH.orR() || d_normal.bits.opcode === TLMessages.ReleaseAck))
+      assert (!d_normal.valid || (d_trackerOH.orR || d_normal.bits.opcode === TLMessages.ReleaseAck))
 
       // A tracker response is anything neither dropped nor a ReleaseAck
       val d_response = d_hasData || !d_what(1)
@@ -217,7 +217,7 @@ class TLBroadcast(params: TLBroadcastParams)(implicit p: Parameters) extends Laz
       val probe_line = Reg(UInt())
       val probe_perms = Reg(UInt(2.W))
       val probe_next = probe_todo & ~(leftOR(probe_todo) << 1)
-      val probe_busy = probe_todo.orR()
+      val probe_busy = probe_todo.orR
       val probe_target = if (caches.size == 0) 0.U else Mux1H(probe_next, cache_targets)
 
       // Probe whatever the FSM wants to do next
@@ -233,13 +233,13 @@ class TLBroadcast(params: TLBroadcastParams)(implicit p: Parameters) extends Laz
 
       // To accept a request from A, the probe FSM must be idle and there must be a matching tracker
       val freeTrackers = VecInit(trackers.map { t => t.idle }).asUInt
-      val freeTracker = freeTrackers.orR()
+      val freeTracker = freeTrackers.orR
       val matchTrackers = VecInit(trackers.map { t => t.line === in.a.bits.address >> lineShift }).asUInt
-      val matchTracker = matchTrackers.orR()
+      val matchTracker = matchTrackers.orR
       val allocTracker = freeTrackers & ~(leftOR(freeTrackers) << 1)
       val selectTracker = Mux(matchTracker, matchTrackers, allocTracker)
       val trackerReadys = VecInit(trackers.map(_.in_a.ready)).asUInt
-      val trackerReady = (selectTracker & trackerReadys).orR()
+      val trackerReady = (selectTracker & trackerReadys).orR
 
       in.a.ready := (!a_first || filter.io.request.ready) && trackerReady
       (trackers zip selectTracker.asBools) foreach { case (t, select) =>

--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -23,7 +23,7 @@ class IDMapGenerator(numIds: Int) extends Module {
 
   val select = ~(leftOR(bitmap) << 1) & bitmap
   io.alloc.bits := OHToUInt(select)
-  io.alloc.valid := bitmap.orR()
+  io.alloc.valid := bitmap.orR
 
   val clr = Wire(init = UInt(0, width = numIds))
   when (io.alloc.fire()) { clr := UIntToOH(io.alloc.bits) }

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -53,7 +53,7 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
         val allocated = RegInit(UInt(0, width = maxInFlight))
         val nextFreeOH = ~(leftOR(~allocated) << 1) & ~allocated
         val nextFree = OHToUInt(nextFreeOH)
-        val full = allocated.andR()
+        val full = allocated.andR
 
         val a_first = edgeIn.first(in.a)
         val d_last  = edgeIn.last(in.d)

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -109,7 +109,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
         step.send  := false.B // => looks like a retry to injector
         step.first := false.B
         step.last  := (if (lgBytes + 1 >= lgMax) true.B else
-                       !((UIntToOH1(send.size, lgMax) & ~send.addr) >> (lgBytes + 1)).orR())
+                       !((UIntToOH1(send.size, lgMax) & ~send.addr) >> (lgBytes + 1)).orR)
         step.addr  := Cat(send.addr(edgeIn.bundle.addressBits-1, lgMax), send.addr(lgMax-1, 0) + beatBytes.U)
       } .otherwise /* new burst */ {
         step.full  := false.B

--- a/src/main/scala/util/AsyncQueue.scala
+++ b/src/main/scala/util/AsyncQueue.scala
@@ -50,7 +50,7 @@ object GrayCounter {
   def apply(bits: Int, increment: Bool = true.B, clear: Bool = false.B, name: String = "binary"): UInt = {
     val incremented = Wire(UInt(bits.W))
     val binary = RegNext(next=incremented, init=0.U).suggestName(name)
-    incremented := Mux(clear, 0.U, binary + increment.asUInt())
+    incremented := Mux(clear, 0.U, binary + increment.asUInt)
     incremented ^ (incremented >> 1)
   }
 }

--- a/src/main/scala/util/LanePositionedQueue.scala
+++ b/src/main/scala/util/LanePositionedQueue.scala
@@ -426,7 +426,7 @@ class OnePortLanePositionedQueueModule[T <: Data](ecc: Code)(gen: T, args: LaneP
     nEnq_next >= (2*lanes).U
   }
 
-  val pre_gap = (pre_enq_row >> 1).zext() - (pre_deq_row >> 1).zext()
+  val pre_gap = (pre_enq_row >> 1).zext - (pre_deq_row >> 1).zext
   val pre_gap0 = pre_gap === 0.S && next_maybe_empty
   val pre_gap1 = pre_gap0 || pre_gap === (1-rows/2).S || pre_gap === 1.S
   val pre_gap2 = pre_gap1 || pre_gap === (2-rows/2).S || pre_gap === 2.S

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -34,7 +34,7 @@ package object util {
       }
     }
 
-    def asUInt(): UInt = Cat(x.map(_.asUInt).reverse)
+    def asUInt: UInt = Cat(x.map(_.asUInt).reverse)
 
     def rotate(n: Int): Seq[T] = x.drop(n) ++ x.take(n)
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: chipsalliance/chisel3#2758

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

fix https://github.com/chipsalliance/chisel3/pull/2758
+ Remove parenthesized forms of asUInt(), asSInt(), orR(), andR(), zext();
