### PR TITLE
Add CI on riscv-arch-test based on mill

### DIFF
--- a/.github/workflows/mill-ci.yml
+++ b/.github/workflows/mill-ci.yml
@@ -59,3 +59,37 @@ jobs:
       - name: compile emulator
         run: |
           nix --experimental-features 'nix-command flakes' develop -c mill -i "emulator[freechips.rocketchip.system.TestHarness,freechips.rocketchip.system.${{ matrix.config }}].elf"
+
+  riscv-arch-test:
+    name: riscv-arch-test
+    runs-on: [self-hosted, linux]
+    strategy:
+      matrix:
+        config: ["DefaultRV32Config,32,RV32IMAC", "DefaultConfig,64,RV64IMAC"]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      - name: install nix
+        run : |
+          # cleanup
+          rm -rf /etc/*.backup-before-nix
+          rm -rf /etc/profile.d/nix.sh.backup-before-nix
+          # from https://github.com/cachix/install-nix-action/issues/122#issuecomment-1062065844
+          sh <(curl -L https://nixos.org/nix/install) --daemon --no-channel-add
+          mkdir -p ~/.config/nix
+          touch ~/.config/nix/nix.conf
+          echo "max-jobs = auto" >> ~/.config/nix/nix.conf
+          echo "cores = 0" >> ~/.config/nix/nix.conf
+          echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+          echo "/nix/var/nix/profiles/per-user/$USER/profile/bin" >> "$GITHUB_PATH"
+          echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+          echo "NIX_PATH=nixpkgs=channel:nixos-unstable" >> "$GITHUB_ENV"
+
+      - name: Coursier Cache
+        uses: coursier/cache-action@v6
+
+      - name: run riscv-arch-test
+        run: |
+          nix develop -c mill -i -j 0 "runnable-arch-test[freechips.rocketchip.system.TestHarness,freechips.rocketchip.system.${{ matrix.config }}].run"

--- a/build.sc
+++ b/build.sc
@@ -330,6 +330,10 @@ class RunableTest(top: String, config: String, suiteName: String, exclude: Strin
 object `runnable-arch-test` extends mill.Cross[ArchTest](
   ("freechips.rocketchip.system.TestHarness", "freechips.rocketchip.system.DefaultConfig", "64", "RV64IMAFDCZicsr_Zifencei"),
   ("freechips.rocketchip.system.TestHarness", "freechips.rocketchip.system.DefaultRV32Config", "32", "RV32IMAFCZicsr_Zifencei"),
+  // For CI within reasonable time
+  // zicsr is disabled due to ebreak issue
+  ("freechips.rocketchip.system.TestHarness", "freechips.rocketchip.system.DefaultConfig", "64", "RV64IMAC"),
+  ("freechips.rocketchip.system.TestHarness", "freechips.rocketchip.system.DefaultRV32Config", "32", "RV32IMAC"),
 )
 class ArchTest(top: String, config: String, xlen: String, isa: String) extends Module {
   def ispecString = T {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->


**Related issue**: #3191, #3192, #3193

Cherry-picked commits from them to test CI. Especially, #3193 is for passing ebreak test. These commits will be removed once they have been merged. The successful running of CI introduced by this PR may indicate that these PR could be merged.

This CI may finish running in a reasonable time. In my machine, running arch-test without floating point finished in one hour.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Add new CI on riscv-arch-test based on mill