### PR TITLE
optimize: reduce time complexity of ALU by eliminating Mux

### DIFF
--- a/src/main/scala/rocket/ALU.scala
+++ b/src/main/scala/rocket/ALU.scala
@@ -59,9 +59,9 @@ class ALU(implicit p: Parameters) extends CoreModule()(p) {
   })
 
   // ADD, SUB
-  val in2_inv = Mux(isSub(io.fn), ~io.in2, io.in2)
+  val in2_inv = io.in2 - (isSub(io.fn) << xLen-1)
   val in1_xor_in2 = io.in1 ^ in2_inv
-  io.adder_out := io.in1 + in2_inv + isSub(io.fn)
+  io.adder_out := io.in1 + in2_inv
 
   // SLT, SLTU
   val slt =


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**:   API modification

<!-- choose one -->
**Development Phase**: implementation
Optimize: Reduce time complexity of ALU by eliminating Mux
- Replaced the Mux used to invert 'in2' when the function is subtraction with bit-wise operations.
- This eliminates the need for the Mux and reduces the number of operations required, leading to a reduction in time complexity.

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This optimization improves the performance of the ALU module by reducing the time complexity of the function selection
