### PR TITLE
Explicitly use python3 for mem gen scripts

### DIFF
--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # See LICENSE.SiFive for license details.
 # See LICENSE.Berkeley for license details.

--- a/scripts/vlsi_rom_gen
+++ b/scripts/vlsi_rom_gen
@@ -1,10 +1,6 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # See LICENSE.SiFive for license details.
-
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import doctest
 import sys
@@ -68,8 +64,7 @@ def gen_rom(name, width, depth, rom_hex_file):
     }
     return verilog_template.format(**variables)
 
-
-def iterate_by_n(it, n):
+def iterate_by_n(li, n):
     """Iterate over items in it, yielding n-tuples of successive items.
 
     >>> list(iterate_by_n([1, 2, 3, 4, 5, 6], n=2))
@@ -81,21 +76,15 @@ def iterate_by_n(it, n):
         ...
     ValueError: Iterable length not evenly divisible by 4
     """
-    it = iter(it)
-    while True:
+    if len(li) % n != 0:
+        raise ValueError(
+            'Iterable length not evenly divisible by {}'.format(n)
+        )
+    for i in range(len(li) // n):
         batch = ()
-        for i in range(n):
-            try:
-                batch += (next(it),)
-            except StopIteration:
-                if batch:  # If this is not the first iteration
-                    raise ValueError(
-                        'Iterable length not evenly divisible by {}'.format(n)
-                    )
-                else:
-                    raise
+        for j in range(n):
+            batch += (li[i * n + j],)
         yield batch
-
 
 def try_cast_int(x):
     try:


### PR DESCRIPTION
Related to https://github.com/chipsalliance/rocket-chip/issues/3228

Ubuntu 22.04 explicitly asks python script to use python3 or python2 in their shebang instead of an ambiguous python.

As for the change in `iterate_by_n`, see https://stackoverflow.com/questions/16465313/how-yield-catches-stopiteration-exception where it said

> PEP 479 has made it an error to allow a StopIteration to bubble up uncaught from a generator function. If that happens, Python will turn it into a RuntimeError exception instead. This means that code like the examples in older versions of itertools that used a StopIteration to break out of a generator function needs to be modified.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #3228

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation