### PR TITLE
RegDescsJson should use actual name of devices instead of "device"

### DIFF
--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -108,7 +108,7 @@ case class TLRegisterNode(
     // Dump out the register map for documentation purposes.
     val base = address.head.base
     val baseHex = s"0x${base.toInt.toHexString}"
-    val name = s"deviceAt${baseHex}" //TODO: It would be better to name this other than "Device at ...."
+    val name = s"${device.describe(ResourceBindings()).name}.At${baseHex}"
     val json = GenRegDescsAnno.serialize(base, name, mapping:_*)
     var suffix = 0
     while( ElaborationArtefacts.contains(s"${baseHex}.${suffix}.regmap.json")) {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**:   implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
