### PR TITLE
Support passing wdata through TracedInstruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ docs-target/
 /test_lib/
 /testbuild/
 rocketchip.jar
+*#
+.#*

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -214,6 +214,7 @@ class TracedInstruction(implicit p: Parameters) extends CoreBundle {
   val interrupt = Bool()
   val cause = UInt(xLen.W)
   val tval = UInt((coreMaxAddrBits max iLen).W)
+  val wdata = Option.when(traceHasWdata)(UInt((vLen max xLen).W))
 }
 
 class TraceAux extends Bundle {

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -63,6 +63,7 @@ case class RocketCoreParams(
   val retireWidth: Int = 1
   val instBits: Int = if (useCompressed) 16 else 32
   val lrscCycles: Int = 80 // worst case is 14 mispredicted branches + slop
+  val traceHasWdata: Boolean = false // ooo wb, so no wdata in trace
   override val customIsaExt = Some("Xrocket") // CEASE instruction
   override def minFLen: Int = fpu.map(_.minFLen).getOrElse(32)
   override def customCSRs(implicit p: Parameters) = new RocketCustomCSRs

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -53,6 +53,7 @@ trait CoreParams {
   val nPTECacheEntries: Int
   val mtvecInit: Option[BigInt]
   val mtvecWritable: Boolean
+  val traceHasWdata: Boolean
   def customIsaExt: Option[String] = None
   def customCSRs(implicit p: Parameters): CustomCSRs = new CustomCSRs
 
@@ -109,6 +110,7 @@ trait HasCoreParameters extends HasTileParameters {
   val mtvecInit = coreParams.mtvecInit
   val mtvecWritable = coreParams.mtvecWritable
   val customIsaExt = coreParams.customIsaExt
+  val traceHasWdata = coreParams.traceHasWdata
 
   def vLen = coreParams.vLen
   def sLen = coreParams.sLen


### PR DESCRIPTION
Rocket can't pass through wdata due to OOO write back, but other cores may support this.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
