### PR TITLE
CSR: writes to vsatp.ASID should be mode-checked

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -1359,8 +1359,8 @@ class CSRFile(
         }
         when (mode_ok || !reg_mstatus.v) {
           reg_vsatp.ppn := new_vsatp.ppn(vpnBits.min(new_vsatp.ppn.getWidth)-1,0)
+          if (asIdBits > 0) reg_vsatp.asid := new_vsatp.asid(asIdBits-1,0)
         }
-        if (asIdBits > 0) reg_vsatp.asid := new_vsatp.asid(asIdBits-1,0)
       }
       when (decoded_addr(CSRs.vsie))      { reg_mie := (reg_mie & ~read_hideleg) | ((wdata << 1) & read_hideleg) }
       when (decoded_addr(CSRs.vsscratch)) { reg_vsscratch := wdata }


### PR DESCRIPTION
**Type of change**: bug report

**Impact**: functional fix

**Development Phase**: implementation

**Release Notes**
The RISC-V Privileged ISA spec says:

> When V=0, a write to vsatp with an unsupported MODE value is ... the fields of vsatp are treated as WARL in the normal way. However, when V=1, a write to satp with an unsupported MODE value is ignored and no write to vsatp is effected.

We were not handling the V=1 case.