### PR TITLE
Swtich to FSDB in vsim

### DIFF
--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -58,6 +58,7 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	+define+RANDOMIZE_INVALID_ASSIGN \
 	+define+RANDOMIZE_DELAY=0.1 \
 	+define+MODEL=$(MODEL) \
+	+define+FSDB \
 	+libext+.v \
 
 #--------------------------------------------------------------------
@@ -76,7 +77,7 @@ $(simv_debug) : $(sim_vsrcs) $(sim_csrcs)
 	cd $(sim_dir) && \
 	rm -rf csrc && \
 	$(VCS) $(VCS_OPTS) -o $(simv_debug) \
-	+define+DEBUG -debug_pp \
+	+define+DEBUG -debug_pp -debug_access+all -kdb -lca \
 
 #--------------------------------------------------------------------
 # Run

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -44,7 +44,7 @@ $(output_dir)/%.vcd: $(output_dir)/% $(simv_debug)
 	cd $(sim_dir) && $(exec_simv_debug) +permissive +verbose +vcdfile=$@ +max-cycles=$(timeout_cycles) +permissive-off $< $(disasm) $(patsubst %.vcd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 
 $(output_dir)/%.vpd: $(output_dir)/% $(simv_debug)
-	cd $(sim_dir) && $(exec_simv_debug) +permissive +verbose +vcdplusfile=$@ +max-cycles=$(timeout_cycles) +permissive-off $< $(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
+	cd $(sim_dir) && $(exec_simv_debug) +permissive +verbose +fsdbfile=$@ +max-cycles=$(timeout_cycles) +permissive-off $< $(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 
 $(output_dir)/%.saif: $(output_dir)/% $(simv_debug)
 	cd $(sim_dir) && rm -f $(output_dir)/pipe-$*.vcd && vcd2saif -input $(output_dir)/pipe-$*.vcd -pipe "$(exec_simv_debug) +permissive +verbose +vcdfile=$(output_dir)/pipe-$*.vcd +max-cycles=$(bmark_timeout_cycles) +permissive-off $<" -output $@ > $(patsubst %.saif,%.out,$@) 2>&1


### PR DESCRIPTION
VPD/DVE is deprecated

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
VSIM simulators will now generate FSDB waveforms
