### PR TITLE
Remove redundant TLBExceptions V bit

### DIFF
--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -59,11 +59,10 @@ class TLBReq(lgMaxSize: Int)(implicit p: Parameters) extends CoreBundle()(p) {
 
 }
 
-class TLBExceptions(implicit p: Parameters) extends CoreBundle()(p) {
+class TLBExceptions extends Bundle {
   val ld = Bool()
   val st = Bool()
   val inst = Bool()
-  val v = Bool()
 }
 
 class TLBResp(implicit p: Parameters) extends CoreBundle()(p) {


### PR DESCRIPTION
This was introduced by "(185cac83) Add hypervisor extension (#2841)"

This is a dead code, as no circuit is producing and consuming this bit.

This was discovered when migrating Core.scala to chisel3, where strict checking was applied for IO and firrtl found this is not connected.

In the context of hypervisor extension, V bit, or _virtualization mode_, indicates whether the hart is currently executing in a guest.

For TLBReq, the V bit is needed as it affects the PTW thus TLB behavior on whether to do _Two-Stage Address Translation_.

However, the bit is not needed for TLBException. The exceptions (pf, gf, ae, ma) have no V=1/V=0 variants. Also, there is no point to add V bit for gf (guest page fault).

The io.resp.gf added below in the original patch also does not connect io.resp.gf.v. If this V bit should be added for this specific exception, it should be connected.

I assume this was added accidentally, as the original "extends CoreBundle()(p)" modification seems irrelevant.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
