### PR TITLE
IDecode: Fix aes64ks1i imm decode

### DIFF
--- a/src/main/scala/rocket/CryptoNIST.scala
+++ b/src/main/scala/rocket/CryptoNIST.scala
@@ -10,7 +10,6 @@ class CryptoNISTInterface(xLen: Int) extends Bundle {
   val fn   = Input(UInt(ABLUFN().SZ_ZKN_FN.W))
   val hl   = Input(Bool())
   val bs   = Input(UInt(2.W))
-  val rnum = Input(UInt(4.W))
   val rs1  = Input(UInt(xLen.W))
   val rs2  = Input(UInt(xLen.W))
   val rd   = Output(UInt(xLen.W))
@@ -171,8 +170,9 @@ class CryptoNIST(xLen:Int) extends Module {
       Mux(isEnc, sr_enc.io.out, sr_dec.io.out)
     }
     // var name from rvk spec ks1
+    val rnum = io.rs2(3,0)
     val tmp1 = io.rs1(63,32)
-    val tmp2 = Mux(io.rnum === 0xA.U, tmp1, tmp1.rotateRight(8))
+    val tmp2 = Mux(rnum === 0xA.U, tmp1, tmp1.rotateRight(8))
     // reuse 8 Sbox here
     val si = Mux(isKs1, Cat(0.U(32.W), tmp2), sr)
     val so = VecInit(asBytes(si).map(x => {
@@ -191,7 +191,7 @@ class CryptoNIST(xLen:Int) extends Module {
       Mux(isEnc, mc_enc.io.out, mc_dec.io.out)
     }
     // var name from rvk spec ks1
-    val rc = VecInit(AES.rcon.map(_.U(8.W)).toSeq)(io.rnum)
+    val rc = VecInit(AES.rcon.map(_.U(8.W)).toSeq)(rnum)
     val tmp4 = so(31,0) ^ rc
     val ks1 = Cat(tmp4, tmp4)
     // var name from rvk spec ks2

--- a/src/main/scala/rocket/IDecode.scala
+++ b/src/main/scala/rocket/IDecode.scala
@@ -646,7 +646,7 @@ class ZKND64Decode(implicit val p: Parameters) extends DecodeConstants with Uses
     AES64DS ->  List(Y,N,N,N,N,N,Y,Y,N,N,Y,N,A2_RS2,A1_RS1, IMM_X, DW_XPR,aluFn.FN_AES_DS, N,M_X,        N,N,N,N,N,N,Y,CSR.N,N,N,N,N),
     AES64DSM -> List(Y,N,N,N,N,N,Y,Y,N,N,Y,N,A2_RS2,A1_RS1, IMM_X, DW_XPR,aluFn.FN_AES_DSM,N,M_X,        N,N,N,N,N,N,Y,CSR.N,N,N,N,N),
     AES64IM ->  List(Y,N,N,N,N,N,Y,Y,N,N,Y,N,A2_RS2,A1_RS1, IMM_X, DW_XPR,aluFn.FN_AES_IM, N,M_X,        N,N,N,N,N,N,Y,CSR.N,N,N,N,N),
-    AES64KS1I ->List(Y,N,N,N,N,N,Y,Y,N,N,Y,N,A2_RS2,A1_RS1, IMM_X, DW_XPR,aluFn.FN_AES_KS1,N,M_X,        N,N,N,N,N,N,Y,CSR.N,N,N,N,N),
+    AES64KS1I ->List(Y,N,N,N,N,N,N,Y,N,N,Y,N,A2_IMM,A1_RS1, IMM_I, DW_XPR,aluFn.FN_AES_KS1,N,M_X,        N,N,N,N,N,N,Y,CSR.N,N,N,N,N),
     AES64KS2 -> List(Y,N,N,N,N,N,Y,Y,N,N,Y,N,A2_RS2,A1_RS1, IMM_X, DW_XPR,aluFn.FN_AES_KS2,N,M_X,        N,N,N,N,N,N,Y,CSR.N,N,N,N,N))
 }
 class ZKNE32Decode(implicit val p: Parameters) extends DecodeConstants with UsesABLUFN

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -456,7 +456,6 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     zkn.io.fn   := ex_ctrl.alu_fn
     zkn.io.hl   := ex_reg_inst(27)
     zkn.io.bs   := ex_reg_inst(31,30)
-    zkn.io.rnum := ex_reg_inst(23,20)
     zkn.io.rs1  := ex_op1.asUInt
     zkn.io.rs2  := ex_op2.asUInt
     zkn.io.rd


### PR DESCRIPTION
It is not rs2, it is imm

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #3255

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: Functionality will not change, as the original rs2 from regfile is not used. Performance may inprove as #3255 indicates.

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Fix aes64ks1i decoding
