### PR TITLE
Fix Werror: key word error `given`

### DIFF
--- a/src/main/scala/util/IDPool.scala
+++ b/src/main/scala/util/IDPool.scala
@@ -23,8 +23,8 @@ class IDPool(numIds: Int, lateValid: Boolean = false, revocableSelect: Boolean =
   io.alloc.bits  := (if (revocableSelect) PriorityEncoder(bitmap) else select)
 
   val taken  = Mux(io.alloc.ready, UIntToOH(io.alloc.bits, numIds), 0.U)
-  val given  = Mux(io.free .valid, UIntToOH(io.free .bits, numIds), 0.U)
-  val bitmap1 = (bitmap & ~taken) | given
+  val allocated = Mux(io.free .valid, UIntToOH(io.free .bits, numIds), 0.U)
+  val bitmap1 = (bitmap & ~taken) | allocated
   val select1 = PriorityEncoder(bitmap1)
   val valid1  = (  (bitmap.orR && !((PopCount(bitmap) === 1.U) && io.alloc.ready))  // bitmap not zero, and not allocating last bit
                 || io.free.valid)


### PR DESCRIPTION
+ Wrap `given` in backticks to use it as an identifier, which will become a keyword in Scala 3.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

We are going to cleanup all the warnings as described in [ROADMAP](https://github.com/chipsalliance/chisel3/blob/master/ROADMAP.md).