### PR TITLE
Fix unconnected io.start for TLRAMXbarTest and TLMulticlientXbarTest

### DIFF
--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -457,6 +457,7 @@ class TLRAMXbar(nManagers: Int, txns: Int)(implicit p: Parameters) extends LazyM
 
 class TLRAMXbarTest(nManagers: Int, txns: Int = 5000, timeout: Int = 500000)(implicit p: Parameters) extends UnitTest(timeout) {
   val dut = Module(LazyModule(new TLRAMXbar(nManagers,txns)).module)
+  dut.io.start := io.start
   io.finished := dut.io.finished
 }
 
@@ -482,5 +483,6 @@ class TLMulticlientXbar(nManagers: Int, nClients: Int, txns: Int)(implicit p: Pa
 
 class TLMulticlientXbarTest(nManagers: Int, nClients: Int, txns: Int = 5000, timeout: Int = 500000)(implicit p: Parameters) extends UnitTest(timeout) {
   val dut = Module(LazyModule(new TLMulticlientXbar(nManagers, nClients, txns)).module)
+  dut.io.start := io.start
   io.finished := dut.io.finished
 }


### PR DESCRIPTION
Running TileLink unit test `TLXbarUnitTestConfig` would result in FIRRTL error about `io.start` port of DUT being uninitialized:
`Xbar.scala:458:19: error: sink "dut.io_start" not fully initialized in module "TLRAMXbarTest"`

This fixes the issue by connecting them with the top module `UnitTestSuite`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
