### PR TITLE
HasTilesModuleImp should not extends HasPeripheryDebugModuleImp

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -71,16 +71,16 @@ class ResetCtrlIO(val nComponents: Int)(implicit val p: Parameters) extends Bund
   */
 
 trait HasPeripheryDebug { this: BaseSubsystem =>
-  private val tlbus = locateTLBusWrapper(p(ExportDebug).slaveWhere)
+  def tlbus = locateTLBusWrapper(p(ExportDebug).slaveWhere)
 
-  val debugCustomXbarOpt = p(DebugModuleKey).map(params => LazyModule( new DebugCustomXbar(outputRequiresInput = false)))
-  val apbDebugNodeOpt = p(ExportDebug).apb.option(APBMasterNode(Seq(APBMasterPortParameters(Seq(APBMasterParameters("debugAPB"))))))
+  lazy val debugCustomXbarOpt = p(DebugModuleKey).map(params => LazyModule( new DebugCustomXbar(outputRequiresInput = false)))
+  lazy val apbDebugNodeOpt = p(ExportDebug).apb.option(APBMasterNode(Seq(APBMasterPortParameters(Seq(APBMasterParameters("debugAPB"))))))
   val debugTLDomainOpt = p(DebugModuleKey).map { _ =>
     val domain = ClockSinkNode(Seq(ClockSinkParameters()))
     domain := tlbus.fixedClockNode
     domain
   }
-  val debugOpt = p(DebugModuleKey).map { params =>
+  lazy val debugOpt = p(DebugModuleKey).map { params =>
     val tlDM = LazyModule(new TLDebugModule(tlbus.beatBytes))
 
     tlDM.node := tlbus.coupleTo("debug"){ TLFragmenter(tlbus) := _ }

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -3,16 +3,18 @@
 package freechips.rocketchip.groundtest
 
 import chisel3._
-import org.chipsalliance.cde.config.{Parameters}
+import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp}
+import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy.{AddressSet, LazyModule}
 import freechips.rocketchip.interrupts.{IntSinkNode, IntSinkPortSimple}
-import freechips.rocketchip.subsystem.{BaseSubsystem, BaseSubsystemModuleImp, HasTiles, CanHaveMasterAXI4MemPort}
-import freechips.rocketchip.tilelink.{TLRAM, TLFragmenter}
+import freechips.rocketchip.subsystem.{BaseSubsystem, BaseSubsystemModuleImp, CanHaveMasterAXI4MemPort, HasTiles}
+import freechips.rocketchip.tilelink.{TLFragmenter, TLRAM}
 
 class GroundTestSubsystem(implicit p: Parameters)
   extends BaseSubsystem
   with HasTiles
   with CanHaveMasterAXI4MemPort
+  with HasPeripheryDebug
 {
   val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), beatBytes=pbus.beatBytes))
   pbus.coupleTo("TestRAM") { testram.node := TLFragmenter(pbus) := _ }
@@ -28,7 +30,8 @@ class GroundTestSubsystem(implicit p: Parameters)
   override lazy val module = new GroundTestSubsystemModuleImp(this)
 }
 
-class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer) {
+class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)
+  with HasPeripheryDebugModuleImp {
   val success = IO(Output(Bool()))
   val status = dontTouch(DebugCombiner(outer.tileStatusNodes.map(_.bundle)))
   success := outer.tileCeaseSinkNode.in.head._1.asUInt.andR

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -102,7 +102,6 @@ case class TileSlavePortParams(
 trait HasTileInterruptSources
   extends CanHavePeripheryPLIC
   with CanHavePeripheryCLINT
-  with HasPeripheryDebug
   with InstantiatesTiles
 { this: BaseSubsystem => // TODO ideally this bound would be softened to LazyModule
   /** meipNode is used to create a single bit subsystem input in Configs without a PLIC */
@@ -134,7 +133,7 @@ trait HasTileInterruptSources
 }
 
 /** These are sources of "constants" that are driven into the tile.
-  * 
+  *
   * While they are not expected to change dyanmically while the tile is executing code,
   * they may be either tied to a contant value or programmed during boot or reset.
   * They need to be instantiated before tiles are attached within the subsystem containing them.
@@ -291,10 +290,14 @@ trait CanAttachTile {
     //       we stub out missing interrupts with constant sources here.
 
     // 1. Debug interrupt is definitely asynchronous in all cases.
-    domain.tile.intInwardNode :=
-      context.debugOpt
-        .map { domain { IntSyncAsyncCrossingSink(3) } := _.intnode }
-        .getOrElse { NullIntSource() }
+    context match {
+      case c: HasPeripheryDebug =>
+        domain.tile.intInwardNode :=
+          c.debugOpt
+            .map { domain { IntSyncAsyncCrossingSink(3) } := _.intnode }
+            .getOrElse { NullIntSource() }
+      case _ =>
+    }
 
     // 2. The CLINT and PLIC output interrupts are synchronous to the TileLink bus clock,
     //    so might need to be synchronized depending on the Tile's crossing type.
@@ -395,7 +398,7 @@ case class CloneTileAttachParams(
       },
       instantiatedTiles(sourceHart).asInstanceOf[TilePRCIDomain[TileType]]
     )
-    tile_prci_domain 
+    tile_prci_domain
   }
 }
 
@@ -440,7 +443,7 @@ trait HasTiles extends InstantiatesTiles with HasCoreMonitorBundles with Default
 }
 
 /** Provides some Chisel connectivity to certain tile IOs */
-trait HasTilesModuleImp extends LazyModuleImp with HasPeripheryDebugModuleImp {
+trait HasTilesModuleImp extends LazyModuleImp {
   val outer: HasTiles with HasTileInterruptSources with HasTileInputConstants
 
   val reset_vector = outer.tileResetVectorIONodes.zipWithIndex.map { case (n, i) => n.makeIO(s"reset_vector_$i") }

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -2,9 +2,10 @@
 
 package freechips.rocketchip.subsystem
 
+import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp}
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing}
+import freechips.rocketchip.prci.{NoResetCrossing, ResetCrossingType}
 import freechips.rocketchip.tile._
 
 case class RocketCrossingParams(
@@ -29,9 +30,10 @@ trait HasRocketTiles extends HasTiles { this: BaseSubsystem =>
   }).toList
 }
 
-class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem with HasRocketTiles {
+class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem with HasRocketTiles with HasPeripheryDebug {
   override lazy val module = new RocketSubsystemModuleImp(this)
 }
 
 class RocketSubsystemModuleImp[+L <: RocketSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)
     with HasTilesModuleImp
+    with HasPeripheryDebugModuleImp

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -2,6 +2,7 @@
 
 package freechips.rocketchip.system
 
+import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp}
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
@@ -13,6 +14,7 @@ class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
     with CanHaveMasterAXI4MemPort
     with CanHaveMasterAXI4MMIOPort
     with CanHaveSlaveAXI4Port
+    with HasPeripheryDebug
 {
   // optionally add ROM devices
   // Note that setting BootROMLocated will override the reset_vector for all tiles
@@ -26,3 +28,4 @@ class ExampleRocketSystemModuleImp[+L <: ExampleRocketSystem](_outer: L) extends
     with HasRTCModuleImp
     with HasExtInterruptsModuleImp
     with DontTouch
+    with HasPeripheryDebugModuleImp


### PR DESCRIPTION
I'm beaten by current debug io connections, and decide to get rid of `HasPeripheryDebugModuleImp` and instantiate our own version. However I just noticed, the `HasTiles` also extends `HasPeripheryDebugModuleImp`......
This PR simply remove `HasPeripheryDebugModuleImp` from `HasTiles`.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
