### PR TITLE
Porting Chisel 2 to Chisel 3: amba/axi4/UserYanker.scala

### DIFF
--- a/src/main/scala/amba/axi4/UserYanker.scala
+++ b/src/main/scala/amba/axi4/UserYanker.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.amba.axi4
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -54,14 +55,14 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
       val wqueues = Seq.tabulate(edgeIn.master.endId) { i => queue(i) }
 
       val arid = in.ar.bits.id
-      val ar_ready = Vec(rqueues.map(_.enq.ready))(arid)
+      val ar_ready = VecInit(rqueues.map(_.enq.ready))(arid)
       in .ar.ready := out.ar.ready && ar_ready
       out.ar.valid := in .ar.valid && ar_ready
       out.ar.bits :<= in .ar.bits
 
       val rid = out.r.bits.id
-      val r_valid = Vec(rqueues.map(_.deq.valid))(rid)
-      val r_bits = Vec(rqueues.map(_.deq.bits))(rid)
+      val r_valid = VecInit(rqueues.map(_.deq.valid))(rid)
+      val r_bits = VecInit(rqueues.map(_.deq.bits))(rid)
       assert (!out.r.valid || r_valid) // Q must be ready faster than the response
       in.r :<> out.r
       in.r.bits.echo :<= r_bits
@@ -75,14 +76,14 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
       }
 
       val awid = in.aw.bits.id
-      val aw_ready = Vec(wqueues.map(_.enq.ready))(awid)
+      val aw_ready = VecInit(wqueues.map(_.enq.ready))(awid)
       in .aw.ready := out.aw.ready && aw_ready
       out.aw.valid := in .aw.valid && aw_ready
       out.aw.bits :<= in .aw.bits
 
       val bid = out.b.bits.id
-      val b_valid = Vec(wqueues.map(_.deq.valid))(bid)
-      val b_bits = Vec(wqueues.map(_.deq.bits))(bid)
+      val b_valid = VecInit(wqueues.map(_.deq.valid))(bid)
+      val b_bits = VecInit(wqueues.map(_.deq.bits))(bid)
       assert (!out.b.valid || b_valid) // Q must be ready faster than the response
       in.b :<> out.b
       in.b.bits.echo :<= b_bits


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

As [`Chisel._` is Deprecated in Chisel 3.6](https://github.com/chipsalliance/chisel3/blob/5bc236268801861d325af7100922da3d14cd8b07/ROADMAP.md?plain=1#L33), we are porting Chisel 2 to Chisel 3.
