### PR TITLE
Porting Chisel 2 to Chisel 3: devices/

### DIFF
--- a/src/main/scala/devices/tilelink/ClockBlocker.scala
+++ b/src/main/scala/devices/tilelink/ClockBlocker.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.prci._

--- a/src/main/scala/devices/tilelink/Deadlock.scala
+++ b/src/main/scala/devices/tilelink/Deadlock.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 
@@ -17,10 +17,10 @@ class TLDeadlock(params: DevNullParams, beatBytes: Int = 4)(implicit p: Paramete
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val (in, _) = node.in(0)
-    in.a.ready := Bool(false)
-    in.b.valid := Bool(false)
-    in.c.ready := Bool(false)
-    in.d.valid := Bool(false)
-    in.e.ready := Bool(false)
+    in.a.ready := false.B
+    in.b.valid := false.B
+    in.c.ready := false.B
+    in.d.valid := false.B
+    in.e.ready := false.B
   }
 }

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
@@ -22,7 +23,7 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
     val a = if (buffer) {Queue(in.a, 1)} else in.a
 
     val da = Wire(in.d)
-    val idle = RegInit(Bool(true))
+    val idle = RegInit(true.B)
 
     val a_last = edge.last(a)
     val (da_first, da_last, _) = edge.firstlast(da)
@@ -32,12 +33,12 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
     da.valid := a.valid && a_last && idle
 
     da.bits.opcode  := TLMessages.adResponse(a.bits.opcode)
-    da.bits.param   := UInt(0) // toT, but error grants must be handled transiently (ie: you don't keep permissions)
+    da.bits.param   := 0.U // toT, but error grants must be handled transiently (ie: you don't keep permissions)
     da.bits.size    := a.bits.size
     da.bits.source  := a.bits.source
-    da.bits.sink    := UInt(0)
-    da.bits.denied  := Bool(true)
-    da.bits.data    := UInt(0)
+    da.bits.sink    := 0.U
+    da.bits.denied  := true.B
+    da.bits.data    := 0.U
     da.bits.corrupt := edge.hasData(da.bits)
 
     if (params.acquire) {
@@ -48,21 +49,21 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
       val dc_last = edge.last(dc)
 
       // Only allow one Grant in-flight at a time
-      when (da.fire() && da.bits.opcode === Grant) { idle := Bool(false) }
-      when (in.e.fire()) { idle := Bool(true) }
+      when (da.fire && da.bits.opcode === Grant) { idle := false.B }
+      when (in.e.fire) { idle := true.B }
 
       c.ready := (dc.ready && dc_last) || !c_last
       dc.valid := c.valid && c_last
 
       // ReleaseAck is not allowed to report failure
       dc.bits.opcode  := ReleaseAck
-      dc.bits.param   := Vec(toB, toN, toN)(c.bits.param)
+      dc.bits.param   := VecInit(toB, toN, toN)(c.bits.param)
       dc.bits.size    := c.bits.size
       dc.bits.source  := c.bits.source
-      dc.bits.sink    := UInt(0)
-      dc.bits.denied  := Bool(false)
-      dc.bits.data    := UInt(0)
-      dc.bits.corrupt := Bool(false)
+      dc.bits.sink    := 0.U
+      dc.bits.denied  := false.B
+      dc.bits.data    := 0.U
+      dc.bits.corrupt := false.B
 
       // Combine response channels
       TLArbiter.lowest(edge, in.d, dc, da)
@@ -71,9 +72,9 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
     }
 
     // We never probe or issue B requests
-    in.b.valid := Bool(false)
+    in.b.valid := false.B
 
     // Sink GrantAcks
-    in.e.ready := Bool(true)
+    in.e.ready := true.B
   }
 }

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -22,7 +22,7 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
     val (in, edge) = node.in(0)
     val a = if (buffer) {Queue(in.a, 1)} else in.a
 
-    val da = Wire(in.d)
+    val da = Wire(chiselTypeOf(in.d))
     val idle = RegInit(true.B)
 
     val a_last = edge.last(a)
@@ -43,7 +43,7 @@ class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)
 
     if (params.acquire) {
       val c = if (buffer) {Queue(in.c, 1)} else in.c
-      val dc = Wire(in.d)
+      val dc = Wire(chiselTypeOf(in.d))
 
       val c_last = edge.last(c)
       val dc_last = edge.last(dc)

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{Attachable, HierarchicalLocation, TLBusWrapperLocation}
@@ -29,22 +30,22 @@ class TLMaskROM(c: MaskROMParams)(implicit p: Parameters) extends LazyModule {
 
     val rom = ROMGenerator(ROMConfig(c.name, c.depth, c.width))
     rom.io.clock := clock
-    rom.io.address := edge.addr_hi(in.a.bits.address - UInt(c.address))(log2Ceil(c.depth)-1, 0)
-    rom.io.oe := Bool(true) // active high tri state enable
-    rom.io.me := in.a.fire()
+    rom.io.address := edge.addr_hi(in.a.bits.address - c.address.U)(log2Ceil(c.depth)-1, 0)
+    rom.io.oe := true.B // active high tri state enable
+    rom.io.me := in.a.fire
 
-    val d_full = RegInit(Bool(false))
+    val d_full = RegInit(false.B)
     val d_size = Reg(UInt())
     val d_source = Reg(UInt())
-    val d_data = rom.io.q holdUnless RegNext(in.a.fire())
+    val d_data = rom.io.q holdUnless RegNext(in.a.fire)
 
     // Flow control
-    when (in.d.fire()) { d_full := Bool(false) }
-    when (in.a.fire()) { d_full := Bool(true)  }
+    when (in.d.fire) { d_full := false.B }
+    when (in.a.fire) { d_full := true.B  }
     in.d.valid := d_full
     in.a.ready := in.d.ready || !d_full
 
-    when (in.a.fire()) {
+    when (in.a.fire) {
       d_size   := in.a.bits.size
       d_source := in.a.bits.source
     }
@@ -52,9 +53,9 @@ class TLMaskROM(c: MaskROMParams)(implicit p: Parameters) extends LazyModule {
     in.d.bits := edge.AccessAck(d_source, d_size, d_data)
 
     // Tie off unused channels
-    in.b.valid := Bool(false)
-    in.c.ready := Bool(true)
-    in.e.ready := Bool(true)
+    in.b.valid := false.B
+    in.c.ready := true.B
+    in.e.ready := true.B
   }
 }
 

--- a/src/main/scala/devices/tilelink/MasterMux.scala
+++ b/src/main/scala/devices/tilelink/MasterMux.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
@@ -28,11 +28,11 @@ class MuteMaster(name: String = "MuteMaster", maxProbe: Int = 0)(implicit p: Par
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val Seq((out, edgeOut)) = node.out
-    out.a.valid := Bool(false)
+    out.a.valid := false.B
     out.b.ready := out.c.ready
     out.c.valid := out.b.valid
-    out.d.ready := Bool(true)
-    out.e.valid := Bool(false)
+    out.d.ready := true.B
+    out.e.valid := false.B
 
     out.c.bits := edgeOut.ProbeAck(out.b.bits, TLPermissions.NtoN)
   }
@@ -45,8 +45,8 @@ class MasterMux(uFn: Seq[TLMasterPortParameters] => TLMasterPortParameters)(impl
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val bypass = Bool(INPUT)
-      val pending = Bool(OUTPUT)
+      val bypass = Input(Bool())
+      val pending = Output(Bool())
     })
 
     val Seq((in0, edgeIn0), (in1, edgeIn1)) = node.in
@@ -57,7 +57,7 @@ class MasterMux(uFn: Seq[TLMasterPortParameters] => TLMasterPortParameters)(impl
     val (flight, next_flight) = edgeOut.inFlight(out)
 
     io.pending := (flight > 0.U)
-    when (next_flight === UInt(0)) { bypass := io.bypass }
+    when (next_flight === 0.U) { bypass := io.bypass }
     val stall = (bypass =/= io.bypass) && edgeOut.first(out.a)
 
     in0.a.ready := !stall && out.a.ready &&  bypass
@@ -91,17 +91,17 @@ class MasterMux(uFn: Seq[TLMasterPortParameters] => TLMasterPortParameters)(impl
       def castE(x: TLBundleE) = { val ret = Wire(out.e.bits); ret <> x; ret }
       out.e.bits := Mux(bypass, castE(in0.e.bits), castE(in1.e.bits))
     } else {
-      in0.b.valid := Bool(false)
-      in0.c.ready := Bool(true)
-      in0.e.ready := Bool(true)
+      in0.b.valid := false.B
+      in0.c.ready := true.B
+      in0.e.ready := true.B
 
-      in1.b.valid := Bool(false)
-      in1.c.ready := Bool(true)
-      in1.e.ready := Bool(true)
+      in1.b.valid := false.B
+      in1.c.ready := true.B
+      in1.e.ready := true.B
 
-      out.b.ready := Bool(true)
-      out.c.valid := Bool(false)
-      out.e.valid := Bool(false)
+      out.b.ready := true.B
+      out.c.valid := false.B
+      out.e.valid := false.B
     }
   }
 }
@@ -124,7 +124,7 @@ class TLMasterMuxTester(txns: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) with UnitTestModule {
     io.finished := fuzz1.module.io.finished && fuzz2.module.io.finished
-    mux.module.io.bypass := LFSR64(Bool(true))(0)
+    mux.module.io.bypass := LFSR64(true.B)(0)
   }
 }
 

--- a/src/main/scala/devices/tilelink/PhysicalFilter.scala
+++ b/src/main/scala/devices/tilelink/PhysicalFilter.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
@@ -16,13 +17,13 @@ class DevicePMP(params: DevicePMPParams) extends GenericParameterizedBundle(para
 {
   require (params.addressBits > params.pageBits)
 
-  val l = UInt(width = 1) // locked
-  val a = UInt(width = 1) // LSB of A (0=disabled, 1=TOR)
-  val r = UInt(width = 1)
-  val w = UInt(width = 1)
+  val l = UInt(1.W) // locked
+  val a = UInt(1.W) // LSB of A (0=disabled, 1=TOR)
+  val r = UInt(1.W)
+  val w = UInt(1.W)
 
-  val addr_hi = UInt(width = params.addressBits-params.pageBits)
-  def address = Cat(addr_hi, UInt(0, width=params.pageBits))
+  val addr_hi = UInt((params.addressBits-params.pageBits).W)
+  def address = Cat(addr_hi, 0.U(params.pageBits.W))
   def blockPriorAddress = l(0) && a(0)
 
   def fields(blockAddress: Bool, initial: PMPInitialValue): Seq[RegField] = {
@@ -52,7 +53,7 @@ class DevicePMP(params: DevicePMPParams) extends GenericParameterizedBundle(para
     def field(bits: Int, reg: UInt, desc: RegFieldDesc, lock: Bool = l(0)) =
       RegField(bits, RegReadFn(reg), RegWriteFn((wen, data) => {
         when (wen && !lock) { reg := data }
-        Bool(true)
+        true.B
       }), Some(desc))
 
     Seq(
@@ -192,8 +193,8 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
   class Impl extends LazyModuleImp(this) {
     // We need to be able to represent +1 larger than the largest populated address
     val addressBits = log2Ceil(node.edges.out.map(_.manager.maxAddress).max+1+1)
-    val pmps = RegInit(Vec(params.pmpRegisters.map { ival => DevicePMP(addressBits, params.pageBits, Some(ival)) }))
-    val blocks = pmps.tail.map(_.blockPriorAddress) :+ Bool(false)
+    val pmps = RegInit(VecInit(params.pmpRegisters.map { ival => DevicePMP(addressBits, params.pageBits, Some(ival)) }))
+    val blocks = pmps.tail.map(_.blockPriorAddress) :+ false.B
     controlNode.regmap(0 -> ((pmps zip blocks) zip params.pmpRegisters).zipWithIndex.map{ case (((p, b), init), i) =>
       RegFieldGroup(s"devicepmp${i}", Some(s"Physical Filter Device PMP Register ${i}"), p.fields(b, init))
     }.toList.flatten)
@@ -202,7 +203,7 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
       out <> in
 
       // Generally useful wires needed below
-      val mySinkId = UInt(edgeOut.manager.endSinkId)
+      val mySinkId = edgeOut.manager.endSinkId.U
       val a_first = edgeIn.first(in.a)
       val (d_first, d_last, _) = edgeIn.firstlast(in.d)
 
@@ -210,49 +211,49 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
       val needW = in.a.bits.opcode =/= TLMessages.Get &&
                   (in.a.bits.opcode =/= TLMessages.AcquireBlock ||
                    in.a.bits.param  =/= TLPermissions.NtoB ||
-                   Bool(!edgeIn.manager.anySupportAcquireB))
+                   (!edgeIn.manager.anySupportAcquireB).B)
       val needR = in.a.bits.opcode =/= TLMessages.PutFullData &&
                   in.a.bits.opcode =/= TLMessages.PutPartialData
-      val lt = Bool(false) +: pmps.map(in.a.bits.address < _.address)
+      val lt = false.B +: pmps.map(in.a.bits.address < _.address)
       // sel[i] is true if PMP[i].a is set and PMP[i-1].address <= address < PMP[i].address
       val sel = (pmps.map(_.a) zip (lt.init zip lt.tail)) map { case (a, (l, r)) => a(0) && !l && r }
       val ok = pmps.map(p => (p.r(0) || !needR) && (p.w(0) || !needW))
       // If PMP[i] matches the address and is active, apply PMP[i].r/w permissions.
-      val allowFirst = PriorityMux(sel :+ Bool(true), ok :+ Bool(false)) // deny if no match
+      val allowFirst = PriorityMux(sel :+ true.B, ok :+ false.B) // deny if no match
       val allow = allowFirst holdUnless a_first // don't change our mind mid-transaction
 
       // Track the progress of transactions from A => D
-      val d_rack  = Bool(edgeIn.manager.anySupportAcquireB) && in.d.bits.opcode === TLMessages.ReleaseAck
-      val flight = RegInit(UInt(0, width = log2Ceil(edgeIn.client.endSourceId+1+1))) // +1 for inclusive range +1 for a_first vs. d_last
-      val denyWait = RegInit(Bool(false)) // deny already inflight?
-      flight := flight + (a_first && in.a.fire()) - (d_last && !d_rack && in.d.fire())
+      val d_rack  = edgeIn.manager.anySupportAcquireB.B && in.d.bits.opcode === TLMessages.ReleaseAck
+      val flight = RegInit(0.U(log2Ceil(edgeIn.client.endSourceId+1+1).W)) // +1 for inclusive range +1 for a_first vs. d_last
+      val denyWait = RegInit(false.B) // deny already inflight?
+      flight := flight + (a_first && in.a.fire) - (d_last && !d_rack && in.d.fire)
 
       // Discard denied A traffic, but first block it until there is nothing in-flight
-      val deny_ready = !denyWait && flight === UInt(0)
+      val deny_ready = !denyWait && flight === 0.U
       in.a.ready := Mux(allow, out.a.ready, !a_first || deny_ready)
       out.a.valid := in.a.valid && allow
 
       // Frame an appropriate deny message
-      val denyValid = RegInit(Bool(false))
+      val denyValid = RegInit(false.B)
       val deny = Reg(in.d.bits)
       val d_opcode = TLMessages.adResponse(in.a.bits.opcode)
-      val d_grant = Bool(edgeIn.manager.anySupportAcquireB) && deny.opcode === TLMessages.Grant
+      val d_grant = edgeIn.manager.anySupportAcquireB.B && deny.opcode === TLMessages.Grant
       when (in.a.valid && !allow && deny_ready && a_first) {
-        denyValid    := Bool(true)
-        denyWait     := Bool(true)
+        denyValid    := true.B
+        denyWait     := true.B
         deny.opcode  := d_opcode
-        deny.param   := UInt(0) // toT, but error grants must be handled transiently (ie: you don't keep permissions)
+        deny.param   := 0.U // toT, but error grants must be handled transiently (ie: you don't keep permissions)
         deny.size    := in.a.bits.size
         deny.source  := in.a.bits.source
         deny.sink    := mySinkId
-        deny.denied  := Bool(true)
-        deny.data    := UInt(0)
+        deny.denied  := true.B
+        deny.data    := 0.U
         deny.corrupt := d_opcode(0)
       }
       when (denyValid && in.d.ready && d_last) {
-        denyValid := Bool(false)
+        denyValid := false.B
         when (!d_grant) {
-          denyWait := Bool(false)
+          denyWait := false.B
         }
       }
 
@@ -271,7 +272,7 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
         val wSourceVec = Reg(Vec(edgeIn.client.endSourceId, Bool()))
         val aWOk = PriorityMux(sel, pmps.map(_.w(0)))
         val dWOk = wSourceVec(in.d.bits.source)
-        val bypass = Bool(edgeIn.manager.minLatency == 0) && in.a.valid && in.a.bits.source === in.d.bits.source
+        val bypass = (edgeIn.manager.minLatency == 0).B && in.a.valid && in.a.bits.source === in.d.bits.source
         val d_grant = in.d.bits.opcode === TLMessages.Grant || in.d.bits.opcode === TLMessages.GrantData
         val dWHeld = Mux(bypass, aWOk, dWOk) holdUnless d_first
 
@@ -279,12 +280,12 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
           in.d.bits.param := TLPermissions.toB
         }
 
-        when (in.a.fire() && a_first) {
+        when (in.a.fire && a_first) {
           wSourceVec(in.a.bits.source) := aWOk
         }
 
         edgeIn.client.unusedSources.foreach { id =>
-          wSourceVec(id) := Bool(true)
+          wSourceVec(id) := true.B
         }
 
         // Swallow GrantAcks
@@ -292,8 +293,8 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
         out.e.valid := in.e.valid && !isMyId
         in.e.ready := out.e.ready || isMyId
 
-        when (in.e.fire() && isMyId) {
-          denyWait := Bool(false)
+        when (in.e.fire && isMyId) {
+          denyWait := false.B
         }
       }
     }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -2,9 +2,9 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
-import Chisel.ImplicitConversions._
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.diplomacy._
@@ -19,20 +19,20 @@ import chisel3.internal.sourceinfo.SourceInfo
 import scala.math.min
 
 class GatewayPLICIO extends Bundle {
-  val valid = Bool(OUTPUT)
-  val ready = Bool(INPUT)
-  val complete = Bool(INPUT)
+  val valid = Output(Bool())
+  val ready = Input(Bool())
+  val complete = Input(Bool())
 }
 
 class LevelGateway extends Module {
-  val io = new Bundle {
-    val interrupt = Bool(INPUT)
+  val io = IO(new Bundle {
+    val interrupt = Input(Bool())
     val plic = new GatewayPLICIO
-  }
+  })
 
-  val inFlight = Reg(init=Bool(false))
-  when (io.interrupt && io.plic.ready) { inFlight := true }
-  when (io.plic.complete) { inFlight := false }
+  val inFlight = RegInit(false.B)
+  when (io.interrupt && io.plic.ready) { inFlight := true.B }
+  when (io.plic.complete) { inFlight := false.B }
   io.plic.valid := io.interrupt && !inFlight
 }
 
@@ -160,32 +160,32 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
 
     val prioBits = log2Ceil(nPriorities+1)
     val priority =
-      if (nPriorities > 0) Reg(Vec(nDevices, UInt(width=prioBits)))
-      else Wire(init=Vec.fill(nDevices max 1)(UInt(1)))
+      if (nPriorities > 0) Reg(Vec(nDevices, UInt(prioBits.W)))
+      else WireDefault(VecInit.fill(nDevices max 1)(1.U))
     val threshold =
-      if (nPriorities > 0) Reg(Vec(nHarts, UInt(width=prioBits)))
-      else Wire(init=Vec.fill(nHarts)(UInt(0)))
-    val pending = Reg(init=Vec.fill(nDevices max 1){Bool(false)})
+      if (nPriorities > 0) Reg(Vec(nHarts, UInt(prioBits.W)))
+      else WireDefault(VecInit.fill(nHarts)(0.U))
+    val pending = RegInit(VecInit.fill(nDevices max 1){false.B})
 
     /* Construct the enable registers, chunked into 8-bit segments to reduce verilog size */
     val firstEnable = nDevices min 7
     val fullEnables = (nDevices - firstEnable) / 8
     val tailEnable  = nDevices - firstEnable - 8*fullEnables
-    def enableRegs = (Reg(UInt(width = firstEnable)) +:
-                      Seq.fill(fullEnables) { Reg(UInt(width = 8)) }) ++
-                     (if (tailEnable > 0) Some(Reg(UInt(width = tailEnable))) else None)
+    def enableRegs = (Reg(UInt(firstEnable.W)) +:
+                      Seq.fill(fullEnables) { Reg(UInt(8.W)) }) ++
+                     (if (tailEnable > 0) Some(Reg(UInt(tailEnable.W))) else None)
     val enables = Seq.fill(nHarts) { enableRegs }
-    val enableVec = Vec(enables.map(x => Cat(x.reverse)))
-    val enableVec0 = Vec(enableVec.map(x => Cat(x, UInt(0, width=1))))
+    val enableVec = VecInit(enables.map(x => Cat(x.reverse)))
+    val enableVec0 = VecInit(enableVec.map(x => Cat(x, 0.U(1.W))))
     
-    val maxDevs = Reg(Vec(nHarts, UInt(width = log2Ceil(nDevices+1))))
+    val maxDevs = Reg(Vec(nHarts, UInt(log2Ceil(nDevices+1).W)))
     val pendingUInt = Cat(pending.reverse)
     for (hart <- 0 until nHarts) {
       val fanin = Module(new PLICFanIn(nDevices, prioBits))
       fanin.io.prio := priority
       fanin.io.ip   := enableVec(hart) & pendingUInt
       maxDevs(hart) := fanin.io.dev
-      harts(hart)   := ShiftRegister(Reg(next = fanin.io.max) > threshold(hart), params.intStages)
+      harts(hart)   := ShiftRegister(RegNext(fanin.io.max) > threshold(hart), params.intStages)
     }
 
     // Priority registers are 32-bit aligned so treat each as its own group.
@@ -242,9 +242,9 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     // were to change, it may no longer be true.
     // Note: PLIC doesn't care which hart reads the register.
     val claimer = Wire(Vec(nHarts, Bool()))
-    assert((claimer.asUInt & (claimer.asUInt - UInt(1))) === UInt(0)) // One-Hot
-    val claiming = Seq.tabulate(nHarts){i => Mux(claimer(i), maxDevs(i), UInt(0))}.reduceLeft(_|_)
-    val claimedDevs = Vec(UIntToOH(claiming, nDevices+1).asBools)
+    assert((claimer.asUInt & (claimer.asUInt - 1.U)) === 0.U) // One-Hot
+    val claiming = Seq.tabulate(nHarts){i => Mux(claimer(i), maxDevs(i), 0.U)}.reduceLeft(_|_)
+    val claimedDevs = VecInit(UIntToOH(claiming, nDevices+1).asBools)
 
     ((pending zip gateways) zip claimedDevs.tail) foreach { case ((p, g), c) =>
       g.ready := !p
@@ -259,9 +259,9 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     // were to change, it may no longer be true.
     // Note -- PLIC doesn't care which hart writes the register.
     val completer = Wire(Vec(nHarts, Bool()))
-    assert((completer.asUInt & (completer.asUInt - UInt(1))) === UInt(0)) // One-Hot
-    val completerDev = Wire(UInt(width = log2Up(nDevices + 1)))
-    val completedDevs = Mux(completer.reduce(_ || _), UIntToOH(completerDev, nDevices+1), UInt(0))
+    assert((completer.asUInt & (completer.asUInt - 1.U)) === 0.U) // One-Hot
+    val completerDev = Wire(UInt(log2Up(nDevices + 1).W))
+    val completedDevs = Mux(completer.reduce(_ || _), UIntToOH(completerDev, nDevices+1), 0.U)
     (gateways zip completedDevs.asBools.tail) foreach { case (g, c) =>
        g.complete := c
     }
@@ -286,14 +286,14 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
         RegField(32,
           RegReadFn { valid =>
             claimer(i) := valid
-            (Bool(true), maxDevs(i))
+            (true.B, maxDevs(i))
           },
           RegWriteFn { (valid, data) =>
             assert(completerDev === data.extract(log2Ceil(nDevices+1)-1, 0), 
                    "completerDev should be consistent for all harts")
             completerDev := data.extract(log2Ceil(nDevices+1)-1, 0)
             completer(i) := valid && enableVec0(i)(completerDev)
-            Bool(true)
+            true.B
           },
           Some(RegFieldDesc(s"claim_complete_$i",
             s"Claim/Complete register for Target $i. Reading this register returns the claimed interrupt number and makes it no longer pending." +
@@ -309,7 +309,7 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     node.regmap((priorityRegFields ++ pendingRegFields ++ enableRegFields ++ hartRegFields):_*)
 
     if (nDevices >= 2) {
-      val claimed = claimer(0) && maxDevs(0) > 0
+      val claimed = claimer(0) && maxDevs(0) > 0.U
       val completed = completer(0)
       property.cover(claimed && RegEnable(claimed, false.B, claimed || completed), "TWO_CLAIMS", "two claims with no intervening complete")
       property.cover(completed && RegEnable(completed, false.B, claimed || completed), "TWO_COMPLETES", "two completes with no intervening claim")
@@ -317,10 +317,10 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
       val ep = enables(0).asUInt & pending.asUInt
       val ep2 = RegNext(ep)
       val diff = ep & ~ep2
-      property.cover((diff & (diff - 1)) =/= 0, "TWO_INTS_PENDING", "two enabled interrupts became pending on same cycle")
+      property.cover((diff & (diff - 1.U)) =/= 0.U, "TWO_INTS_PENDING", "two enabled interrupts became pending on same cycle")
 
       if (nPriorities > 0)
-        ccover(maxDevs(0) > (UInt(1) << priority(0).getWidth) && maxDevs(0) <= Cat(UInt(1), threshold(0)),
+        ccover(maxDevs(0) > (1.U << priority(0).getWidth) && maxDevs(0) <= Cat(1.U, threshold(0)),
                "THRESHOLD", "interrupt pending but less than threshold")
     }
 
@@ -330,23 +330,23 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
 }
 
 class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
-  val io = new Bundle {
-    val prio = Vec(nDevices, UInt(width = prioBits)).flip
-    val ip   = UInt(width = nDevices).flip
-    val dev  = UInt(width = log2Ceil(nDevices+1))
-    val max  = UInt(width = prioBits)
-  }
+  val io = IO(new Bundle {
+    val prio = Flipped(Vec(nDevices, UInt(prioBits.W)))
+    val ip   = Flipped(UInt(nDevices.W))
+    val dev  = UInt(log2Ceil(nDevices+1).W)
+    val max  = UInt(prioBits.W)
+  })
 
   def findMax(x: Seq[UInt]): (UInt, UInt) = {
     if (x.length > 1) {
       val half = 1 << (log2Ceil(x.length) - 1)
       val left = findMax(x take half)
       val right = findMax(x drop half)
-      MuxT(left._1 >= right._1, left, (right._1, UInt(half) | right._2))
-    } else (x.head, UInt(0))
+      MuxT(left._1 >= right._1, left, (right._1, half.U | right._2))
+    } else (x.head, 0.U)
   }
 
-  val effectivePriority = (UInt(1) << prioBits) +: (io.ip.asBools zip io.prio).map { case (p, x) => Cat(p, x) }
+  val effectivePriority = (1.U << prioBits) +: (io.ip.asBools zip io.prio).map { case (p, x) => Cat(p, x) }
   val (maxPri, maxDev) = findMax(effectivePriority)
   io.max := maxPri // strips the always-constant high '1' bit
   io.dev := maxDev

--- a/src/main/scala/devices/tilelink/TestRAM.scala
+++ b/src/main/scala/devices/tilelink/TestRAM.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
@@ -37,7 +38,7 @@ class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int 
 
     val addrBits = (mask zip edge.addr_hi(in.a.bits).asBools).filter(_._1).map(_._2)
     val memAddress = Cat(addrBits.reverse)
-    val mem = Mem(1 << addrBits.size, Vec(beatBytes, Bits(width = 8)))
+    val mem = Mem(1 << addrBits.size, Vec(beatBytes, Bits(8.W)))
     val bad = Mem(1 << addrBits.size, Bool())
 
     // "Flow control"
@@ -45,21 +46,21 @@ class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int 
     in.d.valid := in.a.valid
 
     val hasData = edge.hasData(in.a.bits)
-    val wdata = Vec.tabulate(beatBytes) { i => in.a.bits.data(8*(i+1)-1, 8*i) }
+    val wdata = VecInit(Seq.tabulate(beatBytes) {i => in.a.bits.data(8*(i+1)-1, 8*i)})
 
     in.d.bits := edge.AccessAck(in.a.bits)
     in.d.bits.data := Cat(mem(memAddress).reverse)
-    in.d.bits.corrupt := !hasData && bad(memAddress) && Bool(trackCorruption)
+    in.d.bits.corrupt := !hasData && bad(memAddress) && trackCorruption.B
     in.d.bits.opcode := Mux(hasData, TLMessages.AccessAck, TLMessages.AccessAckData)
-    when (in.a.fire() && hasData) {
+    when (in.a.fire && hasData) {
       mem.write(memAddress, wdata, in.a.bits.mask.asBools)
       bad.write(memAddress, in.a.bits.corrupt)
     }
 
     // Tie off unused channels
-    in.b.valid := Bool(false)
-    in.c.ready := Bool(true)
-    in.e.ready := Bool(true)
+    in.b.valid := false.B
+    in.c.ready := true.B
+    in.e.ready := true.B
   }
 }
 

--- a/src/main/scala/devices/tilelink/Zero.scala
+++ b/src/main/scala/devices/tilelink/Zero.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink.TLMessages
@@ -36,8 +37,8 @@ class TLZero(address: AddressSet, beatBytes: Int = 4)(implicit p: Parameters)
     in.d.bits.opcode := TLMessages.adResponse(edge.opcode(a.bits))
 
     // Tie off unused channels
-    in.b.valid := Bool(false)
-    in.c.ready := Bool(true)
-    in.e.ready := Bool(true)
+    in.b.valid := false.B
+    in.c.ready := true.B
+    in.e.ready := true.B
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

As [`Chisel._` is Deprecated in Chisel 3.6](https://github.com/chipsalliance/chisel3/blob/5bc236268801861d325af7100922da3d14cd8b07/ROADMAP.md?plain=1#L33), we are porting Chisel 2 to Chisel 3.