### PR TITLE
Porting Chisel 2 to Chisel 3: rocket/

### DIFF
--- a/src/main/scala/rocket/BTB.scala
+++ b/src/main/scala/rocket/BTB.scala
@@ -202,7 +202,7 @@ class BTB(implicit p: Parameters) extends BtbModule {
   val tgts = Reg(Vec(entries, UInt((matchBits - log2Up(coreInstBytes)).W)))
   val tgtPages = Reg(Vec(entries, UInt(log2Up(nPages).W)))
   val pages = Reg(Vec(nPages, UInt((vaddrBits - matchBits).W)))
-  val pageValid = RegInit(init = 0.U(nPages.W))
+  val pageValid = RegInit(0.U(nPages.W))
   val pagesMasked = (pageValid.asBools zip pages).map { case (v, p) => Mux(v, p, 0.U) }
 
   val isValid = RegInit(0.U(entries.W))

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -476,7 +476,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
       }
     }
 
-    val s0_valid = !l2_refill && arb.io.out.fire()
+    val s0_valid = !l2_refill && arb.io.out.fire
     val s0_suitable = arb.io.out.bits.bits.vstage1 === arb.io.out.bits.bits.stage2 && !arb.io.out.bits.bits.need_gpa
     val s1_valid = RegNext(s0_valid && s0_suitable && arb.io.out.bits.valid)
     val s2_valid = RegNext(s1_valid)
@@ -584,7 +584,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
 
   switch (state) {
     is (s_ready) {
-      when (arb.io.out.fire()) {
+      when (arb.io.out.fire) {
         val satp_initial_count = pgLevels.U - minPgLevels.U - satp.additionalPgLevels
         val vsatp_initial_count = pgLevels.U - minPgLevels.U - io.dpath.vsatp.additionalPgLevels
         val hgatp_initial_count = pgLevels.U - minPgLevels.U - io.dpath.hgatp.additionalPgLevels
@@ -677,7 +677,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     // fragment_superpage
     Mux(state === s_fragment_superpage && !homogeneous && count =/= (pgLevels - 1).U, makePTE(makeFragmentedSuperpagePPN(r_pte.ppn)(count), r_pte),
     // when tlb request come->request mem, use root address in satp(or vsatp,hgatp)
-    Mux(arb.io.out.fire(), Mux(arb.io.out.bits.bits.stage2, makeHypervisorRootPTE(io.dpath.hgatp, io.dpath.vsatp.ppn, r_pte), makePTE(satp.ppn, r_pte)),
+    Mux(arb.io.out.fire, Mux(arb.io.out.bits.bits.stage2, makeHypervisorRootPTE(io.dpath.hgatp, io.dpath.vsatp.ppn, r_pte), makePTE(satp.ppn, r_pte)),
     r_pte)))))))
 
   when (l2_hit && !l2_error) {
@@ -773,7 +773,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   private def makeHypervisorRootPTE(hgatp: PTBR, vpn: UInt, default: PTE) = {
     val count = pgLevels.U - minPgLevels.U - hgatp.additionalPgLevels
     val idxs = (0 to pgLevels-minPgLevels).map(i => (vpn >> (pgLevels-i)*pgLevelBits))
-    val lsbs = WireDefault(t = UInt(maxHypervisorExtraAddrBits.W), init = idxs(count))
+    val lsbs = WireDefault(UInt(maxHypervisorExtraAddrBits.W), idxs(count))
     val pte = WireDefault(default)
     pte.ppn := Cat(hgatp.ppn >> maxHypervisorExtraAddrBits, lsbs)
     pte

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.rocket
 
 import chisel3._
 import chisel3.util._
-import chisel3.util.ImplicitConversions._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
@@ -85,11 +84,11 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
       }
 
       req.size := a.size
-      req.signed := false
+      req.signed := false.B
       req.addr := a.address
       req.tag := 0.U
-      req.phys := true
-      req.no_xcpt := true
+      req.phys := true.B
+      req.no_xcpt := true.B
       req.data := 0.U
       req.no_alloc := false.B
       req.mask := 0.U
@@ -112,7 +111,7 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
     io.dmem.s1_data.data := acq.data
     io.dmem.s1_data.mask := acq.mask
     io.dmem.s1_kill := state =/= s_wait1
-    io.dmem.s2_kill := false
+    io.dmem.s2_kill := false.B
 
     tl_in.d.valid := io.dmem.resp.valid || state === s_grant
     tl_in.d.bits := Mux(acq.opcode.isOneOf(TLMessages.PutFullData, TLMessages.PutPartialData),

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -306,7 +306,7 @@ case class TLBConfig(
   * @param edge collect SoC metadata.
   */
 class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(p) {
-  val io = new Bundle {
+  val io = IO(new Bundle {
     /** request from Core */
     val req = Flipped(Decoupled(new TLBReq(lgMaxSize)))
     /** response to Core */
@@ -317,7 +317,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
     val ptw = new TLBPTWIO
     /** suppress a TLB refill, one cycle after a miss */
     val kill = Input(Bool())
-  }
+  })
 
   val pageGranularityPMPs = pmpGranularity >= (1 << pgIdxBits)
   val vpn = io.req.bits.vaddr(vaddrBits-1, pgIdxBits)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

As [`Chisel._` is Deprecated in Chisel 3.6](https://github.com/chipsalliance/chisel3/blob/5bc236268801861d325af7100922da3d14cd8b07/ROADMAP.md?plain=1#L33), we are porting Chisel 2 to Chisel 3.