### PR TITLE
Pinning nix to 2.13.3 in github workflows

### DIFF
--- a/.github/workflows/mill-ci.yml
+++ b/.github/workflows/mill-ci.yml
@@ -31,8 +31,9 @@ jobs:
         with:
           submodules: 'true'
 
-      - uses: cachix/install-nix-action@v14.1
+      - uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Coursier Cache
@@ -53,8 +54,9 @@ jobs:
         with:
           submodules: 'true'
 
-      - uses: cachix/install-nix-action@v14.1
+      - uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Coursier Cache
@@ -76,8 +78,9 @@ jobs:
           submodules: 'true'
 
       - name: install nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Coursier Cache


### PR DESCRIPTION
Nix 2.14 was released with incompatibilities with cachix/install-nix-action.
This PR pins nix to 2.13.3 to avoid CI fails
See: https://github.com/cachix/install-nix-action/issues/161