### PR TITLE
Porting Chisel 2 to Chisel 3: tilelink/

### DIFF
--- a/src/main/scala/tilelink/Atomics.scala
+++ b/src/main/scala/tilelink/Atomics.scala
@@ -2,25 +2,26 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 
 class Atomics(params: TLBundleParameters) extends Module
 {
-  val io = new Bundle {
-    val write    = Bool().flip // ignore opcode
-    val a        = new TLBundleA(params).flip
-    val data_in  = UInt(width = params.dataBits).flip
-    val data_out = UInt(width = params.dataBits)
-  }
+  val io = IO(new Bundle {
+    val write    = Flipped(Bool()) // ignore opcode
+    val a        = Flipped(new TLBundleA(params))
+    val data_in  = Flipped(UInt(params.dataBits.W))
+    val data_out = UInt(params.dataBits.W)
+  })
 
   // Arithmetic, what to do
   val adder    = io.a.param(2)
   val unsigned = io.a.param(1)
   val take_max = io.a.param(0)
 
-  val signBit = io.a.mask & Cat(UInt(1), ~io.a.mask >> 1)
+  val signBit = io.a.mask & Cat(1.U, ~io.a.mask >> 1)
   val inv_d = Mux(adder, io.data_in, ~io.data_in)
   val sum = (FillInterleaved(8, io.a.mask) & io.a.data) + inv_d
   def sign(x: UInt): Bool = (Cat(x.asBools.grouped(8).map(_.last).toList.reverse) & signBit).orR
@@ -32,31 +33,31 @@ class Atomics(params: TLBundleParameters) extends Module
   val pick_a = take_max === a_bigger
 
   // Logical, what to do
-  val lut = Vec(Seq(
-    UInt(0x6),   // XOR
-    UInt(0xe),   // OR
-    UInt(0x8),   // AND
-    UInt(0xc)))( // SWAP
+  val lut = VecInit(Seq(
+    (0x6).U,   // XOR
+    (0xe).U,   // OR
+    (0x8).U,   // AND
+    (0xc).U))( // SWAP
     io.a.param(1,0))
   val logical = Cat((io.a.data.asBools zip io.data_in.asBools).map { case (a, d) =>
     lut(Cat(a, d))
   }.reverse)
 
   // Operation, what to do? (0=d, 1=a, 2=sum, 3=logical)
-  val select = Mux(io.write, UInt(1), Vec(Seq(
-    UInt(1),   // PutFullData
-    UInt(1),   // PutPartialData
-    Mux(adder, UInt(2), Mux(pick_a, UInt(1), UInt(0))), // ArithmeticData
-    UInt(3),   // LogicalData
-    UInt(0),   // Get
-    UInt(0),   // Hint
-    UInt(0),   // AcquireBlock
-    UInt(0)))( // AcquirePerm
+  val select = Mux(io.write, 1.U, VecInit(Seq(
+    1.U,   // PutFullData
+    1.U,   // PutPartialData
+    Mux(adder, 2.U, Mux(pick_a, 1.U, 0.U)), // ArithmeticData
+    3.U,   // LogicalData
+    0.U,   // Get
+    0.U,   // Hint
+    0.U,   // AcquireBlock
+    0.U))( // AcquirePerm
     io.a.opcode))
 
   // Only the masked bytes can be modified
-  val selects = io.a.mask.asBools.map(b => Mux(b, select, UInt(0)))
+  val selects = io.a.mask.asBools.map(b => Mux(b, select, 0.U))
   io.data_out := Cat(selects.zipWithIndex.map { case (s, i) =>
-    Vec(Seq(io.data_in, io.a.data, sum, logical).map(_((i + 1) * 8 - 1, i * 8)))(s)
+    VecInit(Seq(io.data_in, io.a.data, sum, logical).map(_((i + 1) * 8 - 1, i * 8)))(s)
   }.reverse)
 }

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -481,7 +481,7 @@ class TLBroadcastTracker(id: Int, lineBytes: Int, caches: Int, bufferless: Boole
   io.cacheOH := cacheOH
 
   val i_data = Wire(Decoupled(new TLBroadcastData(edgeIn.bundle)))
-  val o_data = Queue(i_data, if (bufferless) 1 else (lineBytes / edgeIn.manager.beatBytes), pipe=bufferless)
+  val o_data = Queue(i_data, if (bufferless) 1 else (lineBytes / edgeIn.manager.beatBytes), bufferless)
 
   io.in_a.ready := (idle || !io.in_a_first) && i_data.ready
   i_data.valid := (idle || !io.in_a_first) && io.in_a.valid

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 
@@ -43,12 +43,12 @@ class TLBuffer(
         out.c <> c(in .c)
         out.e <> e(in .e)
       } else {
-        in.b.valid := Bool(false)
-        in.c.ready := Bool(true)
-        in.e.ready := Bool(true)
-        out.b.ready := Bool(true)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
+        in.b.valid := false.B
+        in.c.ready := true.B
+        in.e.ready := true.B
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
       }
     }
   }
@@ -120,12 +120,12 @@ class TLBufferAndNotCancel(
         out.c <> c(in .c)
         out.e <> e(in .e)
       } else {
-        in.b.valid := Bool(false)
-        in.c.ready := Bool(true)
-        in.e.ready := Bool(true)
-        out.b.ready := Bool(true)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
+        in.b.valid := false.B
+        in.c.ready := true.B
+        in.e.ready := true.B
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
       }
     }
   }

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -63,8 +63,8 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
         // Fortunately, no masters we know of behave this way!
 
         // Take requests from A to A or D (if BtoT Acquire)
-        val a_a = Wire(out.a)
-        val a_d = Wire(in.d)
+        val a_a = Wire(chiselTypeOf(out.a))
+        val a_d = Wire(chiselTypeOf(in.d))
         val isPut = in.a.bits.opcode === PutFullData || in.a.bits.opcode === PutPartialData
         val toD = (in.a.bits.opcode === AcquireBlock && in.a.bits.param === TLPermissions.BtoT) ||
                   (in.a.bits.opcode === AcquirePerm)
@@ -90,7 +90,7 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
           capPermissions = TLPermissions.toT)
 
         // Take ReleaseData from C to A; Release from C to D
-        val c_a = Wire(out.a)
+        val c_a = Wire(chiselTypeOf(out.a))
         c_a.valid := in.c.valid && in.c.bits.opcode === ReleaseData
         c_a.bits := edgeOut.Put(
           fromSource = in.c.bits.source << 1,
@@ -101,7 +101,7 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
         c_a.bits.user :<= in.c.bits.user
 
         // Releases without Data succeed instantly
-        val c_d = Wire(in.d)
+        val c_d = Wire(chiselTypeOf(in.d))
         c_d.valid := in.c.valid && in.c.bits.opcode === Release
         c_d.bits := edgeIn.ReleaseAck(in.c.bits)
 
@@ -120,7 +120,7 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
         pool.io.free.valid := in.e.fire
         pool.io.free.bits  := in.e.bits.sink
 
-        val in_d = Wire(in.d)
+        val in_d = Wire(chiselTypeOf(in.d))
         val d_first = edgeOut.first(in_d)
         val d_grant = in_d.bits.opcode === GrantData || in_d.bits.opcode === Grant
         pool.io.alloc.ready := in.d.fire && d_first && d_grant
@@ -130,7 +130,7 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
         in.d.bits.sink := pool.io.alloc.bits holdUnless d_first
 
         // Take responses from D and transform them
-        val d_d = Wire(in.d)
+        val d_d = Wire(chiselTypeOf(in.d))
         d_d <> out.d
         d_d.bits.source := out.d.bits.source >> 1
 

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -71,19 +72,19 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
 
         a_a.valid := in.a.valid && !toD
         a_a.bits := in.a.bits
-        a_a.bits.source := in.a.bits.source << 1 | Mux(isPut, UInt(1), UInt(0))
+        a_a.bits.source := in.a.bits.source << 1 | Mux(isPut, 1.U, 0.U)
 
         // Transform Acquire into Get
         when (in.a.bits.opcode === AcquireBlock || in.a.bits.opcode === AcquirePerm) {
           a_a.bits.opcode := Get
-          a_a.bits.param  := UInt(0)
-          a_a.bits.source := in.a.bits.source << 1 | UInt(1)
+          a_a.bits.param  := 0.U
+          a_a.bits.source := in.a.bits.source << 1 | 1.U
         }
 
         // Upgrades are instantly successful
         a_d.valid := in.a.valid && toD
         a_d.bits := edgeIn.Grant(
-          fromSink = UInt(0),
+          fromSink = 0.U,
           toSource = in.a.bits.source,
           lgSize   = in.a.bits.size,
           capPermissions = TLPermissions.toT)
@@ -108,21 +109,21 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
         in.c.ready := Mux(in.c.bits.opcode === Release, c_d.ready, c_a.ready)
 
         // Discard E
-        in.e.ready := Bool(true)
+        in.e.ready := true.B
 
         // Block B; should never happen
-        out.b.ready := Bool(false)
+        out.b.ready := false.B
         assert (!out.b.valid)
 
         // Track in-flight sinkIds
         val pool = Module(new IDPool(sinkIds))
-        pool.io.free.valid := in.e.fire()
+        pool.io.free.valid := in.e.fire
         pool.io.free.bits  := in.e.bits.sink
 
         val in_d = Wire(in.d)
         val d_first = edgeOut.first(in_d)
         val d_grant = in_d.bits.opcode === GrantData || in_d.bits.opcode === Grant
-        pool.io.alloc.ready := in.d.fire() && d_first && d_grant
+        pool.io.alloc.ready := in.d.fire && d_first && d_grant
         in.d.valid := in_d.valid && (pool.io.alloc.valid || !d_first || !d_grant)
         in_d.ready := in.d.ready && (pool.io.alloc.valid || !d_first || !d_grant)
         in.d.bits := in_d.bits
@@ -136,18 +137,18 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
         // Record if a target was writable and auto-promote toT if it was
         // This is structured so that the vector can be constant prop'd away
         val wSourceVec = Reg(Vec(edgeIn.client.endSourceId, Bool()))
-        val aWOk = edgeIn.manager.fastProperty(in.a.bits.address, !_.supportsPutFull.none, (b:Boolean) => Bool(b))
+        val aWOk = edgeIn.manager.fastProperty(in.a.bits.address, !_.supportsPutFull.none, (b:Boolean) => b.B)
         val dWOk = wSourceVec(d_d.bits.source)
-        val bypass = Bool(edgeIn.manager.minLatency == 0) && in.a.valid && in.a.bits.source === d_d.bits.source
+        val bypass = (edgeIn.manager.minLatency == 0).B && in.a.valid && in.a.bits.source === d_d.bits.source
         val dWHeld = Mux(bypass, aWOk, dWOk) holdUnless d_first
 
-        when (in.a.fire()) {
+        when (in.a.fire) {
           wSourceVec(in.a.bits.source) := aWOk
         }
 
         // Wipe out any unused registers
         edgeIn.client.unusedSources.foreach { id =>
-          wSourceVec(id) := Bool(edgeIn.manager.anySupportPutFull)
+          wSourceVec(id) := edgeIn.manager.anySupportPutFull.B
         }
 
         when (out.d.bits.opcode === AccessAckData && out.d.bits.source(0)) {
@@ -160,12 +161,12 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
 
         // Combine the sources of messages into the channels
         TLArbiter(TLArbiter.lowestIndexFirst)(out.a, (edgeOut.numBeats1(c_a.bits), c_a), (edgeOut.numBeats1(a_a.bits), a_a))
-        TLArbiter(TLArbiter.lowestIndexFirst)(in_d,  (edgeIn .numBeats1(d_d.bits), d_d), (UInt(0), Queue(c_d, 2)), (UInt(0), Queue(a_d, 2)))
+        TLArbiter(TLArbiter.lowestIndexFirst)(in_d,  (edgeIn .numBeats1(d_d.bits), d_d), (0.U, Queue(c_d, 2)), (0.U, Queue(a_d, 2)))
 
         // Tie off unused ports
-        in.b.valid := Bool(false)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
+        in.b.valid := false.B
+        out.c.valid := false.B
+        out.e.valid := false.B
       }
     }
   }

--- a/src/main/scala/tilelink/Delayer.scala
+++ b/src/main/scala/tilelink/Delayer.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 
@@ -15,7 +16,7 @@ class TLDelayer(q: Double)(implicit p: Parameters) extends LazyModule
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     def feed[T <: Data](sink: DecoupledIO[T], source: DecoupledIO[T], noise: T): Unit = {
-      val allow = UInt((q * 65535.0).toInt) <= LFSRNoiseMaker(16, source.valid)
+      val allow = ((q * 65535.0).toInt).U <= LFSRNoiseMaker(16, source.valid)
       sink.valid := source.valid && allow
       source.ready := sink.ready && allow
       sink.bits := source.bits

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.internal.sourceinfo.SourceInfo
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.util._
@@ -15,9 +16,9 @@ class TLEdge(
   extends TLEdgeParameters(client, manager, params, sourceInfo)
 {
   def isAligned(address: UInt, lgSize: UInt): Bool = {
-    if (maxLgSize == 0) Bool(true) else {
+    if (maxLgSize == 0) true.B else {
       val mask = UIntToOH1(lgSize, maxLgSize)
-      (address & mask) === UInt(0)
+      (address & mask) === 0.U
     }
   }
 
@@ -62,27 +63,27 @@ class TLEdge(
 
   def isRequest(x: TLChannel): Bool = {
     x match {
-      case a: TLBundleA => Bool(true)
-      case b: TLBundleB => Bool(true)
+      case a: TLBundleA => true.B
+      case b: TLBundleB => true.B
       case c: TLBundleC => c.opcode(2) && c.opcode(1)
         //    opcode === TLMessages.Release ||
         //    opcode === TLMessages.ReleaseData
       case d: TLBundleD => d.opcode(2) && !d.opcode(1)
         //    opcode === TLMessages.Grant     ||
         //    opcode === TLMessages.GrantData
-      case e: TLBundleE => Bool(false)
+      case e: TLBundleE => false.B
     }
   }
 
   def isResponse(x: TLChannel): Bool = {
     x match {
-      case a: TLBundleA => Bool(false)
-      case b: TLBundleB => Bool(false)
+      case a: TLBundleA => false.B
+      case b: TLBundleB => false.B
       case c: TLBundleC => !c.opcode(2) || !c.opcode(1)
         //    opcode =/= TLMessages.Release &&
         //    opcode =/= TLMessages.ReleaseData
-      case d: TLBundleD => Bool(true) // Grant isResponse + isRequest
-      case e: TLBundleE => Bool(true)
+      case d: TLBundleD => true.B // Grant isResponse + isRequest
+      case e: TLBundleE => true.B
     }
   }
 
@@ -105,9 +106,9 @@ class TLEdge(
       case d: TLBundleD => d.opcode(0)
         //    opcode === TLMessages.AccessAckData ||
         //    opcode === TLMessages.GrantData
-      case e: TLBundleE => Bool(false)
+      case e: TLBundleE => false.B
     }
-    staticHasData(x).map(Bool(_)).getOrElse(opdata)
+    staticHasData(x).map(_.B).getOrElse(opdata)
   }
 
   def opcode(x: TLDataChannel): UInt = {
@@ -190,34 +191,34 @@ class TLEdge(
 
   def addr_hi(x: UInt): UInt = x >> log2Ceil(manager.beatBytes)
   def addr_lo(x: UInt): UInt =
-    if (manager.beatBytes == 1) UInt(0) else x(log2Ceil(manager.beatBytes)-1, 0)
+    if (manager.beatBytes == 1) 0.U else x(log2Ceil(manager.beatBytes)-1, 0)
 
   def addr_hi(x: TLAddrChannel): UInt = addr_hi(address(x))
   def addr_lo(x: TLAddrChannel): UInt = addr_lo(address(x))
 
   def numBeats(x: TLChannel): UInt = {
     x match {
-      case _: TLBundleE => UInt(1)
+      case _: TLBundleE => 1.U
       case bundle: TLDataChannel => {
         val hasData = this.hasData(bundle)
         val size = this.size(bundle)
         val cutoff = log2Ceil(manager.beatBytes)
-        val small = if (manager.maxTransfer <= manager.beatBytes) Bool(true) else size <= UInt(cutoff)
+        val small = if (manager.maxTransfer <= manager.beatBytes) true.B else size <= (cutoff).U
         val decode = UIntToOH(size, maxLgSize+1) >> cutoff
-        Mux(hasData, decode | small.asUInt, UInt(1))
+        Mux(hasData, decode | small.asUInt, 1.U)
       }
     }
   }
 
   def numBeats1(x: TLChannel): UInt = {
     x match {
-      case _: TLBundleE => UInt(0)
+      case _: TLBundleE => 0.U
       case bundle: TLDataChannel => {
         if (maxLgSize == 0) {
-          UInt(0)
+          0.U
         } else {
           val decode = UIntToOH1(size(bundle), maxLgSize) >> log2Ceil(manager.beatBytes)
-          Mux(hasData(bundle), decode, UInt(0))
+          Mux(hasData(bundle), decode, 0.U)
         }
       }
     }
@@ -225,10 +226,10 @@ class TLEdge(
 
   def firstlastHelper(bits: TLChannel, fire: Bool): (Bool, Bool, Bool, UInt) = {
     val beats1   = numBeats1(bits)
-    val counter  = RegInit(UInt(0, width = log2Up(maxTransfer / manager.beatBytes)))
-    val counter1 = counter - UInt(1)
-    val first = counter === UInt(0)
-    val last  = counter === UInt(1) || beats1 === UInt(0)
+    val counter  = RegInit(0.U(log2Up(maxTransfer / manager.beatBytes).W))
+    val counter1 = counter - 1.U
+    val first = counter === 0.U
+    val last  = counter === 1.U || beats1 === 0.U
     val done  = last && fire
     val count = (beats1 & ~counter1)
     when (fire) {
@@ -291,7 +292,7 @@ class TLEdge(
 
   // This is a very expensive circuit; use only if you really mean it!
   def inFlight(x: TLBundle): (UInt, UInt) = {
-    val flight = RegInit(UInt(0, width = log2Ceil(3*client.endSourceId+1)))
+    val flight = RegInit(0.U(log2Ceil(3*client.endSourceId+1).W))
     val bce = manager.anySupportAcquireB && client.anySupportProbe
 
     val (a_first, a_last, _) = firstlast(x.a)
@@ -349,8 +350,8 @@ class TLEdgeOut(
     a.source  := fromSource
     a.address := toAddress
     a.mask    := mask(toAddress, lgSize)
-    a.data    := UInt(0)
-    a.corrupt := Bool(false)
+    a.data    := 0.U
+    a.corrupt := false.B
     (legal, a)
   }
 
@@ -364,8 +365,8 @@ class TLEdgeOut(
     a.source  := fromSource
     a.address := toAddress
     a.mask    := mask(toAddress, lgSize)
-    a.data    := UInt(0)
-    a.corrupt := Bool(false)
+    a.data    := 0.U
+    a.corrupt := false.B
     (legal, a)
   }
 
@@ -378,8 +379,8 @@ class TLEdgeOut(
     c.size    := lgSize
     c.source  := fromSource
     c.address := toAddress
-    c.data    := UInt(0)
-    c.corrupt := Bool(false)
+    c.data    := 0.U
+    c.corrupt := false.B
     (legal, c)
   }
 
@@ -398,7 +399,7 @@ class TLEdgeOut(
   }
 
   def Release(fromSource: UInt, toAddress: UInt, lgSize: UInt, shrinkPermissions: UInt, data: UInt): (Bool, TLBundleC) =
-    Release(fromSource, toAddress, lgSize, shrinkPermissions, data, Bool(false))
+    Release(fromSource, toAddress, lgSize, shrinkPermissions, data, false.B)
 
   def ProbeAck(b: TLBundleB, reportPermissions: UInt): TLBundleC =
     ProbeAck(b.source, b.address, b.size, reportPermissions)
@@ -410,8 +411,8 @@ class TLEdgeOut(
     c.size    := lgSize
     c.source  := fromSource
     c.address := toAddress
-    c.data    := UInt(0)
-    c.corrupt := Bool(false)
+    c.data    := 0.U
+    c.corrupt := false.B
     c
   }
 
@@ -431,7 +432,7 @@ class TLEdgeOut(
   }
 
   def ProbeAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, reportPermissions: UInt, data: UInt): TLBundleC =
-    ProbeAck(fromSource, toAddress, lgSize, reportPermissions, data, Bool(false))
+    ProbeAck(fromSource, toAddress, lgSize, reportPermissions, data, false.B)
 
   def GrantAck(d: TLBundleD): TLBundleE = GrantAck(d.sink)
   def GrantAck(toSink: UInt): TLBundleE = {
@@ -446,25 +447,25 @@ class TLEdgeOut(
     val legal = manager.supportsGetFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.Get
-    a.param   := UInt(0)
+    a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
     a.address := toAddress
     a.mask    := mask(toAddress, lgSize)
-    a.data    := UInt(0)
-    a.corrupt := Bool(false)
+    a.data    := 0.U
+    a.corrupt := false.B
     (legal, a)
   }
 
   def Put(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt): (Bool, TLBundleA) =
-    Put(fromSource, toAddress, lgSize, data, Bool(false))
+    Put(fromSource, toAddress, lgSize, data, false.B)
 
   def Put(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, corrupt: Bool): (Bool, TLBundleA) = {
     require (manager.anySupportPutFull, s"TileLink: No managers visible from this edge support Puts, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsPutFullFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.PutFullData
-    a.param   := UInt(0)
+    a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
     a.address := toAddress
@@ -475,14 +476,14 @@ class TLEdgeOut(
   }
 
   def Put(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, mask: UInt): (Bool, TLBundleA) =
-    Put(fromSource, toAddress, lgSize, data, mask, Bool(false))
+    Put(fromSource, toAddress, lgSize, data, mask, false.B)
 
   def Put(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, mask: UInt, corrupt: Bool): (Bool, TLBundleA) = {
     require (manager.anySupportPutPartial, s"TileLink: No managers visible from this edge support masked Puts, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsPutPartialFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.PutPartialData
-    a.param   := UInt(0)
+    a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
     a.address := toAddress
@@ -492,7 +493,7 @@ class TLEdgeOut(
     (legal, a)
   }
 
-  def Arithmetic(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = Bool(false)): (Bool, TLBundleA) = {
+  def Arithmetic(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = false.B): (Bool, TLBundleA) = {
     require (manager.anySupportArithmetic, s"TileLink: No managers visible from this edge support arithmetic AMOs, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsArithmeticFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
@@ -507,7 +508,7 @@ class TLEdgeOut(
     (legal, a)
   }
 
-  def Logical(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = Bool(false)) = {
+  def Logical(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = false.B) = {
     require (manager.anySupportLogical, s"TileLink: No managers visible from this edge support logical AMOs, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsLogicalFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
@@ -532,8 +533,8 @@ class TLEdgeOut(
     a.source  := fromSource
     a.address := toAddress
     a.mask    := mask(toAddress, lgSize)
-    a.data    := UInt(0)
-    a.corrupt := Bool(false)
+    a.data    := 0.U
+    a.corrupt := false.B
     (legal, a)
   }
 
@@ -541,22 +542,22 @@ class TLEdgeOut(
   def AccessAck(fromSource: UInt, toAddress: UInt, lgSize: UInt) = {
     val c = Wire(new TLBundleC(bundle))
     c.opcode  := TLMessages.AccessAck
-    c.param   := UInt(0)
+    c.param   := 0.U
     c.size    := lgSize
     c.source  := fromSource
     c.address := toAddress
-    c.data    := UInt(0)
-    c.corrupt := Bool(false)
+    c.data    := 0.U
+    c.corrupt := false.B
     c
   }
 
   def AccessAck(b: TLBundleB, data: UInt): TLBundleC = AccessAck(b.source, address(b), b.size, data)
   def AccessAck(b: TLBundleB, data: UInt, corrupt: Bool): TLBundleC = AccessAck(b.source, address(b), b.size, data, corrupt)
-  def AccessAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt): TLBundleC = AccessAck(fromSource, toAddress, lgSize, data, Bool(false))
+  def AccessAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt): TLBundleC = AccessAck(fromSource, toAddress, lgSize, data, false.B)
   def AccessAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, corrupt: Bool) = {
     val c = Wire(new TLBundleC(bundle))
     c.opcode  := TLMessages.AccessAckData
-    c.param   := UInt(0)
+    c.param   := 0.U
     c.size    := lgSize
     c.source  := fromSource
     c.address := toAddress
@@ -569,12 +570,12 @@ class TLEdgeOut(
   def HintAck(fromSource: UInt, toAddress: UInt, lgSize: UInt) = {
     val c = Wire(new TLBundleC(bundle))
     c.opcode  := TLMessages.HintAck
-    c.param   := UInt(0)
+    c.param   := 0.U
     c.size    := lgSize
     c.source  := fromSource
     c.address := toAddress
-    c.data    := UInt(0)
-    c.corrupt := Bool(false)
+    c.data    := 0.U
+    c.corrupt := false.B
     c
   }
 }
@@ -604,12 +605,12 @@ class TLEdgeIn(
     b.source  := toSource
     b.address := fromAddress
     b.mask    := mask(fromAddress, lgSize)
-    b.data    := UInt(0)
-    b.corrupt := Bool(false)
+    b.data    := 0.U
+    b.corrupt := false.B
     (legal, b)
   }
 
-  def Grant(fromSink: UInt, toSource: UInt, lgSize: UInt, capPermissions: UInt): TLBundleD = Grant(fromSink, toSource, lgSize, capPermissions, Bool(false))
+  def Grant(fromSink: UInt, toSource: UInt, lgSize: UInt, capPermissions: UInt): TLBundleD = Grant(fromSink, toSource, lgSize, capPermissions, false.B)
   def Grant(fromSink: UInt, toSource: UInt, lgSize: UInt, capPermissions: UInt, denied: Bool) = {
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.Grant
@@ -618,12 +619,12 @@ class TLEdgeIn(
     d.source  := toSource
     d.sink    := fromSink
     d.denied  := denied
-    d.data    := UInt(0)
-    d.corrupt := Bool(false)
+    d.data    := 0.U
+    d.corrupt := false.B
     d
   }
 
-  def Grant(fromSink: UInt, toSource: UInt, lgSize: UInt, capPermissions: UInt, data: UInt): TLBundleD = Grant(fromSink, toSource, lgSize, capPermissions, data, Bool(false), Bool(false))
+  def Grant(fromSink: UInt, toSource: UInt, lgSize: UInt, capPermissions: UInt, data: UInt): TLBundleD = Grant(fromSink, toSource, lgSize, capPermissions, data, false.B, false.B)
   def Grant(fromSink: UInt, toSource: UInt, lgSize: UInt, capPermissions: UInt, data: UInt, denied: Bool, corrupt: Bool) = {
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.GrantData
@@ -637,17 +638,17 @@ class TLEdgeIn(
     d
   }
 
-  def ReleaseAck(c: TLBundleC): TLBundleD = ReleaseAck(c.source, c.size, Bool(false))
+  def ReleaseAck(c: TLBundleC): TLBundleD = ReleaseAck(c.source, c.size, false.B)
   def ReleaseAck(toSource: UInt, lgSize: UInt, denied: Bool): TLBundleD = {
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.ReleaseAck
-    d.param   := UInt(0)
+    d.param   := 0.U
     d.size    := lgSize
     d.source  := toSource
-    d.sink    := UInt(0)
+    d.sink    := 0.U
     d.denied  := denied
-    d.data    := UInt(0)
-    d.corrupt := Bool(false)
+    d.data    := 0.U
+    d.corrupt := false.B
     d
   }
 
@@ -657,25 +658,25 @@ class TLEdgeIn(
     val legal = client.supportsGet(toSource, lgSize)
     val b = Wire(new TLBundleB(bundle))
     b.opcode  := TLMessages.Get
-    b.param   := UInt(0)
+    b.param   := 0.U
     b.size    := lgSize
     b.source  := toSource
     b.address := fromAddress
     b.mask    := mask(fromAddress, lgSize)
-    b.data    := UInt(0)
-    b.corrupt := Bool(false)
+    b.data    := 0.U
+    b.corrupt := false.B
     (legal, b)
   }
 
   def Put(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt): (Bool, TLBundleB) =
-    Put(fromAddress, toSource, lgSize, data, Bool(false))
+    Put(fromAddress, toSource, lgSize, data, false.B)
 
   def Put(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt, corrupt: Bool): (Bool, TLBundleB) = {
     require (client.anySupportPutFull, s"TileLink: No clients visible from this edge support Puts, but one of these managers would try to issue one: ${manager.managers}")
     val legal = client.supportsPutFull(toSource, lgSize)
     val b = Wire(new TLBundleB(bundle))
     b.opcode  := TLMessages.PutFullData
-    b.param   := UInt(0)
+    b.param   := 0.U
     b.size    := lgSize
     b.source  := toSource
     b.address := fromAddress
@@ -686,14 +687,14 @@ class TLEdgeIn(
   }
 
   def Put(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt, mask: UInt): (Bool, TLBundleB) =
-    Put(fromAddress, toSource, lgSize, data, mask, Bool(false))
+    Put(fromAddress, toSource, lgSize, data, mask, false.B)
 
   def Put(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt, mask: UInt, corrupt: Bool): (Bool, TLBundleB) = {
     require (client.anySupportPutPartial, s"TileLink: No clients visible from this edge support masked Puts, but one of these managers would try to request one: ${manager.managers}")
     val legal = client.supportsPutPartial(toSource, lgSize)
     val b = Wire(new TLBundleB(bundle))
     b.opcode  := TLMessages.PutPartialData
-    b.param   := UInt(0)
+    b.param   := 0.U
     b.size    := lgSize
     b.source  := toSource
     b.address := fromAddress
@@ -703,7 +704,7 @@ class TLEdgeIn(
     (legal, b)
   }
 
-  def Arithmetic(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = Bool(false)) = {
+  def Arithmetic(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = false.B) = {
     require (client.anySupportArithmetic, s"TileLink: No clients visible from this edge support arithmetic AMOs, but one of these managers would try to request one: ${manager.managers}")
     val legal = client.supportsArithmetic(toSource, lgSize)
     val b = Wire(new TLBundleB(bundle))
@@ -718,7 +719,7 @@ class TLEdgeIn(
     (legal, b)
   }
 
-  def Logical(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = Bool(false)) = {
+  def Logical(fromAddress: UInt, toSource: UInt, lgSize: UInt, data: UInt, atomic: UInt, corrupt: Bool = false.B) = {
     require (client.anySupportLogical, s"TileLink: No clients visible from this edge support logical AMOs, but one of these managers would try to request one: ${manager.managers}")
     val legal = client.supportsLogical(toSource, lgSize)
     val b = Wire(new TLBundleB(bundle))
@@ -743,56 +744,56 @@ class TLEdgeIn(
     b.source  := toSource
     b.address := fromAddress
     b.mask    := mask(fromAddress, lgSize)
-    b.data    := UInt(0)
-    b.corrupt := Bool(false)
+    b.data    := 0.U
+    b.corrupt := false.B
     (legal, b)
   }
 
   def AccessAck(a: TLBundleA): TLBundleD = AccessAck(a.source, a.size)
   def AccessAck(a: TLBundleA, denied: Bool): TLBundleD = AccessAck(a.source, a.size, denied)
-  def AccessAck(toSource: UInt, lgSize: UInt): TLBundleD = AccessAck(toSource, lgSize, Bool(false))
+  def AccessAck(toSource: UInt, lgSize: UInt): TLBundleD = AccessAck(toSource, lgSize, false.B)
   def AccessAck(toSource: UInt, lgSize: UInt, denied: Bool) = {
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.AccessAck
-    d.param   := UInt(0)
+    d.param   := 0.U
     d.size    := lgSize
     d.source  := toSource
-    d.sink    := UInt(0)
+    d.sink    := 0.U
     d.denied  := denied
-    d.data    := UInt(0)
-    d.corrupt := Bool(false)
+    d.data    := 0.U
+    d.corrupt := false.B
     d
   }
 
   def AccessAck(a: TLBundleA, data: UInt): TLBundleD = AccessAck(a.source, a.size, data)
   def AccessAck(a: TLBundleA, data: UInt, denied: Bool, corrupt: Bool): TLBundleD = AccessAck(a.source, a.size, data, denied, corrupt)
-  def AccessAck(toSource: UInt, lgSize: UInt, data: UInt): TLBundleD = AccessAck(toSource, lgSize, data, Bool(false), Bool(false))
+  def AccessAck(toSource: UInt, lgSize: UInt, data: UInt): TLBundleD = AccessAck(toSource, lgSize, data, false.B, false.B)
   def AccessAck(toSource: UInt, lgSize: UInt, data: UInt, denied: Bool, corrupt: Bool) = {
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.AccessAckData
-    d.param   := UInt(0)
+    d.param   := 0.U
     d.size    := lgSize
     d.source  := toSource
-    d.sink    := UInt(0)
+    d.sink    := 0.U
     d.denied  := denied
     d.data    := data
     d.corrupt := corrupt
     d
   }
 
-  def HintAck(a: TLBundleA): TLBundleD = HintAck(a, Bool(false))
+  def HintAck(a: TLBundleA): TLBundleD = HintAck(a, false.B)
   def HintAck(a: TLBundleA, denied: Bool): TLBundleD = HintAck(a.source, a.size, denied)
-  def HintAck(toSource: UInt, lgSize: UInt): TLBundleD = HintAck(toSource, lgSize, Bool(false))
+  def HintAck(toSource: UInt, lgSize: UInt): TLBundleD = HintAck(toSource, lgSize, false.B)
   def HintAck(toSource: UInt, lgSize: UInt, denied: Bool) = {
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.HintAck
-    d.param   := UInt(0)
+    d.param   := 0.U
     d.size    := lgSize
     d.source  := toSource
-    d.sink    := UInt(0)
+    d.sink    := 0.U
     d.denied  := denied
-    d.data    := UInt(0)
-    d.corrupt := Bool(false)
+    d.data    := 0.U
+    d.corrupt := false.B
     d
   }
 }

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -273,17 +273,17 @@ class TLEdge(
 
   // Does the request need T permissions to be executed?
   def needT(a: TLBundleA): Bool = {
-    val acq_needT = MuxLookup(a.param, Wire(Bool()), Array(
+    val acq_needT = MuxLookup(a.param, WireDefault(Bool(), DontCare), Array(
       TLPermissions.NtoB -> false.B,
       TLPermissions.NtoT -> true.B,
       TLPermissions.BtoT -> true.B))
-    MuxLookup(a.opcode, Wire(Bool()), Array(
+    MuxLookup(a.opcode, WireDefault(Bool(), DontCare), Array(
       TLMessages.PutFullData    -> true.B,
       TLMessages.PutPartialData -> true.B,
       TLMessages.ArithmeticData -> true.B,
       TLMessages.LogicalData    -> true.B,
       TLMessages.Get            -> false.B,
-      TLMessages.Hint           -> MuxLookup(a.param, Wire(Bool()), Array(
+      TLMessages.Hint           -> MuxLookup(a.param, WireDefault(Bool(), DontCare), Array(
         TLHints.PREFETCH_READ   -> false.B,
         TLHints.PREFETCH_WRITE  -> true.B)),
       TLMessages.AcquireBlock   -> acq_needT,
@@ -406,6 +406,7 @@ class TLEdgeOut(
 
   def ProbeAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, reportPermissions: UInt): TLBundleC = {
     val c = Wire(new TLBundleC(bundle))
+    c :#= DontCare
     c.opcode  := TLMessages.ProbeAck
     c.param   := reportPermissions
     c.size    := lgSize
@@ -421,6 +422,7 @@ class TLEdgeOut(
 
   def ProbeAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, reportPermissions: UInt, data: UInt, corrupt: Bool): TLBundleC = {
     val c = Wire(new TLBundleC(bundle))
+    c :#= DontCare
     c.opcode  := TLMessages.ProbeAckData
     c.param   := reportPermissions
     c.size    := lgSize
@@ -446,6 +448,7 @@ class TLEdgeOut(
     require (manager.anySupportGet, s"TileLink: No managers visible from this edge support Gets, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsGetFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
+    a :#= DontCare
     a.opcode  := TLMessages.Get
     a.param   := 0.U
     a.size    := lgSize
@@ -464,6 +467,7 @@ class TLEdgeOut(
     require (manager.anySupportPutFull, s"TileLink: No managers visible from this edge support Puts, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsPutFullFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
+    a :#= DontCare
     a.opcode  := TLMessages.PutFullData
     a.param   := 0.U
     a.size    := lgSize
@@ -482,6 +486,7 @@ class TLEdgeOut(
     require (manager.anySupportPutPartial, s"TileLink: No managers visible from this edge support masked Puts, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsPutPartialFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
+    a :#= DontCare
     a.opcode  := TLMessages.PutPartialData
     a.param   := 0.U
     a.size    := lgSize
@@ -497,6 +502,7 @@ class TLEdgeOut(
     require (manager.anySupportArithmetic, s"TileLink: No managers visible from this edge support arithmetic AMOs, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsArithmeticFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
+    a :#= DontCare
     a.opcode  := TLMessages.ArithmeticData
     a.param   := atomic
     a.size    := lgSize
@@ -512,6 +518,7 @@ class TLEdgeOut(
     require (manager.anySupportLogical, s"TileLink: No managers visible from this edge support logical AMOs, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsLogicalFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
+    a :#= DontCare
     a.opcode  := TLMessages.LogicalData
     a.param   := atomic
     a.size    := lgSize

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -344,6 +344,7 @@ class TLEdgeOut(
     require (manager.anySupportAcquireB, s"TileLink: No managers visible from this edge support Acquires, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsAcquireBFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
+    a :#= DontCare
     a.opcode  := TLMessages.AcquireBlock
     a.param   := growPermissions
     a.size    := lgSize
@@ -374,6 +375,7 @@ class TLEdgeOut(
     require (manager.anySupportAcquireB, s"TileLink: No managers visible from this edge support Acquires, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsAcquireBFast(toAddress, lgSize)
     val c = Wire(new TLBundleC(bundle))
+    c :#= DontCare
     c.opcode  := TLMessages.Release
     c.param   := shrinkPermissions
     c.size    := lgSize
@@ -388,6 +390,7 @@ class TLEdgeOut(
     require (manager.anySupportAcquireB, s"TileLink: No managers visible from this edge support Acquires, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsAcquireBFast(toAddress, lgSize)
     val c = Wire(new TLBundleC(bundle))
+    c :#= DontCare
     c.opcode  := TLMessages.ReleaseData
     c.param   := shrinkPermissions
     c.size    := lgSize
@@ -534,6 +537,7 @@ class TLEdgeOut(
     require (manager.anySupportHint, s"TileLink: No managers visible from this edge support Hints, but one of these clients would try to request one: ${client.clients}")
     val legal = manager.supportsHintFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
+    a :#= DontCare
     a.opcode  := TLMessages.Hint
     a.param   := param
     a.size    := lgSize
@@ -548,6 +552,7 @@ class TLEdgeOut(
   def AccessAck(b: TLBundleB): TLBundleC = AccessAck(b.source, address(b), b.size)
   def AccessAck(fromSource: UInt, toAddress: UInt, lgSize: UInt) = {
     val c = Wire(new TLBundleC(bundle))
+    c :#= DontCare
     c.opcode  := TLMessages.AccessAck
     c.param   := 0.U
     c.size    := lgSize
@@ -563,6 +568,7 @@ class TLEdgeOut(
   def AccessAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt): TLBundleC = AccessAck(fromSource, toAddress, lgSize, data, false.B)
   def AccessAck(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, corrupt: Bool) = {
     val c = Wire(new TLBundleC(bundle))
+    c :#= DontCare
     c.opcode  := TLMessages.AccessAckData
     c.param   := 0.U
     c.size    := lgSize
@@ -576,6 +582,7 @@ class TLEdgeOut(
   def HintAck(b: TLBundleB): TLBundleC = HintAck(b.source, address(b), b.size)
   def HintAck(fromSource: UInt, toAddress: UInt, lgSize: UInt) = {
     val c = Wire(new TLBundleC(bundle))
+    c :#= DontCare
     c.opcode  := TLMessages.HintAck
     c.param   := 0.U
     c.size    := lgSize

--- a/src/main/scala/tilelink/ErrorEvaluator.scala
+++ b/src/main/scala/tilelink/ErrorEvaluator.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -20,8 +20,8 @@ object RequestPattern
     val amask = UIntToOH1(a.size, a.params.addressBits)
     val abase = a.address
     pattern.map { case p =>
-      val pbase = UInt(p.base)
-      val pmask = UInt(p.mask & ((BigInt(1) << a.params.addressBits) - 1))
+      val pbase = p.base.U
+      val pmask = (p.mask & ((BigInt(1) << a.params.addressBits) - 1)).U
       (amask | pmask | ~(abase ^ pbase)).andR
     }.reduce(_ || _)
   }
@@ -51,20 +51,20 @@ class TLErrorEvaluator(test: RequestPattern, testOn: Boolean, testOff: Boolean, 
       val (d_first, d_last, _) = edgeOut.firstlast(out.d)
       val d_hasData = edgeOut.hasData(out.d.bits)
 
-      when (in.a.fire()) { inject_map.write(in.a.bits.source, inject_now) }
+      when (in.a.fire) { inject_map.write(in.a.bits.source, inject_now) }
 
-      val bypass = Bool(edgeOut.manager.minLatency == 0) && in.a.fire() && in.a.bits.source === in.d.bits.source
+      val bypass = (edgeOut.manager.minLatency == 0).B && in.a.fire && in.a.bits.source === in.d.bits.source
       val d_inject = Mux(bypass, inject_now, inject_map.read(in.d.bits.source)) holdUnless d_first
       in.d.bits.corrupt := out.d.bits.corrupt || (d_inject &&   d_hasData)
-      in.d.bits.denied  := out.d.bits.denied  || (d_inject && (!d_hasData || Bool(deny)))
+      in.d.bits.denied  := out.d.bits.denied  || (d_inject && (!d_hasData || deny.B))
 
       val r_detect = Reg(Bool())
-      val d_detect = (!d_first && r_detect) || (Bool(!deny) && out.d.bits.corrupt) || out.d.bits.denied
-      when (out.d.fire()) { r_detect := d_detect }
+      val d_detect = (!d_first && r_detect) || ((!deny).B && out.d.bits.corrupt) || out.d.bits.denied
+      when (out.d.fire) { r_detect := d_detect }
 
       val d_hint = out.d.bits.opcode === TLMessages.HintAck // even illegal hints can succeed
-      assert (Bool(!testOn)  || !out.d.fire() || !d_last || !d_inject ||  d_detect || d_hint, "Denied/Corrupt flag was not set!")
-      assert (Bool(!testOff) || !out.d.fire() || !d_last ||  d_inject || !d_detect, "Denied/Corrupt flag was set!")
+      assert ((!testOn).B  || !out.d.fire || !d_last || !d_inject ||  d_detect || d_hint, "Denied/Corrupt flag was not set!")
+      assert ((!testOff).B || !out.d.fire || !d_last ||  d_inject || !d_detect, "Denied/Corrupt flag was set!")
     }
   }
 }

--- a/src/main/scala/tilelink/FIFOFixer.scala
+++ b/src/main/scala/tilelink/FIFOFixer.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.property
@@ -45,15 +46,15 @@ class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Para
       val (fixMap, splatMap) = fifoMap(edgeOut.manager.managers)
 
       // Do we need to serialize the request to this manager?
-      val a_notFIFO = edgeIn.manager.fastProperty(in.a.bits.address, _.fifoId != Some(0), (b:Boolean) => Bool(b))
+      val a_notFIFO = edgeIn.manager.fastProperty(in.a.bits.address, _.fifoId != Some(0), (b:Boolean) => b.B)
       // Compact the IDs of the cases we serialize
       val compacted = ((fixMap zip splatMap) zip edgeOut.manager.managers) flatMap {
         case ((f, s), m) => if (f == Some(0)) Some(m.v1copy(fifoId = s)) else None
       }
       val sinks = if (compacted.exists(_.supportsAcquireB)) edgeOut.manager.endSinkId else 0
-      val a_id = if (compacted.isEmpty) UInt(0) else
+      val a_id = if (compacted.isEmpty) 0.U else
         edgeOut.manager.v1copy(managers = compacted, endSinkId = sinks).findFifoIdFast(in.a.bits.address)
-      val a_noDomain = a_id === UInt(0)
+      val a_noDomain = a_id === 0.U
 
       if (false) {
         println(s"FIFOFixer for: ${edgeIn.client.clients.map(_.name).mkString(", ")}")
@@ -69,19 +70,19 @@ class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Para
 
       // Keep one bit for each source recording if there is an outstanding request that must be made FIFO
       // Sources unused in the stall signal calculation should be pruned by DCE
-      val flight = RegInit(Vec.fill(edgeIn.client.endSourceId) { Bool(false) })
-      when (a_first && in.a.fire()) { flight(in.a.bits.source) := !a_notFIFO }
-      when (d_first && in.d.fire()) { flight(in.d.bits.source) := Bool(false) }
+      val flight = RegInit(VecInit(Seq.fill(edgeIn.client.endSourceId) { false.B }))
+      when (a_first && in.a.fire) { flight(in.a.bits.source) := !a_notFIFO }
+      when (d_first && in.d.fire) { flight(in.d.bits.source) := false.B }
 
       val stalls = edgeIn.client.clients.filter(c => c.requestFifo && c.sourceId.size > 1).map { c =>
         val a_sel = c.sourceId.contains(in.a.bits.source)
-        val id    = RegEnable(a_id, in.a.fire() && a_sel && !a_notFIFO)
+        val id    = RegEnable(a_id, in.a.fire && a_sel && !a_notFIFO)
         val track = flight.slice(c.sourceId.start, c.sourceId.end)
 
         a_sel && a_first && track.reduce(_ || _) && (a_noDomain || id =/= a_id)
       }
 
-      val stall = stalls.foldLeft(Bool(false))(_||_)
+      val stall = stalls.foldLeft(false.B)(_||_)
 
       out.a <> in.a
       in.d <> out.d
@@ -93,26 +94,26 @@ class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Para
         out.c <> in .c
         out.e <> in .e
       } else {
-        in.b.valid := Bool(false)
-        in.c.ready := Bool(true)
-        in.e.ready := Bool(true)
-        out.b.ready := Bool(true)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
+        in.b.valid := false.B
+        in.c.ready := true.B
+        in.e.ready := true.B
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
       }
 
 //Functional cover properties
      
       property.cover(in.a.valid && stall, "COVER FIFOFIXER STALL", "Cover: Stall occured for a valid transaction")
 
-      val SourceIdFIFOed = RegInit(UInt(0, width = edgeIn.client.endSourceId))
-      val SourceIdSet = Wire(init = UInt(0, width = edgeIn.client.endSourceId))
-      val SourceIdClear = Wire(init = UInt(0, width = edgeIn.client.endSourceId))
+      val SourceIdFIFOed = RegInit(0.U(edgeIn.client.endSourceId.W))
+      val SourceIdSet = WireDefault(0.U(edgeIn.client.endSourceId.W))
+      val SourceIdClear = WireDefault(0.U(edgeIn.client.endSourceId.W))
 
-      when (a_first && in.a.fire() && !a_notFIFO)  {
+      when (a_first && in.a.fire && !a_notFIFO)  {
         SourceIdSet := UIntToOH(in.a.bits.source)
       }
-      when (d_first && in.d.fire())  {
+      when (d_first && in.d.fire)  {
         SourceIdClear := UIntToOH(in.d.bits.source)
       }
 

--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 
@@ -60,12 +60,12 @@ class TLFilter(
 
       // In case the inner interface removes Acquire, tie-off the channels
       if (!edgeIn.manager.anySupportAcquireB) {
-        in.b.valid := Bool(false)
-        in.c.ready := Bool(true)
-        in.e.ready := Bool(true)
-        out.b.ready := Bool(true)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
+        in.b.valid := false.B
+        in.c.ready := true.B
+        in.e.ready := true.B
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
       }
     }
   }

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -187,12 +188,12 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         // Whatever toggle bit the D is reassembling, A will use the opposite.
 
         // First, handle the return path
-        val acknum = RegInit(UInt(0, width = counterBits))
+        val acknum = RegInit(0.U(counterBits.W))
         val dOrig = Reg(UInt())
-        val dToggle = RegInit(Bool(false))
+        val dToggle = RegInit(false.B)
         val dFragnum = out.d.bits.source(fragmentBits-1, 0)
-        val dFirst = acknum === UInt(0)
-        val dLast = dFragnum === UInt(0) // only for AccessAck (!Data)
+        val dFirst = acknum === 0.U
+        val dLast = dFragnum === 0.U // only for AccessAck (!Data)
         val dsizeOH  = UIntToOH (out.d.bits.size, log2Ceil(maxDownSize)+1)
         val dsizeOH1 = UIntToOH1(out.d.bits.size, log2Up(maxDownSize))
         val dHasData = edgeOut.hasData(out.d.bits)
@@ -200,13 +201,13 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         // calculate new acknum
         val acknum_fragment = dFragnum << log2Ceil(minSize/beatBytes)
         val acknum_size = dsizeOH1 >> log2Ceil(beatBytes)
-        assert (!out.d.valid || (acknum_fragment & acknum_size) === UInt(0))
-        val dFirst_acknum = acknum_fragment | Mux(dHasData, acknum_size, UInt(0))
-        val ack_decrement = Mux(dHasData, UInt(1), dsizeOH >> log2Ceil(beatBytes))
+        assert (!out.d.valid || (acknum_fragment & acknum_size) === 0.U)
+        val dFirst_acknum = acknum_fragment | Mux(dHasData, acknum_size, 0.U)
+        val ack_decrement = Mux(dHasData, 1.U, dsizeOH >> log2Ceil(beatBytes))
         // calculate the original size
         val dFirst_size = OH1ToUInt((dFragnum << log2Ceil(minSize)) | dsizeOH1)
 
-        when (out.d.fire()) {
+        when (out.d.fire) {
           acknum := Mux(dFirst, dFirst_acknum, acknum - ack_decrement)
           when (dFirst) {
             dOrig := dFirst_size
@@ -216,9 +217,9 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
 
         // Swallow up non-data ack fragments
         val doEarlyAck = earlyAck match {
-          case EarlyAck.AllPuts  => Bool(true)
+          case EarlyAck.AllPuts  => true.B
           case EarlyAck.PutFulls => out.d.bits.source(fragmentBits+1)
-          case EarlyAck.None     => Bool(false)
+          case EarlyAck.None     => false.B
         }
         val drop = !dHasData && !Mux(doEarlyAck, dFirst, dLast)
         out.d.ready := in.d.ready || drop
@@ -230,7 +231,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         if (edgeOut.manager.mayDenyPut) {
           val r_denied = Reg(Bool())
           val d_denied = (!dFirst && r_denied) || out.d.bits.denied
-          when (out.d.fire()) { r_denied := d_denied }
+          when (out.d.fire) { r_denied := d_denied }
           in.d.bits.denied := d_denied
         }
         if (edgeOut.manager.mayDenyGet) {
@@ -251,13 +252,13 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         val maxHints       = managers.map(m => if (m.supportsHint) maxDownSize else 0)
 
         // We assume that the request is valid => size 0 is impossible
-        val lgMinSize = UInt(log2Ceil(minSize))
-        val maxLgArithmetics = maxArithmetics.map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-        val maxLgLogicals    = maxLogicals   .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-        val maxLgGets        = maxGets       .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-        val maxLgPutFulls    = maxPutFulls   .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-        val maxLgPutPartials = maxPutPartials.map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-        val maxLgHints       = maxHints      .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
+        val lgMinSize = log2Ceil(minSize).U
+        val maxLgArithmetics = maxArithmetics.map(m => if (m == 0) lgMinSize else log2Ceil(m).U)
+        val maxLgLogicals    = maxLogicals   .map(m => if (m == 0) lgMinSize else log2Ceil(m).U)
+        val maxLgGets        = maxGets       .map(m => if (m == 0) lgMinSize else log2Ceil(m).U)
+        val maxLgPutFulls    = maxPutFulls   .map(m => if (m == 0) lgMinSize else log2Ceil(m).U)
+        val maxLgPutPartials = maxPutPartials.map(m => if (m == 0) lgMinSize else log2Ceil(m).U)
+        val maxLgHints       = maxHints      .map(m => if (m == 0) lgMinSize else log2Ceil(m).U)
 
         // Make the request repeatable
         val repeater = Module(new Repeater(in.a.bits))
@@ -287,40 +288,40 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         val aOrigOH1 = UIntToOH1(aOrig, log2Ceil(maxSize))
         val aFragOH1 = UIntToOH1(aFrag, log2Up(maxDownSize))
         val aHasData = edgeIn.hasData(in_a.bits)
-        val aMask = Mux(aHasData, UInt(0), aFragOH1)
+        val aMask = Mux(aHasData, 0.U, aFragOH1)
 
-        val gennum = RegInit(UInt(0, width = counterBits))
-        val aFirst = gennum === UInt(0)
-        val old_gennum1 = Mux(aFirst, aOrigOH1 >> log2Ceil(beatBytes), gennum - UInt(1))
+        val gennum = RegInit(0.U(counterBits.W))
+        val aFirst = gennum === 0.U
+        val old_gennum1 = Mux(aFirst, aOrigOH1 >> log2Ceil(beatBytes), gennum - 1.U)
         val new_gennum = ~(~old_gennum1 | (aMask >> log2Ceil(beatBytes))) // ~(~x|y) is width safe
         val aFragnum = ~(~(old_gennum1 >> log2Ceil(minSize/beatBytes)) | (aFragOH1 >> log2Ceil(minSize)))
-        val aLast = aFragnum === UInt(0)
+        val aLast = aFragnum === 0.U
         val aToggle = !Mux(aFirst, dToggle, RegEnable(dToggle, aFirst))
         val aFull = if (earlyAck == EarlyAck.PutFulls) Some(in_a.bits.opcode === TLMessages.PutFullData) else None
 
-        when (out.a.fire()) { gennum := new_gennum }
+        when (out.a.fire) { gennum := new_gennum }
 
-        repeater.io.repeat := !aHasData && aFragnum =/= UInt(0)
+        repeater.io.repeat := !aHasData && aFragnum =/= 0.U
         out.a <> in_a
-        out.a.bits.address := in_a.bits.address | ~(old_gennum1 << log2Ceil(beatBytes) | ~aOrigOH1 | aFragOH1 | UInt(minSize-1))
+        out.a.bits.address := in_a.bits.address | ~(old_gennum1 << log2Ceil(beatBytes) | ~aOrigOH1 | aFragOH1 | (minSize-1).U)
         out.a.bits.source := Cat(Seq(in_a.bits.source) ++ aFull ++ Seq(aToggle.asUInt, aFragnum))
         out.a.bits.size := aFrag
 
         // Optimize away some of the Repeater's registers
         assert (!repeater.io.full || !aHasData)
         out.a.bits.data := in.a.bits.data
-        val fullMask = UInt((BigInt(1) << beatBytes) - 1)
+        val fullMask = ((BigInt(1) << beatBytes) - 1).U
         assert (!repeater.io.full || in_a.bits.mask === fullMask)
         out.a.bits.mask := Mux(repeater.io.full, fullMask, in.a.bits.mask)
         out.a.bits.user.partialAssignL(in.a.bits.user.subset(_.isData))
 
         // Tie off unused channels
-        in.b.valid := Bool(false)
-        in.c.ready := Bool(true)
-        in.e.ready := Bool(true)
-        out.b.ready := Bool(true)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
+        in.b.valid := false.B
+        in.c.ready := true.B
+        in.e.ready := true.B
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
       }
     }
   }

--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -11,25 +12,25 @@ class IDMapGenerator(numIds: Int) extends Module {
   require (numIds > 0)
 
   val w = log2Up(numIds)
-  val io = new Bundle {
-    val free = Decoupled(UInt(width = w)).flip
-    val alloc = Decoupled(UInt(width = w))
-  }
+  val io = IO(new Bundle {
+    val free = Flipped(Decoupled(UInt(w.W)))
+    val alloc = Decoupled(UInt(w.W))
+  })
 
-  io.free.ready := Bool(true)
+  io.free.ready := true.B
 
   // True indicates that the id is available
-  val bitmap = RegInit(UInt((BigInt(1) << numIds) -  1, width = numIds))
+  val bitmap = RegInit(((BigInt(1) << numIds) -  1).U(numIds.W))
 
   val select = ~(leftOR(bitmap) << 1) & bitmap
   io.alloc.bits := OHToUInt(select)
   io.alloc.valid := bitmap.orR
 
-  val clr = Wire(init = UInt(0, width = numIds))
-  when (io.alloc.fire()) { clr := UIntToOH(io.alloc.bits) }
+  val clr = WireDefault(0.U(numIds.W))
+  when (io.alloc.fire) { clr := UIntToOH(io.alloc.bits) }
 
-  val set = Wire(init = UInt(0, width = numIds))
-  when (io.free.fire()) { set := UIntToOH(io.free.bits) }
+  val set = WireDefault(0.U(numIds.W))
+  when (io.free.fire) { set := UIntToOH(io.free.bits) }
 
   bitmap := (bitmap & ~clr) | set
   assert (!io.free.valid || !(bitmap & ~clr)(io.free.bits)) // No double freeing
@@ -37,13 +38,13 @@ class IDMapGenerator(numIds: Int) extends Module {
 
 object LFSR64
 { 
-  def apply(increment: Bool = Bool(true)): UInt =
+  def apply(increment: Bool = true.B): UInt =
   { 
     val wide = 64
-    val lfsr = Reg(UInt(width = wide)) // random initial value based on simulation seed
+    val lfsr = Reg(UInt(wide.W)) // random initial value based on simulation seed
     val xor = lfsr(0) ^ lfsr(1) ^ lfsr(3) ^ lfsr(4)
     when (increment) {
-      lfsr := Mux(lfsr === UInt(0), UInt(1), Cat(xor, lfsr(wide-1,1)))
+      lfsr := Mux(lfsr === 0.U, 1.U, Cat(xor, lfsr(wide-1,1)))
     }
     lfsr
   }
@@ -51,10 +52,10 @@ object LFSR64
 
 trait HasNoiseMakerIO
 {
-  val io = new Bundle {
-    val inc = Bool(INPUT)
-    val random = UInt(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val inc = Input(Bool())
+    val random = Output(UInt())
+  })
 }
 
 class LFSRNoiseMaker(wide: Int) extends Module with HasNoiseMakerIO
@@ -64,7 +65,7 @@ class LFSRNoiseMaker(wide: Int) extends Module with HasNoiseMakerIO
 }
 
 object LFSRNoiseMaker {
-  def apply(wide: Int, increment: Bool = Bool(true)): UInt = {
+  def apply(wide: Int, increment: Bool = true.B): UInt = {
     val nm = Module(new LFSRNoiseMaker(wide))
     nm.io.inc := increment
     nm.io.random
@@ -111,7 +112,7 @@ class TLFuzzer(
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val finished = Bool(OUTPUT)
+      val finished = Output(Bool())
     })
 
     val (out, edge) = node.out(0)
@@ -125,12 +126,12 @@ class TLFuzzer(
     val dataBits     = edge.bundle.dataBits
 
     // Progress through operations
-    val num_reqs = Reg(init = UInt(nOperations, log2Up(nOperations+1)))
-    val num_resps = Reg(init = UInt(nOperations, log2Up(nOperations+1)))
+    val num_reqs = RegInit(nOperations.U(log2Up(nOperations+1).W))
+    val num_resps = RegInit(nOperations.U(log2Up(nOperations+1).W))
     if (nOperations>0) {
-      io.finished := num_resps === UInt(0)
+      io.finished := num_resps === 0.U
     } else {
-      io.finished := Bool(false)
+      io.finished := false.B
     }
 
     // Progress within each operation
@@ -147,9 +148,9 @@ class TLFuzzer(
     val inc = Wire(Bool())
     val inc_beat = Wire(Bool())
     val arth_op_3 = noiseMaker(3, inc, 0)
-    val arth_op   = Mux(arth_op_3 > UInt(4), UInt(4), arth_op_3)
+    val arth_op   = Mux(arth_op_3 > 4.U, 4.U, arth_op_3)
     val log_op    = noiseMaker(2, inc, 0)
-    val amo_size  = UInt(2) + noiseMaker(1, inc, 0) // word or dword
+    val amo_size  = 2.U + noiseMaker(1, inc, 0) // word or dword
     val size      = noiseMaker(sizeBits, inc, 0)
     val rawAddr   = noiseMaker(addressBits, inc, 2)
     val addr      = overrideAddress.map(_.legalize(rawAddr)).getOrElse(rawAddr) & ~UIntToOH1(size, addressBits)
@@ -171,7 +172,7 @@ class TLFuzzer(
                              edge.Logical(src, addr, size, data, log_op)
                             } else { (glegal, gbits) }
     val (hlegal,  hbits)  = if(edge.manager.anySupportHint) {
-                              edge.Hint(src, addr, size, UInt(0))
+                              edge.Hint(src, addr, size, 0.U)
                             } else { (glegal, gbits) }
 
     val legal_dest = edge.manager.containsSafe(addr)
@@ -180,45 +181,45 @@ class TLFuzzer(
     val a_type_sel  = noiseMaker(3, inc, 0)
 
     val legal = legal_dest && MuxLookup(a_type_sel, glegal, Seq(
-      UInt("b000") -> glegal,
-      UInt("b001") -> (pflegal && !Bool(noModify)),
-      UInt("b010") -> (pplegal && !Bool(noModify)),
-      UInt("b011") -> (alegal && !Bool(noModify)),
-      UInt("b100") -> (llegal && !Bool(noModify)),
-      UInt("b101") -> hlegal))
+      "b000".U -> glegal,
+      "b001".U -> (pflegal && !noModify.B),
+      "b010".U -> (pplegal && !noModify.B),
+      "b011".U -> (alegal && !noModify.B),
+      "b100".U -> (llegal && !noModify.B),
+      "b101".U -> hlegal))
 
     val bits = MuxLookup(a_type_sel, gbits, Seq(
-      UInt("b000") -> gbits,
-      UInt("b001") -> pfbits,
-      UInt("b010") -> ppbits,
-      UInt("b011") -> abits,
-      UInt("b100") -> lbits,
-      UInt("b101") -> hbits))
+      "b000".U -> gbits,
+      "b001".U -> pfbits,
+      "b010".U -> ppbits,
+      "b011".U -> abits,
+      "b100".U -> lbits,
+      "b101".U -> hbits))
 
     // Wire up Fuzzer flow control
-    val a_gen = if (nOperations>0) num_reqs =/= UInt(0) else Bool(true)
-    out.a.valid := !reset && a_gen && legal && (!a_first || idMap.io.alloc.valid)
+    val a_gen = if (nOperations>0) num_reqs =/= 0.U else true.B
+    out.a.valid := !reset.asBool && a_gen && legal && (!a_first || idMap.io.alloc.valid)
     idMap.io.alloc.ready := a_gen && legal && a_first && out.a.ready
-    idMap.io.free.valid := d_first && out.d.fire()
+    idMap.io.free.valid := d_first && out.d.fire
     idMap.io.free.bits := out.d.bits.source
 
     out.a.bits  := bits
-    out.b.ready := Bool(true)
-    out.c.valid := Bool(false)
-    out.d.ready := Bool(true)
-    out.e.valid := Bool(false)
+    out.b.ready := true.B
+    out.c.valid := false.B
+    out.d.ready := true.B
+    out.e.valid := false.B
 
     // Increment the various progress-tracking states
     inc := !legal || req_done
-    inc_beat := !legal || out.a.fire()
+    inc_beat := !legal || out.a.fire
 
     if (nOperations>0) {
-      when (out.a.fire() && a_last) {
-        num_reqs := num_reqs - UInt(1)
+      when (out.a.fire && a_last) {
+        num_reqs := num_reqs - 1.U
       }
 
-      when (out.d.fire() && d_last) {
-        num_resps := num_resps - UInt(1)
+      when (out.d.fire && d_last) {
+        num_resps := num_resps - 1.U
       }
     }
   }

--- a/src/main/scala/tilelink/Jbar.scala
+++ b/src/main/scala/tilelink/Jbar.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.diplomacy._
 

--- a/src/main/scala/tilelink/Map.scala
+++ b/src/main/scala/tilelink/Map.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 
@@ -23,9 +23,9 @@ class TLMap(fn: AddressSet => BigInt)(implicit p: Parameters) extends LazyModule
       out <> in
       val convert = edgeIn.manager.managers.flatMap(_.address) zip edgeOut.manager.managers.flatMap(_.address)
       def forward(x: UInt) =
-        convert.map { case (i, o) => Mux(i.contains(x), UInt(o.base) | (x & UInt(o.mask)), UInt(0)) }.reduce(_ | _)
+        convert.map { case (i, o) => Mux(i.contains(x), o.base.U | (x & o.mask.U), 0.U) }.reduce(_ | _)
       def backward(x: UInt) =
-        convert.map { case (i, o) => Mux(o.contains(x), UInt(i.base) | (x & UInt(i.mask)), UInt(0)) }.reduce(_ | _)
+        convert.map { case (i, o) => Mux(o.contains(x), i.base.U | (x & i.mask.U), 0.U) }.reduce(_ | _)
 
       out.a.bits.address := forward(in.a.bits.address)
       if (edgeOut.manager.anySupportAcquireB && edgeOut.client.anySupportProbe) {

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.internal.sourceinfo.SourceInfo
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -595,11 +596,11 @@ class TLSlavePortParameters private(
   def find(address: BigInt) = slaves.find(_.address.exists(_.contains(address)))
 
   // The safe version will check the entire address
-  def findSafe(address: UInt) = Vec(slaves.map(_.address.map(_.contains(address)).reduce(_ || _)))
+  def findSafe(address: UInt) = VecInit(slaves.map(_.address.map(_.contains(address)).reduce(_ || _)))
   // The fast version assumes the address is valid (you probably want fastProperty instead of this function)
   def findFast(address: UInt) = {
     val routingMask = AddressDecoder(slaves.map(_.address))
-    Vec(slaves.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
+    VecInit(slaves.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
   }
 
   // Compute the simplest AddressSets that decide a key
@@ -615,8 +616,8 @@ class TLSlavePortParameters private(
     Mux1H(fastPropertyGroup(p).map { case (v, a) => (a.map(_.contains(address)).reduce(_||_), d(v)) })
 
   // Note: returns the actual fifoId + 1 or 0 if None
-  def findFifoIdFast(address: UInt) = fastProperty(address, _.fifoId.map(_+1).getOrElse(0), (i:Int) => UInt(i))
-  def hasFifoIdFast(address: UInt) = fastProperty(address, _.fifoId.isDefined, (b:Boolean) => Bool(b))
+  def findFifoIdFast(address: UInt) = fastProperty(address, _.fifoId.map(_+1).getOrElse(0), (i:Int) => i.U)
+  def hasFifoIdFast(address: UInt) = fastProperty(address, _.fifoId.isDefined, (b:Boolean) => b.B)
 
   // Does this Port manage this ID/address?
   def containsSafe(address: UInt) = findSafe(address).reduce(_ || _)
@@ -667,9 +668,9 @@ class TLSlavePortParameters private(
     simplified.map { case (s, a) =>
     // s is a size, you are checking for this size either the size of the operation is in s
     // We return an or-reduction of all the cases, checking whether any contains both the dynamic size and dynamic address on the wire.
-      (Bool(Some(s) == range) || s.containsLg(lgSize)) &&
+      ((Some(s) == range).B || s.containsLg(lgSize)) &&
       a.map(_.contains(address)).reduce(_||_)
-    }.foldLeft(Bool(false))(_||_)
+    }.foldLeft(false.B)(_||_)
   }
 
   def supportsAcquireTSafe   (address: UInt, lgSize: UInt, range: Option[TransferSizes] = None) = addressHelper(true, _.supports.acquireT,   address, lgSize, range)
@@ -1121,10 +1122,10 @@ class TLMasterPortParameters private(
   def find(id: Int) = masters.find(_.sourceId.contains(id))
 
   // Synthesizable lookup methods
-  def find(id: UInt) = Vec(masters.map(_.sourceId.contains(id)))
+  def find(id: UInt) = VecInit(masters.map(_.sourceId.contains(id)))
   def contains(id: UInt) = find(id).reduce(_ || _)
 
-  def requestFifo(id: UInt) = Mux1H(find(id), masters.map(c => Bool(c.requestFifo)))
+  def requestFifo(id: UInt) = Mux1H(find(id), masters.map(c => c.requestFifo.B))
 
   // Available during RTL runtime, checks to see if (id, size) is supported by the master's (client's) diplomatic parameters
   private def sourceIdHelper(member: TLMasterParameters => TransferSizes)(id: UInt, lgSize: UInt) = {
@@ -1159,7 +1160,7 @@ class TLMasterPortParameters private(
     emitCases.map { case (s, a) =>
       (s.containsLg(lgSize)) &&
       a.map(_.contains(sourceId)).reduce(_||_)
-    }.foldLeft(Bool(false))(_||_)
+    }.foldLeft(false.B)(_||_)
   }
 
   // Check for emit of a given operation at a specific id

--- a/src/main/scala/tilelink/PatternPusher.scala
+++ b/src/main/scala/tilelink/PatternPusher.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -18,17 +19,17 @@ trait Pattern {
 case class WritePattern(address: BigInt, size: Int, data: BigInt) extends Pattern
 {
   require (0 <= data && data < (BigInt(1) << (8 << size)))
-  def bits(edge: TLEdgeOut) = edge.Put(UInt(0), UInt(address), UInt(size), UInt(data << (8*(address % edge.manager.beatBytes).toInt)))
+  def bits(edge: TLEdgeOut) = edge.Put(0.U, address.U, size.U, (data << (8*(address % edge.manager.beatBytes).toInt)).U)
 }
 
 case class ReadPattern(address: BigInt, size: Int) extends Pattern
 {
-  def bits(edge: TLEdgeOut) = edge.Get(UInt(0), UInt(address), UInt(size))
+  def bits(edge: TLEdgeOut) = edge.Get(0.U, address.U, size.U)
 }
 
 case class ReadExpectPattern(address: BigInt, size: Int, data: BigInt) extends Pattern
 {
-  def bits(edge: TLEdgeOut) = edge.Get(UInt(0), UInt(address), UInt(size))
+  def bits(edge: TLEdgeOut) = edge.Get(0.U, address.U, size.U)
   override def dataIn = Some(data)
 }
 
@@ -39,8 +40,8 @@ class TLPatternPusher(name: String, pattern: Seq[Pattern])(implicit p: Parameter
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val run = Bool(INPUT)
-      val done = Bool(OUTPUT)
+      val run = Input(Bool())
+      val done = Output(Bool())
     })
 
     val (tl_out, edgeOut) = node.out(0)
@@ -48,40 +49,40 @@ class TLPatternPusher(name: String, pattern: Seq[Pattern])(implicit p: Parameter
       require (p.size <= log2Ceil(edgeOut.manager.beatBytes), "Patterns must fit in a single beat")
     }
 
-    val step   = RegInit(UInt(0, width = log2Ceil(pattern.size+1)))
-    val flight = RegInit(Bool(false))
-    val ready  = RegNext(Bool(true), Bool(false))
+    val step   = RegInit(0.U(log2Ceil(pattern.size+1).W))
+    val flight = RegInit(false.B)
+    val ready  = RegNext(true.B, false.B)
 
-    val end = step === UInt(pattern.size)
+    val end = step === pattern.size.U
     io.done := end && !flight
 
     val a = tl_out.a
     val d = tl_out.d
 
     // Expected response?
-    val check  = Vec(pattern.map(p => Bool(p.dataIn.isDefined)))(step) holdUnless a.fire()
-    val expect = Vec(pattern.map(p => UInt(p.dataIn.getOrElse(BigInt(0)))))(step) holdUnless a.fire()
-    assert (!check || !d.fire() || expect === d.bits.data)
+    val check  = VecInit(pattern.map(p => p.dataIn.isDefined.B))(step) holdUnless a.fire
+    val expect = VecInit(pattern.map(p => p.dataIn.getOrElse(BigInt(0)).U))(step) holdUnless a.fire
+    assert (!check || !d.fire || expect === d.bits.data)
 
-    when (a.fire()) {
-      flight := Bool(true)
-      step := step + UInt(1)
+    when (a.fire) {
+      flight := true.B
+      step := step + 1.U
     }
-    when (d.fire()) {
-      flight := Bool(false)
+    when (d.fire) {
+      flight := false.B
     }
 
     val (plegal, pbits) = pattern.map(_.bits(edgeOut)).unzip
-    assert (end || Vec(plegal)(step), s"Pattern pusher ${name} tried to push an illegal request")
+    assert (end || VecInit(plegal)(step), s"Pattern pusher ${name} tried to push an illegal request")
 
     a.valid := io.run && ready && !end && !flight
-    a.bits  := Vec(pbits)(step)
-    d.ready := Bool(true)
+    a.bits  := VecInit(pbits)(step)
+    d.ready := true.B
 
     // Tie off unused channels
-    tl_out.b.ready := Bool(true)
-    tl_out.c.valid := Bool(false)
-    tl_out.e.valid := Bool(false)
+    tl_out.b.ready := true.B
+    tl_out.c.valid := false.B
+    tl_out.e.valid := false.B
   }
 }
 

--- a/src/main/scala/tilelink/RAMModel.scala
+++ b/src/main/scala/tilelink/RAMModel.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -44,7 +45,7 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
       val divisor      = CRC.CRC_16F_4_2
 
       // Reset control logic
-      val wipeIndex = RegInit(UInt(0, width = log2Ceil(endAddressHi) + 1))
+      val wipeIndex = RegInit(0.U((log2Ceil(endAddressHi) + 1).W))
       val wipe = !wipeIndex(log2Ceil(endAddressHi))
       wipeIndex := wipeIndex + wipe.asUInt
 
@@ -57,27 +58,27 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
       in.d.bits  := out.d.bits
 
       // BCE unsupported
-      in.b.valid := Bool(false)
-      out.c.valid := Bool(false)
-      out.e.valid := Bool(false)
-      out.b.ready := Bool(true)
-      in.c.ready := Bool(true)
-      in.e.ready := Bool(true)
+      in.b.valid := false.B
+      out.c.valid := false.B
+      out.e.valid := false.B
+      out.b.ready := true.B
+      in.c.ready := true.B
+      in.e.ready := true.B
 
       val params = TLRAMModel.MonitorParameters(addressBits, sizeBits)
 
       // Infer as simple dual port BRAM/M10k with write-first/new-data semantics (bypass needed)
       val shadow = Seq.fill(beatBytes) { Mem(endAddressHi, new TLRAMModel.ByteMonitor(params)) }
-      val inc_bytes = Seq.fill(beatBytes) { Mem(endAddressHi, UInt(width = countBits)) }
-      val dec_bytes = Seq.fill(beatBytes) { Mem(endAddressHi, UInt(width = countBits)) }
-      val inc_trees = Seq.tabulate(decTrees) { i => Mem(endAddressHi >> (i+1), UInt(width = countBits)) }
-      val dec_trees = Seq.tabulate(decTrees) { i => Mem(endAddressHi >> (i+1), UInt(width = countBits)) }
+      val inc_bytes = Seq.fill(beatBytes) { Mem(endAddressHi, UInt(countBits.W)) }
+      val dec_bytes = Seq.fill(beatBytes) { Mem(endAddressHi, UInt(countBits.W)) }
+      val inc_trees = Seq.tabulate(decTrees) { i => Mem(endAddressHi >> (i+1), UInt(countBits.W)) }
+      val dec_trees = Seq.tabulate(decTrees) { i => Mem(endAddressHi >> (i+1), UInt(countBits.W)) }
 
-      val shadow_wen = Wire(init = Fill(beatBytes, wipe))
-      val inc_bytes_wen = Wire(init = Fill(beatBytes, wipe))
-      val dec_bytes_wen = Wire(init = Fill(beatBytes, wipe))
-      val inc_trees_wen = Wire(init = Fill(decTrees, wipe))
-      val dec_trees_wen = Wire(init = Fill(decTrees, wipe))
+      val shadow_wen = WireDefault(Fill(beatBytes, wipe))
+      val inc_bytes_wen = WireDefault(Fill(beatBytes, wipe))
+      val dec_bytes_wen = WireDefault(Fill(beatBytes, wipe))
+      val inc_trees_wen = WireDefault(Fill(decTrees, wipe))
+      val dec_trees_wen = WireDefault(Fill(decTrees, wipe))
 
       // This must be registers b/c we build a CAM from it
       val flight = Reg(Vec(endSourceId, new TLRAMModel.FlightMonitor(params)))
@@ -89,13 +90,13 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
       a_flight.size   := edge.size(in.a.bits)
       a_flight.opcode := in.a.bits.opcode
 
-      when (in.a.fire()) { flight(in.a.bits.source) := a_flight }
-      val bypass = if (edge.manager.minLatency > 0) Bool(false) else in.a.valid && in.a.bits.source === out.d.bits.source
+      when (in.a.fire) { flight(in.a.bits.source) := a_flight }
+      val bypass = if (edge.manager.minLatency > 0) false.B else in.a.valid && in.a.bits.source === out.d.bits.source
       val d_flight = RegEnable(Mux(bypass, a_flight, flight(out.d.bits.source)), edge.first(out.d))
 
       // Process A access requests
-      val a = Reg(next = in.a.bits)
-      val a_fire = Reg(next = in.a.fire(), init = Bool(false))
+      val a = RegNext(in.a.bits)
+      val a_fire = RegNext(in.a.fire, false.B)
       val (a_first, a_last, _, a_address_inc) = edge.addr_inc(a, a_fire)
       val a_size = edge.size(a)
       val a_sizeOH = UIntToOH(a_size)
@@ -110,8 +111,8 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
       val a_dec_bytes = dec_bytes.map(_.read(a_addr_hi))
       val a_inc_trees = inc_trees.zipWithIndex.map{ case (m, i) => m.read(a_addr_hi >> (i+1)) }
       val a_dec_trees = dec_trees.zipWithIndex.map{ case (m, i) => m.read(a_addr_hi >> (i+1)) }
-      val a_inc_tree = a_inc_trees.fold(UInt(0))(_ + _)
-      val a_dec_tree = a_dec_trees.fold(UInt(0))(_ + _)
+      val a_inc_tree = a_inc_trees.fold(0.U)(_ + _)
+      val a_dec_tree = a_dec_trees.fold(0.U)(_ + _)
       val a_inc = a_inc_bytes.map(_ + a_inc_tree)
       val a_dec = a_dec_bytes.map(_ + a_dec_tree)
 
@@ -120,11 +121,11 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
         assert (a.opcode =/= TLMessages.AcquireBlock && a.opcode =/= TLMessages.AcquirePerm)
 
         // Mark the operation as valid
-        valid(a.source) := Bool(true)
+        valid(a.source) := true.B
 
         // Increase the per-byte flight counter for the whole transaction
         when (a_first && a.opcode =/= TLMessages.Hint && a.opcode =/= TLMessages.Get) {
-          when (a_size <= UInt(shift)) {
+          when (a_size <= shift.U) {
             inc_bytes_wen := a_mask
           }
           inc_trees_wen := a_sizeOH >> (shift+1)
@@ -142,7 +143,7 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
               when (a.opcode === TLMessages.PutPartialData) { printf("PP") }
               when (a.opcode === TLMessages.ArithmeticData) { printf("A ") }
               when (a.opcode === TLMessages.LogicalData) { printf("L ") }
-              printf(" 0x%x := 0x%x #%d %x\n", a_addr_hi << shift | UInt(i), byte, busy, a.param)
+              printf(" 0x%x := 0x%x #%d %x\n", a_addr_hi << shift | i.U, byte, busy, a.param)
             }
           }
         }
@@ -156,16 +157,16 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
       val a_shadow = shadow.map(_.read(a_waddr))
       val a_known_old = !(Cat(a_shadow.map(!_.valid).reverse) & a_mask).orR
       val alu = Module(new Atomics(a.params))
-      alu.io.write := Bool(false)
+      alu.io.write := false.B
       alu.io.a := a
       alu.io.data_in := Cat(a_shadow.map(_.value).reverse)
 
-      val crc = Mem(endSourceId, UInt(width = 16))
+      val crc = Mem(endSourceId, UInt(16.W))
       val crc_valid = Mem(endSourceId, Bool())
-      val a_crc_acc = Mux(a_first, UInt(0), crc(a.source))
-      val a_crc_new = Cat(a_shadow.zipWithIndex.map { case (z, i) => Mux(a_mask(i), z.value, UInt(0)) }.reverse)
+      val a_crc_acc = Mux(a_first, 0.U, crc(a.source))
+      val a_crc_new = Cat(a_shadow.zipWithIndex.map { case (z, i) => Mux(a_mask(i), z.value, 0.U) }.reverse)
       val a_crc = CRC(divisor, Cat(a_crc_acc, a_crc_new), 16 + beatBytes*8)
-      val a_crc_valid = a_known_old && Mux(a_first, Bool(true), crc_valid(a.source))
+      val a_crc_valid = a_known_old && Mux(a_first, true.B, crc_valid(a.source))
       when (a_fire) {
         crc.write(a.source, a_crc)
         crc_valid.write(a.source, a_crc_valid)
@@ -175,8 +176,8 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
         val data = Wire(new TLRAMModel.ByteMonitor(params))
         val busy = a_inc(i) =/= a_dec(i) + (!a_first).asUInt
         val amo = a.opcode === TLMessages.ArithmeticData || a.opcode === TLMessages.LogicalData
-        val beat_amo = a.size <= UInt(log2Ceil(beatBytes))
-        data.valid := Mux(wipe, Bool(false), (!busy || a_fifo) && (!amo || (a_known_old && beat_amo)))
+        val beat_amo = a.size <= log2Ceil(beatBytes).U
+        data.valid := Mux(wipe, false.B, (!busy || a_fifo) && (!amo || (a_known_old && beat_amo)))
         data.value := alu.io.data_out(8*(i+1)-1, 8*i)
         when (shadow_wen(i)) {
           shadow(i).write(a_waddr, data)
@@ -184,14 +185,14 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
       }
 
       for (i <- 0 until beatBytes) {
-        val data = Mux(wipe, UInt(0), a_inc_bytes(i) + UInt(1))
+        val data = Mux(wipe, 0.U, a_inc_bytes(i) + 1.U)
         when (inc_bytes_wen(i)) {
           inc_bytes(i).write(a_waddr, data)
         }
       }
 
       for (i <- 0 until inc_trees.size) {
-        val data = Mux(wipe, UInt(0), a_inc_trees(i) + UInt(1))
+        val data = Mux(wipe, 0.U, a_inc_trees(i) + 1.U)
         when (inc_trees_wen(i)) {
           inc_trees(i).write(a_waddr >> (i+1), data)
         }
@@ -199,7 +200,7 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
 
       // Process D access responses
       val d = RegNext(out.d.bits)
-      val d_fire = Reg(next = out.d.fire(), init = Bool(false))
+      val d_fire = RegNext(out.d.fire, false.B)
       val (d_first, d_last, _, d_address_inc) = edge.addr_inc(d, d_fire)
       val d_size = edge.size(d)
       val d_sizeOH = UIntToOH(d_size)
@@ -214,24 +215,24 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
       val d_dec_bytes = dec_bytes.map(_.read(d_addr_hi))
       val d_inc_trees = inc_trees.zipWithIndex.map{ case (m, i) => m.read(d_addr_hi >> (i+1)) }
       val d_dec_trees = dec_trees.zipWithIndex.map{ case (m, i) => m.read(d_addr_hi >> (i+1)) }
-      val d_inc_tree = d_inc_trees.fold(UInt(0))(_ + _)
-      val d_dec_tree = d_dec_trees.fold(UInt(0))(_ + _)
+      val d_inc_tree = d_inc_trees.fold(0.U)(_ + _)
+      val d_dec_tree = d_dec_trees.fold(0.U)(_ + _)
       val d_inc = d_inc_bytes.map(_ + d_inc_tree)
       val d_dec = d_dec_bytes.map(_ + d_dec_tree)
       val d_shadow = shadow.map(_.read(d_addr_hi))
       val d_valid = valid(d.source) holdUnless d_first
 
       // CRC check
-      val d_crc_reg = Reg(UInt(width = 16))
-      val d_crc_acc = Mux(d_first, UInt(0), d_crc_reg)
+      val d_crc_reg = Reg(UInt(16.W))
+      val d_crc_acc = Mux(d_first, 0.U, d_crc_reg)
       val d_crc_new = FillInterleaved(8, d_mask) & d.data
       val d_crc = CRC(divisor, Cat(d_crc_acc, d_crc_new), 16 + beatBytes*8)
-      val crc_bypass = if (edge.manager.minLatency > 0) Bool(false) else a_fire && a.source === d.source
+      val crc_bypass = if (edge.manager.minLatency > 0) false.B else a_fire && a.source === d.source
       val d_crc_valid = Mux(crc_bypass, a_crc_valid, crc_valid.read(d.source)) holdUnless d_first
       val d_crc_check = Mux(crc_bypass, a_crc, crc.read(d.source)) holdUnless d_first
 
       val d_no_race_reg = Reg(Bool())
-      val d_no_race = Wire(init = d_no_race_reg)
+      val d_no_race = WireDefault(d_no_race_reg)
 
       when (d_fire) {
         d_crc_reg := d_crc
@@ -247,7 +248,7 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
 
         // Decrease the per-byte flight counter for the whole transaction
         when (d_last && d_flight.opcode =/= TLMessages.Hint && d_flight.opcode =/= TLMessages.Get) {
-          when (d_size <= UInt(shift)) {
+          when (d_size <= shift.U) {
             dec_bytes_wen := d_mask
           }
           dec_trees_wen := d_sizeOH >> (shift+1)
@@ -258,8 +259,8 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
             val f_size = flight(i).size
             val f_bits = UIntToOH1(f_size, addressBits)
             val d_bits = UIntToOH1(d_size, addressBits)
-            val overlap = ~(~(f_base ^ d_base) | (f_bits | d_bits)) === UInt(0)
-            when (overlap) { valid(i) := Bool(false) }
+            val overlap = ~(~(f_base ^ d_base) | (f_bits | d_bits)) === 0.U
+            when (overlap) { valid(i) := false.B }
           }
         }
 
@@ -275,9 +276,9 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
           assert (d.opcode === TLMessages.AccessAckData)
           for (i <- 0 until beatBytes) {
             val got = d.data(8*(i+1)-1, 8*i)
-            val shadow = Wire(init = d_shadow(i))
+            val shadow = WireDefault(d_shadow(i))
             when (d_mask(i)) {
-              val d_addr = d_addr_hi << shift | UInt(i)
+              val d_addr = d_addr_hi << shift | i.U
               printf(log + " ")
               when (d_flight.opcode === TLMessages.Get) { printf("g ") }
               when (d_flight.opcode === TLMessages.ArithmeticData) { printf("a ") }
@@ -289,9 +290,9 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
                 printf(", undefined (concurrent incomplete puts #%d)\n", d_inc(i) - d_dec(i))
               } .elsewhen (!d_fifo && !d_valid) {
                 printf(", undefined (concurrent completed put)\n")
-              } .elsewhen (Bool(ignoreDeniedData) && d.denied) {
+              } .elsewhen (ignoreDeniedData.B && d.denied) {
                 printf(", undefined (denied result)\n")
-              } .elsewhen (Bool(ignoreCorruptData) && d.corrupt) {
+              } .elsewhen (ignoreCorruptData.B && d.corrupt) {
                 printf(", undefined (corrupt result)\n")
               } .otherwise {
                 printf("\n")
@@ -303,12 +304,12 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
         }
 
         when (d_flight.opcode === TLMessages.ArithmeticData || d_flight.opcode === TLMessages.LogicalData) {
-          val race = (d_inc zip d_dec) map { case (i, d) => i - d =/= UInt(1) }
-          when (d_first) { d_no_race := Bool(true) }
-          when ((Cat(race.reverse) & d_mask).orR) { d_no_race := Bool(false) }
+          val race = (d_inc zip d_dec) map { case (i, d) => i - d =/= 1.U }
+          when (d_first) { d_no_race := true.B }
+          when ((Cat(race.reverse) & d_mask).orR) { d_no_race := false.B }
           when (d_last) {
             val must_match = d_crc_valid && (d_fifo || (d_valid && d_no_race))
-            val corrupt = (Bool(ignoreCorruptData) && d.corrupt) || (Bool(ignoreDeniedData) && d.denied)
+            val corrupt = (ignoreCorruptData.B && d.corrupt) || (ignoreDeniedData.B && d.denied)
             printf(log + " crc = 0x%x %d\n", d_crc, must_match.asUInt)
             when (!corrupt && must_match && d_crc =/= d_crc_check) { printf("EXPECTED: 0x%x\n", d_crc_check) }
             assert (corrupt || !must_match || d_crc === d_crc_check)
@@ -318,14 +319,14 @@ class TLRAMModel(log: String = "", ignoreCorruptData: Boolean = false, ignoreDen
 
       val d_waddr = Mux(wipe, wipeIndex, d_addr_hi)
       for (i <- 0 until beatBytes) {
-        val data = Mux(wipe, UInt(0), d_dec_bytes(i) + UInt(1))
+        val data = Mux(wipe, 0.U, d_dec_bytes(i) + 1.U)
         when (dec_bytes_wen(i)) {
           dec_bytes(i).write(d_waddr, data)
         }
       }
 
       for (i <- 0 until dec_trees.size) {
-        val data = Mux(wipe, UInt(0), d_dec_trees(i) + UInt(1))
+        val data = Mux(wipe, 0.U, d_dec_trees(i) + 1.U)
         when (dec_trees_wen(i)) {
           dec_trees(i).write(d_waddr >> (i+1), data)
         }
@@ -346,11 +347,11 @@ object TLRAMModel
 
   class ByteMonitor(params: MonitorParameters) extends GenericParameterizedBundle(params) {
     val valid = Bool()
-    val value = UInt(width = 8)
+    val value = UInt(8.W)
   }
   class FlightMonitor(params: MonitorParameters) extends GenericParameterizedBundle(params) {
-    val base    = UInt(width = params.addressBits)
-    val size    = UInt(width = params.sizeBits)
-    val opcode  = UInt(width = 3)
+    val base    = UInt(params.addressBits.W)
+    val size    = UInt(params.sizeBits.W)
+    val opcode  = UInt(3.W)
   }
 }

--- a/src/main/scala/tilelink/RationalCrossing.scala
+++ b/src/main/scala/tilelink/RationalCrossing.scala
@@ -9,7 +9,7 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -32,15 +32,15 @@ class TLRationalCrossingSource(implicit p: Parameters) extends LazyModule
         out.c <> ToRational(in.c, direction)
         out.e <> ToRational(in.e, direction)
       } else {
-        in.b.valid   := Bool(false)
-        in.c.ready   := Bool(true)
-        in.e.ready   := Bool(true)
-        out.b.ready  := Bool(true)
-        out.c.valid  := Bool(false)
-        out.e.valid  := Bool(false)
-        out.b.sink   := UInt(0)
-        out.c.source := UInt(0)
-        out.e.source := UInt(0)
+        in.b.valid   := false.B
+        in.c.ready   := true.B
+        in.e.ready   := true.B
+        out.b.ready  := true.B
+        out.c.valid  := false.B
+        out.e.valid  := false.B
+        out.b.sink   := 0.U
+        out.c.source := 0.U
+        out.e.source := 0.U
       }
     }
   }
@@ -64,15 +64,15 @@ class TLRationalCrossingSink(direction: RationalDirection = Symmetric)(implicit 
         out.c <> FromRational(in.c, direction)
         out.e <> FromRational(in.e, direction)
       } else {
-        out.b.ready := Bool(true)
-        out.c.valid := Bool(false)
-        out.e.valid := Bool(false)
-        in.b.valid  := Bool(false)
-        in.c.ready  := Bool(true)
-        in.e.ready  := Bool(true)
-        in.b.source := UInt(0)
-        in.c.sink   := UInt(0)
-        in.e.sink   := UInt(0)
+        out.b.ready := true.B
+        out.c.valid := false.B
+        out.e.valid := false.B
+        in.b.valid  := false.B
+        in.c.ready  := true.B
+        in.e.ready  := true.B
+        in.b.source := 0.U
+        in.c.sink   := 0.U
+        in.e.sink   := 0.U
       }
     }
   }
@@ -108,10 +108,10 @@ class TLRationalCrossing(direction: RationalDirection = Symmetric)(implicit p: P
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val in_clock  = Clock(INPUT)
-      val in_reset  = Bool(INPUT)
-      val out_clock = Clock(INPUT)
-      val out_reset = Bool(INPUT)
+      val in_clock  = Input(Clock())
+      val in_reset  = Input(Bool())
+      val out_clock = Input(Clock())
+      val out_reset = Input(Bool())
     })
 
     source.module.clock := io.in_clock
@@ -138,7 +138,7 @@ class TLRAMRationalCrossingSource(name: String, txns: Int)(implicit p: Parameter
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     val io = IO(new Bundle {
-      val finished = Bool(OUTPUT)
+      val finished = Output(Bool())
     })
     io.finished := fuzz.module.io.finished
   }

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.RawModule
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
@@ -12,8 +13,8 @@ import freechips.rocketchip.util._
 import scala.math.min
 
 class TLRegisterRouterExtraBundle(val sourceBits: Int, val sizeBits: Int) extends Bundle {
-  val source = UInt(width = sourceBits max 1)
-  val size   = UInt(width = sizeBits max 1)
+  val source = UInt((sourceBits max 1).W)
+  val size   = UInt((sizeBits max 1).W)
 }
 
 case object TLRegisterRouterExtra extends ControlKey[TLRegisterRouterExtraBundle]("tlrr_extra")
@@ -97,9 +98,9 @@ case class TLRegisterNode(
     d.bits.opcode := Mux(out.bits.read, TLMessages.AccessAckData, TLMessages.AccessAck)
 
     // Tie off unused channels
-    bundleIn.b.valid := Bool(false)
-    bundleIn.c.ready := Bool(true)
-    bundleIn.e.ready := Bool(true)
+    bundleIn.b.valid := false.B
+    bundleIn.c.ready := true.B
+    bundleIn.e.ready := true.B
 
     genRegDescsJson(mapping:_*)
   }

--- a/src/main/scala/tilelink/RegisterRouterTest.scala
+++ b/src/main/scala/tilelink/RegisterRouterTest.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper.{RRTest0, RRTest1}

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
@@ -37,12 +38,12 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
       require (!edgeIn.client.anySupportProbe || 
                !edgeOut.manager.anySupportAcquireB)
 
-      out.b.ready := Bool(true)
-      out.c.valid := Bool(false)
-      out.e.valid := Bool(false)
-      in.b.valid := Bool(false)
-      in.c.ready := Bool(true)
-      in.e.ready := Bool(true)
+      out.b.ready := true.B
+      out.c.valid := false.B
+      out.e.valid := false.B
+      in.b.valid := false.B
+      in.c.ready := true.B
+      in.e.ready := true.B
 
       if (noShrinkRequired(edgeIn.client)) {
         out.a <> in.a
@@ -50,7 +51,7 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
       } else {
         // State tracking
         val sourceIdMap = Mem(maxInFlight, in.a.bits.source)
-        val allocated = RegInit(UInt(0, width = maxInFlight))
+        val allocated = RegInit(0.U(maxInFlight.W))
         val nextFreeOH = ~(leftOR(~allocated) << 1) & ~allocated
         val nextFree = OHToUInt(nextFreeOH)
         val full = allocated.andR
@@ -64,18 +65,18 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
         out.a.bits := in.a.bits
         out.a.bits.source := nextFree holdUnless a_first
 
-        val bypass = Bool(edgeOut.manager.minLatency == 0) && in.a.valid && !full && a_first && nextFree === out.d.bits.source
+        val bypass = (edgeOut.manager.minLatency == 0).B && in.a.valid && !full && a_first && nextFree === out.d.bits.source
         in.d <> out.d
         in.d.bits.source := Mux(bypass, in.a.bits.source, sourceIdMap(out.d.bits.source))
 
-        when (a_first && in.a.fire()) {
+        when (a_first && in.a.fire) {
           sourceIdMap(nextFree) := in.a.bits.source
         }
 
-        val alloc = a_first && in.a.fire()
-        val free = d_last && in.d.fire()
-        val alloc_id = Mux(alloc, nextFreeOH, UInt(0))
-        val free_id = Mux(free, UIntToOH(out.d.bits.source), UInt(0))
+        val alloc = a_first && in.a.fire
+        val free = d_last && in.d.fire
+        val alloc_id = Mux(alloc, nextFreeOH, 0.U)
+        val free_id = Mux(free, UIntToOH(out.d.bits.source), 0.U)
         allocated := (allocated | alloc_id) & ~free_id
       }
     }

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -141,9 +141,9 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
         a_commit   := !d_block && !pre.write // only read beats commit to a D beat answer
         in.a.ready := !d_block && pre.write
       } .otherwise /* new burst */ {
-        a_commit := in.a.fire() // every first beat commits to a D beat answer
+        a_commit := in.a.fire // every first beat commits to a D beat answer
         in.a.ready := !d_block
-        when (in.a.fire()) {
+        when (in.a.fire) {
           post.full  := true.B
           post.send  := true.B
           post.last  := a_singleBeat
@@ -153,7 +153,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
           post.hauser:<= in.a.bits.user
           post.echo  :<= in.a.bits.echo
         }
-        when (in.a.fire() && !a_hint) {
+        when (in.a.fire && !a_hint) {
           post.write := edgeIn.hasData(in.a.bits)
           post.hsize := Mux(a_singleBeat, in.a.bits.size, lgBytes.U)
           post.hburst:= Mux(a_singleBeat, BURST_SINGLE, (a_logBeats1<<1) | 1.U)
@@ -206,12 +206,12 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
       // a_ready and htrans, we add another entry for aFlow=false.
       val depth = if (aFlow) 2 else 3
       val d = Wire(in.d)
-      in.d :<> Queue(d, depth, flow=true)
+      in.d :<> Queue(d, depth, true)
       assert (!d.valid || d.ready)
 
       val d_flight = RegInit(0.U(2.W))
       assert (d_flight <= depth.U)
-      d_flight := d_flight + a_commit.asUInt - in.d.fire().asUInt
+      d_flight := d_flight + a_commit.asUInt - in.d.fire.asUInt
       d_block := d_flight >= depth.U
 
       val d_valid   = RegInit(false.B)

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -149,8 +149,8 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       val depth = if (combinational) 1 else 2
       val out_arw = Wire(Decoupled(new AXI4BundleARW(out.params)))
       val out_w = Wire(chiselTypeOf(out.w))
-      out.w :<> Queue.irrevocable(out_w, entries=depth, flow=combinational)
-      val queue_arw = Queue.irrevocable(out_arw, entries=depth, flow=combinational)
+      out.w :<> Queue.irrevocable(out_w, entries=depth, combinational)
+      val queue_arw = Queue.irrevocable(out_arw, entries=depth, combinational)
 
       // Fan out the ARW channel to AR and AW
       out.ar.bits := queue_arw.bits
@@ -162,7 +162,7 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       val beatBytes = edgeIn.manager.beatBytes
       val maxSize   = log2Ceil(beatBytes).U
       val doneAW    = RegInit(false.B)
-      when (in.a.fire()) { doneAW := !a_last }
+      when (in.a.fire) { doneAW := !a_last }
 
       val arw = out_arw.bits
       arw.wen   := a_isPut
@@ -207,7 +207,7 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
 
       // R and B => D arbitration
       val r_holds_d = RegInit(false.B)
-      when (out.r.fire()) { r_holds_d := !out.r.bits.last }
+      when (out.r.fire) { r_holds_d := !out.r.bits.last }
       // Give R higher priority than B, unless B has been delayed for 8 cycles
       val b_delay = Reg(UInt(3.W))
       when (out.b.valid && !out.b.ready) {
@@ -225,7 +225,7 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       // request. We must pulse extend this value as AXI is allowed to change the
       // value of RRESP on every beat, and ChipLink may not.
       val r_first = RegInit(true.B)
-      when (out.r.fire()) { r_first := out.r.bits.last }
+      when (out.r.fire) { r_first := out.r.bits.last }
       val r_denied  = out.r.bits.resp === AXI4Parameters.RESP_DECERR holdUnless r_first
       val r_corrupt = out.r.bits.resp =/= AXI4Parameters.RESP_OKAY
       val b_denied  = out.b.bits.resp =/= AXI4Parameters.RESP_OKAY
@@ -258,8 +258,8 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
         val write = Reg(Bool())
         val idle = count === 0.U
 
-        val inc = as && out_arw.fire()
-        val dec = ds && d_last && in.d.fire()
+        val inc = as && out_arw.fire
+        val dec = ds && d_last && in.d.fire
         count := count + inc.asUInt - dec.asUInt
 
         assert (!dec || count =/= 0.U)        // underflow


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

As [`Chisel._` is Deprecated in Chisel 3.6](https://github.com/chipsalliance/chisel3/blob/5bc236268801861d325af7100922da3d14cd8b07/ROADMAP.md?plain=1#L33), we are porting Chisel 2 to Chisel 3.