### PR TITLE
Porting Chisel 2 to Chisel 3: util/

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -891,7 +891,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   when (metaArb.io.in(4).fire()) { release_state := s_ready }
 
   // cached response
-  io.cpu.resp.bits <> s2_req
+  (io.cpu.resp.bits: Data).waiveAll :<>= (s2_req: Data).waiveAll
   io.cpu.resp.bits.has_data := s2_read
   io.cpu.resp.bits.replay := false.B
   io.cpu.s2_uncached := s2_uncached && !s2_hit
@@ -1176,7 +1176,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   def probeIdx(b: TLBundleB): UInt = b.address(idxMSB, idxLSB)
   def addressToProbe(vaddr: UInt, paddr: UInt): TLBundleB = {
     val res = Wire(new TLBundleB(edge.bundle))
-    res <> DontCare
+    res :#= DontCare
     res.address := paddr
     res.source := (mmioOffset - 1).U
     res

--- a/src/main/scala/util/AsyncResetReg.scala
+++ b/src/main/scala/util/AsyncResetReg.scala
@@ -79,8 +79,8 @@ object AsyncResetReg {
     reg.io.q
   }
 
-  def apply(d: Bool, clk: Clock, rst: Bool): Bool = apply(d, clk, rst, init = false, None)
-  def apply(d: Bool, clk: Clock, rst: Bool, name: String): Bool = apply(d, clk, rst, init = false, Some(name))
+  def apply(d: Bool, clk: Clock, rst: Bool): Bool = apply(d, clk, rst, false, None)
+  def apply(d: Bool, clk: Clock, rst: Bool, name: String): Bool = apply(d, clk, rst, false, Some(name))
 
   // Create Vectors of Registers
   def apply(updateData: UInt, resetData: BigInt, enable: Bool, name: Option[String] = None): UInt = {

--- a/src/main/scala/util/CreditedIO.scala
+++ b/src/main/scala/util/CreditedIO.scala
@@ -73,7 +73,7 @@ final class CreditedIO[T <: Data](gen: T) extends Bundle
     enq.valid := debit
     enq.bits := bits
     assert (!enq.valid || enq.ready)
-    val res = Queue.irrevocable(enq, depth, pipe=true, flow=flow)
+    val res = Queue.irrevocable(enq, depth, true, flow)
     credit := res.fire()
     res
   }

--- a/src/main/scala/util/Frequency.scala
+++ b/src/main/scala/util/Frequency.scala
@@ -3,7 +3,8 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 /** Given a list of (frequency, value) pairs, return a random value
   * according to the frequency distribution.  The sum of the
@@ -23,18 +24,18 @@ object Frequency {
     val (firstFreq, firstVal) = dist.head
 
     // Result wire
-    val result = Wire(Bits(width = firstVal.getWidth))
-    result := UInt(0)
+    val result = Wire(Bits(firstVal.getWidth.W))
+    result := 0.U
 
     // Random value
     val randVal = LCG(log2Up(total))
 
     // Pick return value
     var count = firstFreq
-    var select = when (randVal < UInt(firstFreq)) { result := firstVal }
+    var select = when (randVal < firstFreq.U) { result := firstVal }
     for (p <- dist.drop(1)) {
       count = count + p._1
-      select = select.elsewhen(randVal < UInt(count)) { result := p._2 }
+      select = select.elsewhen(randVal < count.U) { result := p._2 }
     }
 
     return result

--- a/src/main/scala/util/GenericParameterizedBundle.scala
+++ b/src/main/scala/util/GenericParameterizedBundle.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
 
 @deprecated("GenericParameterizedBundle is useless anymore after autoclonetype2 is on.", "Rocket Chip 2021.04")
 abstract class GenericParameterizedBundle[+T <: Object](val params: T) extends Bundle

--- a/src/main/scala/util/HeterogeneousBag.scala
+++ b/src/main/scala/util/HeterogeneousBag.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
 import chisel3.Record
 import chisel3.reflect.DataMirror.internal.chiselTypeClone
 import scala.collection.immutable.ListMap

--- a/src/main/scala/util/IdentityModule.scala
+++ b/src/main/scala/util/IdentityModule.scala
@@ -2,14 +2,14 @@
 
 package freechips.rocketchip.tilelink
 
-import Chisel._
+import chisel3._
 
 class IdentityModule[T <: Data](gen: T) extends Module
 {
-  val io = new Bundle {
-    val in = gen.cloneType.flip
+  val io = IO(new Bundle {
+    val in = Flipped(gen.cloneType)
     val out = gen.cloneType
-  }
+  })
 
   io.out := io.in
 }

--- a/src/main/scala/util/LCG.scala
+++ b/src/main/scala/util/LCG.scala
@@ -3,7 +3,8 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
+import chisel3.util.Cat
 
 /** A 16-bit psuedo-random generator based on a linear conguential
   * generator (LCG).  The state is stored in an unitialised register.
@@ -12,13 +13,13 @@ import Chisel._
   * seeding each LCG16 instance with a different seed.
   */
 class LCG16 extends Module { 
-  val io = new Bundle { 
-    val out = UInt(OUTPUT, 16) 
-    val inc = Bool(INPUT)
-  } 
-  val state = Reg(UInt(width = 32))
+  val io = IO(new Bundle {
+    val out = Output(UInt(16.W))
+    val inc = Input(Bool())
+  })
+  val state = Reg(UInt(32.W))
   when (io.inc) {
-    state := state * UInt(1103515245, 32) + UInt(12345, 32)
+    state := state * 1103515245.U(32.W) + 12345.U(32.W)
   }
   io.out := state(30, 15)
 } 
@@ -27,10 +28,10 @@ class LCG16 extends Module {
   * 16-bit LCG.  Parameter 'width' must be larger than 0.
   */
 class LCG(val w: Int) extends Module {
-  val io = new Bundle { 
-    val out = UInt(OUTPUT, w) 
-    val inc = Bool(INPUT)
-  } 
+  val io = IO(new Bundle {
+    val out = Output(UInt(w.W))
+    val inc = Input(Bool())
+  })
   require(w > 0)
   val numLCG16s : Int = (w+15)/16
   val outs = Seq.fill(numLCG16s) { LCG16(io.inc) }
@@ -38,7 +39,7 @@ class LCG(val w: Int) extends Module {
 }
 
 object LCG16 {
-  def apply(inc: Bool = Bool(true)): UInt = {
+  def apply(inc: Bool = true.B): UInt = {
     val lcg = Module(new LCG16)
     lcg.io.inc := inc
     lcg.io.out
@@ -46,7 +47,7 @@ object LCG16 {
 }
 
 object LCG {
-  def apply(w: Int, inc: Bool = Bool(true)): UInt = {
+  def apply(w: Int, inc: Bool = true.B): UInt = {
     val lcg = Module(new LCG(w))
     lcg.io.inc := inc
     lcg.io.out

--- a/src/main/scala/util/LatencyPipe.scala
+++ b/src/main/scala/util/LatencyPipe.scala
@@ -2,18 +2,19 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 
 class LatencyPipe[T <: Data](typ: T, latency: Int) extends Module {
-  val io = new Bundle {
-    val in = Decoupled(typ).flip
+  val io = IO(new Bundle {
+    val in = Flipped(Decoupled(typ))
     val out = Decoupled(typ)
-  }
+  })
 
   def doN[T](n: Int, func: T => T, in: T): T =
     (0 until n).foldLeft(in)((last, _) => func(last))
 
-  io.out <> doN(latency, (last: DecoupledIO[T]) => Queue(last, 1, pipe=true), io.in)
+  io.out <> doN(latency, (last: DecoupledIO[T]) => Queue(last, 1, true), io.in)
 }
 
 object LatencyPipe {

--- a/src/main/scala/util/MultiWidthFifo.scala
+++ b/src/main/scala/util/MultiWidthFifo.scala
@@ -2,18 +2,19 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.unittest.UnitTest
 
 class MultiWidthFifo(inW: Int, outW: Int, n: Int) extends Module {
-  val io = new Bundle {
-    val in = Decoupled(Bits(width = inW)).flip
-    val out = Decoupled(Bits(width = outW))
-    val count = UInt(OUTPUT, log2Up(n + 1))
-  }
+  val io = IO(new Bundle {
+    val in = Flipped(Decoupled(Bits(inW.W)))
+    val out = Decoupled(Bits(outW.W))
+    val count = Output(UInt(log2Up(n + 1).W))
+  })
 
   if (inW == outW) {
-    val q = Module(new Queue(Bits(width = inW), n))
+    val q = Module(new Queue(Bits(inW.W), n))
     q.io.enq <> io.in
     io.out <> q.io.deq
     io.count := q.io.count
@@ -23,59 +24,59 @@ class MultiWidthFifo(inW: Int, outW: Int, n: Int) extends Module {
     require(inW % outW == 0, s"MultiWidthFifo: in: $inW not divisible by out: $outW")
     require(n % nBeats == 0, s"Cannot store $n output words when output beats is $nBeats")
 
-    val wdata = Reg(Vec(n / nBeats, Bits(width = inW)))
-    val rdata = Vec(wdata.flatMap { indat =>
+    val wdata = Reg(Vec(n / nBeats, Bits(inW.W)))
+    val rdata = VecInit(wdata.flatMap { indat =>
       (0 until nBeats).map(i => indat(outW * (i + 1) - 1, outW * i)) })
 
-    val head = Reg(init = UInt(0, log2Up(n / nBeats)))
-    val tail = Reg(init = UInt(0, log2Up(n)))
-    val size = Reg(init = UInt(0, log2Up(n + 1)))
+    val head = RegInit(0.U(log2Up(n / nBeats).W))
+    val tail = RegInit(0.U(log2Up(n).W))
+    val size = RegInit(0.U(log2Up(n + 1).W))
 
-    when (io.in.fire()) {
+    when (io.in.fire) {
       wdata(head) := io.in.bits
-      head := head + UInt(1)
+      head := head + 1.U
     }
 
-    when (io.out.fire()) { tail := tail + UInt(1) }
+    when (io.out.fire) { tail := tail + 1.U }
 
     size := MuxCase(size, Seq(
-      (io.in.fire() && io.out.fire()) -> (size + UInt(nBeats - 1)),
-      io.in.fire() -> (size + UInt(nBeats)),
-      io.out.fire() -> (size - UInt(1))))
+      (io.in.fire && io.out.fire) -> (size + (nBeats - 1).U),
+      io.in.fire -> (size + nBeats.U),
+      io.out.fire -> (size - 1.U)))
 
-    io.out.valid := size > UInt(0)
+    io.out.valid := size > 0.U
     io.out.bits := rdata(tail)
-    io.in.ready := size < UInt(n)
+    io.in.ready := size < n.U
     io.count := size
   } else {
     val nBeats = outW / inW
 
     require(outW % inW == 0, s"MultiWidthFifo: out: $outW not divisible by in: $inW")
 
-    val wdata = Reg(Vec(n * nBeats, Bits(width = inW)))
-    val rdata = Vec.tabulate(n) { i =>
-      Cat(wdata.slice(i * nBeats, (i + 1) * nBeats).reverse)}
+    val wdata = Reg(Vec(n * nBeats, Bits(inW.W)))
+    val rdata = VecInit(Seq.tabulate(n) { i =>
+      Cat(wdata.slice(i * nBeats, (i + 1) * nBeats).reverse)})
 
-    val head = Reg(init = UInt(0, log2Up(n * nBeats)))
-    val tail = Reg(init = UInt(0, log2Up(n)))
-    val size = Reg(init = UInt(0, log2Up(n * nBeats + 1)))
+    val head = RegInit(0.U(log2Up(n * nBeats).W))
+    val tail = RegInit(0.U(log2Up(n).W))
+    val size = RegInit(0.U(log2Up(n * nBeats + 1).W))
 
-    when (io.in.fire()) {
+    when (io.in.fire) {
       wdata(head) := io.in.bits
-      head := head + UInt(1)
+      head := head + 1.U
     }
 
-    when (io.out.fire()) { tail := tail + UInt(1) }
+    when (io.out.fire) { tail := tail + 1.U }
 
     size := MuxCase(size, Seq(
-      (io.in.fire() && io.out.fire()) -> (size - UInt(nBeats - 1)),
-      io.in.fire() -> (size + UInt(1)),
-      io.out.fire() -> (size - UInt(nBeats))))
+      (io.in.fire && io.out.fire) -> (size - (nBeats - 1).U),
+      io.in.fire -> (size + 1.U),
+      io.out.fire -> (size - nBeats.U)))
 
-    io.count := size >> UInt(log2Up(nBeats))
-    io.out.valid := io.count > UInt(0)
+    io.count := size >> log2Up(nBeats).U
+    io.out.valid := io.count > 0.U
     io.out.bits := rdata(tail)
-    io.in.ready := size < UInt(n * nBeats)
+    io.in.ready := size < (n * nBeats).U
   }
 }
 
@@ -83,21 +84,21 @@ class MultiWidthFifoTest extends UnitTest {
   val big2little = Module(new MultiWidthFifo(16, 8, 8))
   val little2big = Module(new MultiWidthFifo(8, 16, 4))
 
-  val bl_send = Reg(init = Bool(false))
-  val lb_send = Reg(init = Bool(false))
-  val bl_recv = Reg(init = Bool(false))
-  val lb_recv = Reg(init = Bool(false))
-  val bl_finished = Reg(init = Bool(false))
-  val lb_finished = Reg(init = Bool(false))
+  val bl_send = RegInit(false.B)
+  val lb_send = RegInit(false.B)
+  val bl_recv = RegInit(false.B)
+  val lb_recv = RegInit(false.B)
+  val bl_finished = RegInit(false.B)
+  val lb_finished = RegInit(false.B)
 
-  val bl_data = Vec.tabulate(4){i => UInt((2 * i + 1) * 256 + 2 * i, 16)}
-  val lb_data = Vec.tabulate(8){i => UInt(i, 8)}
+  val bl_data = VecInit(Seq.tabulate(4){i => ((2 * i + 1) * 256 + 2 * i).U(16.W)})
+  val lb_data = VecInit(Seq.tabulate(8){i => i.U(8.W)})
 
-  val (bl_send_cnt, bl_send_done) = Counter(big2little.io.in.fire(), 4)
-  val (lb_send_cnt, lb_send_done) = Counter(little2big.io.in.fire(), 8)
+  val (bl_send_cnt, bl_send_done) = Counter(big2little.io.in.fire, 4)
+  val (lb_send_cnt, lb_send_done) = Counter(little2big.io.in.fire, 8)
 
-  val (bl_recv_cnt, bl_recv_done) = Counter(big2little.io.out.fire(), 8)
-  val (lb_recv_cnt, lb_recv_done) = Counter(little2big.io.out.fire(), 4)
+  val (bl_recv_cnt, bl_recv_done) = Counter(big2little.io.out.fire, 8)
+  val (lb_recv_cnt, lb_recv_done) = Counter(little2big.io.out.fire, 4)
 
   big2little.io.in.valid := bl_send
   big2little.io.in.bits := bl_data(bl_send_cnt)
@@ -107,53 +108,53 @@ class MultiWidthFifoTest extends UnitTest {
   little2big.io.in.bits := lb_data(lb_send_cnt)
   little2big.io.out.ready := lb_recv
 
-  val bl_recv_data_idx = bl_recv_cnt >> UInt(1)
+  val bl_recv_data_idx = bl_recv_cnt >> 1.U
   val bl_recv_data = Mux(bl_recv_cnt(0),
     bl_data(bl_recv_data_idx)(15, 8),
     bl_data(bl_recv_data_idx)(7, 0))
 
   val lb_recv_data = Cat(
-    lb_data(Cat(lb_recv_cnt, UInt(1, 1))),
-    lb_data(Cat(lb_recv_cnt, UInt(0, 1))))
+    lb_data(Cat(lb_recv_cnt, 1.U(1.W))),
+    lb_data(Cat(lb_recv_cnt, 0.U(1.W))))
 
   when (io.start) {
-    bl_send := Bool(true)
-    lb_send := Bool(true)
+    bl_send := true.B
+    lb_send := true.B
   }
 
   when (bl_send_done) {
-    bl_send := Bool(false)
-    bl_recv := Bool(true)
+    bl_send := false.B
+    bl_recv := true.B
   }
 
   when (lb_send_done) {
-    lb_send := Bool(false)
-    lb_recv := Bool(true)
+    lb_send := false.B
+    lb_recv := true.B
   }
 
   when (bl_recv_done) {
-    bl_recv := Bool(false)
-    bl_finished := Bool(true)
+    bl_recv := false.B
+    bl_finished := true.B
   }
 
   when (lb_recv_done) {
-    lb_recv := Bool(false)
-    lb_finished := Bool(true)
+    lb_recv := false.B
+    lb_finished := true.B
   }
 
   io.finished := bl_finished && lb_finished
 
-  val bl_start_recv = Reg(next = bl_send_done)
-  val lb_start_recv = Reg(next = lb_send_done)
+  val bl_start_recv = RegNext(bl_send_done)
+  val lb_start_recv = RegNext(lb_send_done)
 
   assert(!little2big.io.out.valid || little2big.io.out.bits === lb_recv_data,
     "Little to Big data mismatch")
   assert(!big2little.io.out.valid || big2little.io.out.bits === bl_recv_data,
     "Bit to Little data mismatch")
 
-  assert(!lb_start_recv || little2big.io.count === UInt(4),
+  assert(!lb_start_recv || little2big.io.count === 4.U,
     "Little to Big count incorrect")
-  assert(!bl_start_recv || big2little.io.count === UInt(8),
+  assert(!bl_start_recv || big2little.io.count === 8.U,
     "Big to Little count incorrect")
 }
 

--- a/src/main/scala/util/PSDTestMode.scala
+++ b/src/main/scala/util/PSDTestMode.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.diplomacy.{BundleBridgeEphemeralNode, ValName}
 
@@ -19,5 +19,5 @@ class PSDTestMode extends Bundle {
 
 trait CanHavePSDTestModeIO {
   implicit val p: Parameters
-  val psd = p(IncludePSDTest).option(new PSDTestMode().asInput)
+  val psd = p(IncludePSDTest).option(Input(new PSDTestMode()))
 }

--- a/src/main/scala/util/Property.scala
+++ b/src/main/scala/util/Property.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.util.property
 
-import Chisel._
+import chisel3._
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.util.{ReadyValidIO}
 

--- a/src/main/scala/util/RationalCrossing.scala
+++ b/src/main/scala/util/RationalCrossing.scala
@@ -74,7 +74,7 @@ class RationalCrossingSource[T <: Data](gen: T, direction: RationalDirection = S
   val enq_in = BlockDuringReset(io.enq)
   val deq = io.deq
   val enq = direction match {
-    case Symmetric  => ShiftQueue(enq_in, 1, flow=true)
+    case Symmetric  => ShiftQueue(enq_in, 1, true)
     case Flexible => ShiftQueue(enq_in, 2)
     case FastToSlow => enq_in
     case SlowToFast => ShiftQueue(enq_in, 2)
@@ -110,7 +110,7 @@ class RationalCrossingSink[T <: Data](gen: T, direction: RationalDirection = Sym
   val enq = io.enq
   val deq = Wire(chiselTypeOf(io.deq))
   direction match {
-    case Symmetric  => io.deq <> ShiftQueue(deq, 1, pipe=true)
+    case Symmetric  => io.deq <> ShiftQueue(deq, 1, true)
     case Flexible   => io.deq <> ShiftQueue(deq, 2)
     case FastToSlow => io.deq <> ShiftQueue(deq, 2)
     case SlowToFast => io.deq <> deq

--- a/src/main/scala/util/ShiftReg.scala
+++ b/src/main/scala/util/ShiftReg.scala
@@ -12,7 +12,7 @@ object ShiftRegInit {
 
   (0 until n).foldRight(in) {
     case (i, next) => {
-      val r = RegNext(next, init = init)
+      val r = RegNext(next, init)
       name.foreach { na => r.suggestName(s"${na}_${i}") }
       r
     }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

As [`Chisel._` is Deprecated in Chisel 3.6](https://github.com/chipsalliance/chisel3/blob/5bc236268801861d325af7100922da3d14cd8b07/ROADMAP.md?plain=1#L33), we are porting Chisel 2 to Chisel 3.