### PR TITLE
[WIP] Porting Chisel 2 to Chisel 3: diplomacy

### DIFF
--- a/src/main/scala/diplomacy/AddressDecoder.scala
+++ b/src/main/scala/diplomacy/AddressDecoder.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel.log2Ceil
+import chisel3.util.log2Ceil
 
 object AddressDecoder
 {

--- a/src/main/scala/diplomacy/Clone.scala
+++ b/src/main/scala/diplomacy/Clone.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel._
+import chisel3._
 import chisel3.experimental.CloneModuleAsRecord
 import chisel3.internal.sourceinfo.{SourceInfo}
 

--- a/src/main/scala/diplomacy/CloneModule.scala
+++ b/src/main/scala/diplomacy/CloneModule.scala
@@ -5,7 +5,7 @@
 
 package chisel3.shim
 
-import Chisel._
+import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.{RawModule, Module}
 import chisel3.internal.Builder
@@ -15,6 +15,6 @@ import scala.collection.mutable.ArrayBuffer
 
 class ClonePorts protected[shim](elts: Data*) extends Record
 {
-  val elements = ListMap(elts.map(d => d.instanceName -> d.chiselCloneType): _*)
+  val elements = ListMap(elts.map(d => d.instanceName -> chiselTypeOf(d)): _*)
   def apply(field: String) = elements(field)
 }

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -560,7 +560,7 @@ final class AutoBundle(elts: (String, Data, Boolean)*) extends Record {
     val ((key, data, flip), i) = tuple
     // Trim trailing _0_1_2 stuff so that when we append _# we don't create collisions.
     val regex = new Regex("(_[0-9]+)*$")
-    val element = if (flip) Flipped(data.cloneType) else data.cloneType
+    val element = if (flip) Flipped(chiselTypeOf(data)) else chiselTypeOf(data)
     (regex.replaceAllIn(key, ""), element, i)
   }
 }

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel.{defaultCompileOptions => _, _}
+import chisel3._
+import chisel3.util._
 import chisel3.internal.sourceinfo.{SourceInfo, UnlocatableSourceInfo}
 import chisel3.{Module, RawModule, Reset, withClockAndReset}
 import chisel3.experimental.{ChiselAnnotation, CloneModuleAsRecord}
@@ -408,7 +409,7 @@ class LazyRawModuleImp(val wrapper: LazyModule) extends RawModule with LazyModul
   /** drive reset explicitly. */
   val childReset: Reset = Wire(Reset())
   // the default is that these are disabled
-  childClock := Bool(false).asClock
+  childClock := false.B.asClock
   childReset := chisel3.DontCare
   val (auto, dangles) = withClockAndReset(childClock, childReset) {
     instantiate()
@@ -559,7 +560,7 @@ final class AutoBundle(elts: (String, Data, Boolean)*) extends Record {
     val ((key, data, flip), i) = tuple
     // Trim trailing _0_1_2 stuff so that when we append _# we don't create collisions.
     val regex = new Regex("(_[0-9]+)*$")
-    val element = if (flip) data.cloneType.flip() else data.cloneType
+    val element = if (flip) Flipped(data.cloneType) else data.cloneType
     (regex.replaceAllIn(key, ""), element, i)
   }
 }

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.experimental.IO
 import chisel3.internal.sourceinfo.SourceInfo
 import org.chipsalliance.cde.config.{Field, Parameters}

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.diplomacy
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.IO
 import chisel3.internal.sourceinfo.SourceInfo
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.util.HeterogeneousBag

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -2,8 +2,8 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel._
-import chisel3.util.ReadyValidIO
+import chisel3._
+import chisel3.util._
 import freechips.rocketchip.util.{ShiftQueue}
 
 /** Options for describing the attributes of memory regions */
@@ -41,20 +41,20 @@ case class IdRange(start: Int, end: Int) extends Ordered[IdRange]
   def contains(x: Int)  = start <= x && x < end
   def contains(x: UInt) =
     if (size == 0) {
-      Bool(false)
+      false.B
     } else if (size == 1) { // simple comparison
-      x === UInt(start)
+      x === start.U
     } else {
       // find index of largest different bit
       val largestDeltaBit = log2Floor(start ^ (end-1))
       val smallestCommonBit = largestDeltaBit + 1 // may not exist in x
       val uncommonMask = (1 << smallestCommonBit) - 1
-      val uncommonBits = (x | UInt(0, width=smallestCommonBit))(largestDeltaBit, 0)
+      val uncommonBits = (x | 0.U(smallestCommonBit.W))(largestDeltaBit, 0)
       // the prefix must match exactly (note: may shift ALL bits away)
-      (x >> smallestCommonBit) === UInt(start >> smallestCommonBit) &&
+      (x >> smallestCommonBit) === (start >> smallestCommonBit).U &&
       // firrtl constant prop range analysis can eliminate these two:
-      UInt(start & uncommonMask) <= uncommonBits &&
-      uncommonBits <= UInt((end-1) & uncommonMask)
+      (start & uncommonMask).U <= uncommonBits &&
+      uncommonBits <= ((end-1) & uncommonMask).U
     }
 
   def shift(x: Int) = IdRange(start+x, end+x)
@@ -87,9 +87,9 @@ case class TransferSizes(min: Int, max: Int)
   def contains(x: Int) = isPow2(x) && min <= x && x <= max
   def containsLg(x: Int) = contains(1 << x)
   def containsLg(x: UInt) =
-    if (none) Bool(false)
-    else if (min == max) { UInt(log2Ceil(min)) === x }
-    else { UInt(log2Ceil(min)) <= x && x <= UInt(log2Ceil(max)) }
+    if (none) false.B
+    else if (min == max) { log2Ceil(min).U === x }
+    else { log2Ceil(min).U <= x && x <= log2Ceil(max).U }
 
   def contains(x: TransferSizes) = x.none || (min <= x.min && x.max <= max)
 
@@ -134,7 +134,7 @@ case class AddressSet(base: BigInt, mask: BigInt) extends Ordered[AddressSet]
   // We do allow negative mask (=> ignore all high bits)
 
   def contains(x: BigInt) = ((x ^ base) & ~mask) == 0
-  def contains(x: UInt) = ((x ^ UInt(base)).zext & SInt(~mask)) === SInt(0)
+  def contains(x: UInt) = ((x ^ base.U).zext & (~mask).S) === 0.S
 
   // turn x into an address contained in this set
   def legalize(x: UInt): UInt = base.U | (mask.U & x)
@@ -261,16 +261,16 @@ case class BufferParams(depth: Int, flow: Boolean, pipe: Boolean)
   def latency = if (isDefined && !flow) 1 else 0
 
   def apply[T <: Data](x: DecoupledIO[T]) =
-    if (isDefined) Queue(x, depth, flow=flow, pipe=pipe)
+    if (isDefined) Queue(x, depth, flow, pipe)
     else x
 
   def irrevocable[T <: Data](x: ReadyValidIO[T]) =
-    if (isDefined) Queue.irrevocable(x, depth, flow=flow, pipe=pipe)
+    if (isDefined) Queue.irrevocable(x, depth, flow, pipe)
     else x
 
   def sq[T <: Data](x: DecoupledIO[T]) =
     if (!isDefined) x else {
-      val sq = Module(new ShiftQueue(x.bits, depth, flow=flow, pipe=pipe))
+      val sq = Module(new ShiftQueue(x.bits, depth, flow, pipe))
       sq.io.enq <> x
       sq.io.deq
     }

--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel.log2Ceil
+import chisel3.util.log2Ceil
 
 import scala.collection.immutable.{ListMap, SortedMap}
 import scala.collection.mutable.HashMap

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -2,7 +2,8 @@
 
 package freechips.rocketchip.diplomacy
 
-import Chisel._
+import chisel3._
+import chisel3.util._
 import chisel3.SyncReadMem
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.util.{DescribedSRAM, Code}
@@ -32,7 +33,7 @@ abstract class DiplomaticSRAM(
       name = devName.getOrElse("mem"),
       desc = devName.getOrElse("mem"),
       size = size,
-      data = Vec(lanes, UInt(width = bits))
+      data = Vec(lanes, UInt(bits.W))
     )
     devName.foreach(n => mem.suggestName(n.split("-").last))
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

As [`Chisel._` is Deprecated in Chisel 3.6](https://github.com/chipsalliance/chisel3/blob/5bc236268801861d325af7100922da3d14cd8b07/ROADMAP.md?plain=1#L33), we are porting Chisel 2 to Chisel 3.