### PR TITLE
L1TLB: VS-mode SFENCE misses tera/giga-page entries fragmented superpages

### DIFF
--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -219,13 +219,12 @@ class TLBEntry(val nSectors: Int, val superpage: Boolean, val superpageOnly: Boo
         for (((v, e), i) <- (valid zip entry_data).zipWithIndex)
           when (tag_v === virtual && i.U === sectorIdx(vpn)) { v := false.B }
       }
-
-      // For fragmented superpage mappings, we assume the worst (largest)
-      // case, and zap entries whose most-significant VPNs match
-      when (((tag_vpn ^ vpn) >> (pgLevelBits * (pgLevels - 1))) === 0.U) {
-        for ((v, e) <- valid zip entry_data)
-          when (tag_v === virtual && e.fragmented_superpage) { v := false.B }
-      }
+    }
+    // For fragmented superpage mappings, we assume the worst (largest)
+    // case, and zap entries whose most-significant VPNs match
+    when (((tag_vpn ^ vpn) >> (pgLevelBits * (pgLevels - 1))) === 0.U) {
+      for ((v, e) <- valid zip entry_data)
+        when (tag_v === virtual && e.fragmented_superpage) { v := false.B }
     }
   }
   def invalidateNonGlobal(virtual: Bool): Unit = {


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

**Type of change**: bug report

**Impact**: functional fix

**Development Phase**: implementation

**Release Notes**
VS-mode (Stage-1) tera/giga/peta-page entries can be fragmented by Stage-2 superpage entries, and need the same TLB Invalidate (SFENCE.VMA / HFENCE.VVMA) matching based on VS-mode (Stage-1) page size.  Fix in the L1TLBs (ITLB and DTLB): superpage entries conservatively match when `fragmented_superpage`, just as we already do in the leaf page sectored entries.