### PR TITLE
mill: fix empty cross arg for riscv-tests.Suite

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -243,7 +243,7 @@ object `riscv-tests` extends Module {
   }
 
   object suite extends mill.Cross[Suite](
-    os.walk(testsRoot).map(_.last).filterNot(_.endsWith("dump")).map(_.split('-').dropRight(1).mkString("-")).toSet.toSeq.sorted: _*
+    os.walk(testsRoot).map(_.last).filterNot(_.endsWith("dump")).map(_.split('-').dropRight(1).mkString("-")).filter(_ != "").toSet.toSeq.sorted: _*
   )
 
   class Suite(name: String) extends Module {


### PR DESCRIPTION
`riscv-tests.suite[]` wont compile

Before

```
$ mill resolve riscv-tests.suite._
[1/1] resolve 
riscv-tests.suite[]
riscv-tests.suite[mt]
riscv-tests.suite[rv32mi-p-lh]
riscv-tests.suite[rv32mi-p-lw]
riscv-tests.suite[rv32mi-p-sh]
...
```

After

```
$ mill resolve riscv-tests.suite._
[1/1] resolve 
riscv-tests.suite[mt]
riscv-tests.suite[rv32mi-p-lh]
riscv-tests.suite[rv32mi-p-lw]
riscv-tests.suite[rv32mi-p-sh]
...
```

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
