### PR TITLE
Hypervisor: encodeVirtualAddress extra MSB to canonicalize VS-disabled

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -1092,9 +1092,10 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   def encodeVirtualAddress(a0: UInt, ea: UInt) = if (vaddrBitsExtended == vaddrBits) ea else {
     // efficient means to compress 64-bit VA into vaddrBits+1 bits
     // (VA is bad if VA(vaddrBits) != VA(vaddrBits-1))
-    val a = a0.asSInt >> vaddrBits
-    val msb = Mux(a === 0.S || a === -1.S, ea(vaddrBits), !ea(vaddrBits-1))
-    Cat(msb, ea(vaddrBits-1,0))
+    val b = vaddrBitsExtended-1
+    val a = (a0 >> b).asSInt
+    val msb = Mux(a === 0.S || a === -1.S, ea(b), !ea(b-1))
+    Cat(msb, ea(b-1, 0))
   }
 
   class Scoreboard(n: Int, zero: Boolean = false)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -190,7 +190,7 @@ trait HasTileParameters extends HasNonDiplomaticTileParameters {
     }
   def vpnBits: Int = vaddrBits - pgIdxBits
   def ppnBits: Int = paddrBits - pgIdxBits
-  def vpnBitsExtended: Int = vpnBits + (vaddrBits < xLen).toInt
+  def vpnBitsExtended: Int = vpnBits + (if (vaddrBits < xLen) 1 + usingHypervisor.toInt else 0)
   def vaddrBitsExtended: Int = vpnBitsExtended + pgIdxBits
 }
 


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

**Type of change**: bug report

**Impact**: functional fix

**Development Phase**: implementation

**Release Notes**
The `encodeVirtualAddress` function in the cache pipeline relies on setting the sign-extended-mask extra bit to the opposite value, but the `badGPA` (i.e. `badVA(false)`) function in the ITLB/DTLB ignores the sign-extended-mask check for GPA when stage-1-**disabled** and stage-2-enabled.
So, when a VA (a.k.a. GPA in this mode Sv39x4) has bits[63:41]!=0 and bit[40]==1, the `encodeVirtualAddress` function sets bit [41]==0, which passes the `badGPA` (i.e. `badVA(false)`) function check.