### PR TITLE
Use chisel 3.6 rc2 instead of SNAPSHOT

### DIFF
--- a/common.sc
+++ b/common.sc
@@ -4,8 +4,8 @@ import mill.scalalib.publish._
 import coursier.maven.MavenRepository
 
 val defaultVersions = Map(
-  "chisel3" -> "3.6-SNAPSHOT",
-  "chisel3-plugin" -> "3.6-SNAPSHOT"
+  "chisel3" -> "3.6.0-RC2",
+  "chisel3-plugin" -> "3.6.0-RC2"
 )
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs", cross: Boolean = false) = {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

Relying on chisel snapshot is causing a lot of pain for rocket chip and its dependencies like hardfloat/inclusive-cache/blocks, especially chisel master now removes Chisel and moves Cat into chisel3._. It even breaks the CI for PRs of last week.

In the dev meeting it is decided that we should rely on 3.6 instead of snapshot.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
