### PR TITLE
config: add WithBootFreq configuration

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -514,6 +514,14 @@ class WithTimebase(hertz: BigInt) extends Config((site, here, up) => {
   case DTSTimebase => hertz
 })
 
+class WithBootFreq(hertz: BigInt) extends Config((site, here, up) => {
+  case TilesLocated(InSubsystem) => up(TilesLocated(InSubsystem), site) map {
+    case tp: RocketTileAttachParams => tp.copy(tileParams = tp.tileParams.copy(
+      core = tp.tileParams.core.copy(bootFreqHz = hertz)))
+    case t => t
+  }
+})
+
 class WithDefaultMemPort extends Config((site, here, up) => {
   case ExtMem => Some(MemoryPortParams(MasterPortParams(
                       base = x"8000_0000",


### PR DESCRIPTION
The rocket-chip will set clock-frequency to 0 in the CPU fields of the device tree. And the value is taken from bootFreqHz in the RocketCoreParams which is zero by default. Some devices will use this property to calculate the clock divider ratio, but a zero value will cause division overflow.

This patch allows setting the value by simply adding WithBootFreq to the configuration, so we will have the correct clock-frequency in the dts.