### PR TITLE
all isaDTS strings to lowercase

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -64,7 +64,7 @@ case class RocketCoreParams(
   val instBits: Int = if (useCompressed) 16 else 32
   val lrscCycles: Int = 80 // worst case is 14 mispredicted branches + slop
   val traceHasWdata: Boolean = false // ooo wb, so no wdata in trace
-  override val customIsaExt = Some("Xrocket") // CEASE instruction
+  override val customIsaExt = Some("xrocket") // CEASE instruction
   override def minFLen: Int = fpu.map(_.minFLen).getOrElse(32)
   override def customCSRs(implicit p: Parameters) = new RocketCustomCSRs
 }

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -109,14 +109,14 @@ trait HasNonDiplomaticTileParameters {
       // rdcycle[h], rdinstret[h] is implemented
       // rdtime[h] is not implemented, and could be provided by software emulation
       // see https://github.com/chipsalliance/rocket-chip/issues/3207
-      //Some(Seq("Zicntr")) ++
-      Some(Seq("Zicsr", "Zifencei", "Zihpm")) ++
-      Option.when(tileParams.core.fpu.nonEmpty && tileParams.core.fpu.get.fLen >= 16 && tileParams.core.fpu.get.minFLen <= 16)(Seq("Zfh")) ++
-      Option.when(tileParams.core.useBitManip)(Seq("Zba", "Zbb", "Zbc")) ++
-      Option.when(tileParams.core.hasBitManipCrypto)(Seq("Zbkb", "Zbkc", "Zbkx")) ++
-      Option.when(tileParams.core.useBitManip)(Seq("Zbs")) ++
-      Option.when(tileParams.core.useCryptoNIST)(Seq("Zknd", "Zkne", "Zknh")) ++
-      Option.when(tileParams.core.useCryptoSM)(Seq("Zksed", "Zksh")) ++
+      //Some(Seq("zicntr")) ++
+      Some(Seq("zicsr", "zifencei", "zihpm")) ++
+      Option.when(tileParams.core.fpu.nonEmpty && tileParams.core.fpu.get.fLen >= 16 && tileParams.core.fpu.get.minFLen <= 16)(Seq("zfh")) ++
+      Option.when(tileParams.core.useBitManip)(Seq("zba", "zbb", "zbc")) ++
+      Option.when(tileParams.core.hasBitManipCrypto)(Seq("zbkb", "zbkc", "zbkx")) ++
+      Option.when(tileParams.core.useBitManip)(Seq("zbs")) ++
+      Option.when(tileParams.core.useCryptoNIST)(Seq("zknd", "zkne", "zknh")) ++
+      Option.when(tileParams.core.useCryptoSM)(Seq("zksed", "zksh")) ++
       tileParams.core.customIsaExt.map(Seq(_))
     ).flatten
     val multiLetterString = multiLetterExt.mkString("_")


### PR DESCRIPTION
The Linux Kernel requires letters in the riscv,isa string in the device tree must be all lowercase to simplify parsing. [see here](https://github.com/torvalds/linux/blob/v6.3/Documentation/devicetree/bindings/riscv/cpus.yaml#L82)

However, rocket-chip will produce an ISA string with uppercase letters will cause the kernel to misbehave. Especially when using defconfig Linux with rocket-chip without FPU, the ISA string parser will confuse the current kernel that the CPU has "f" from "Zifencei", and the kernel will panic at `__fstate_restore` due to illegal instruction exceptions.

I tried to patch the Linux Kernel, but a maintainer thinks it will make the device tree have no backward compatibility. In my opinion, the rocket-chip should be fixed, and the parser in the kernel should also be fixed to avoid illegal parsing causing the kernel to misbehave.

In this PR, I changed all the ISA strings to lowercase to meet the kernel's requirements, and the issue was solved.

**Related issue**: See [https://lore.kernel.org/lkml/20230425-flyable-prompter-5b1e4cebf9db@wendy/](https://lore.kernel.org/lkml/20230425-flyable-prompter-5b1e4cebf9db@wendy/)

**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation
