### PR TITLE
rename M_HLVX to prevent clashing with M_FLUSH

### DIFF
--- a/src/main/scala/rocket/Consts.scala
+++ b/src/main/scala/rocket/Consts.scala
@@ -76,7 +76,7 @@ trait MemoryOpConstants {
   def M_HFENCEV = "b10101".U // HFENCE.VVMA
   def M_HFENCEG = "b10110".U // HFENCE.GVMA
   def M_WOK     = "b10111".U // check write permissions but don't perform a write
-  def M_HLVX    = "b10000".U // HLVX instruction
+  def M_HLVX    = "b11000".U // HLVX instruction
 
   def isAMOLogical(cmd: UInt) = cmd.isOneOf(M_XA_SWAP, M_XA_XOR, M_XA_OR, M_XA_AND)
   def isAMOArithmetic(cmd: UInt) = cmd.isOneOf(M_XA_ADD, M_XA_MIN, M_XA_MAX, M_XA_MINU, M_XA_MAXU)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Renamed the constant M_HLVX from `10000` to `11000` to prevent clashing with M_FLUSH, as `isRead` would always return true for memory commands with `M_FLUSH`.

Note: The bug was spotted while working with `boom/src/main/scala/lsu/dcache.scala` of the BOOM. This prevents `M_FLUSH` commands from sending a response as `s2_send_resp` would always evaluate to false.
