### PR TITLE
Fix AXI4 RegisterRouter on Wire Clone

### DIFF
--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 import freechips.rocketchip.util._
 
 case object AXI4RRId extends ControlKey[UInt]("extra_id")
-case class AXI4RRIdField(width: Int) extends SimpleBundleField(AXI4RRId)(UInt((1 max width).W), 0.U)
+case class AXI4RRIdField(width: Int) extends SimpleBundleField(AXI4RRId)(Output(UInt((1 max width).W)), 0.U)
 
 case class AXI4RegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
   extends SinkNode(AXI4Imp)(Seq(AXI4SlavePortParameters(
@@ -39,8 +39,8 @@ case class AXI4RegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes
     val fields = AXI4RRIdField(ar.bits.params.idBits) +: ar.bits.params.echoFields
     val params = RegMapperParams(log2Up((address.mask+1)/beatBytes), beatBytes, fields)
     val in = Wire(Decoupled(new RegMapperInput(params)))
-    val ar_extra = Wire(in.bits.extra)
-    val aw_extra = Wire(in.bits.extra)
+    val ar_extra = WireDefault(in.bits.extra)
+    val aw_extra = WireDefault(in.bits.extra)
 
     // Prefer to execute reads first
     in.valid := ar.valid || (aw.valid && w.valid)


### PR DESCRIPTION
In legacy code it is ok to clone a Wire using Wire()

now the requirement is more strict and WireDefault is needed

The Output is added for code style consistency

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #3059, #3324

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
