### PR TITLE
Support TLFilter.mSubtract with multiple AddressSets

### DIFF
--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -89,10 +89,14 @@ object TLFilter
   }
 
   // make everything except the intersected address sets visible
-  def mSubtract(except: AddressSet): ManagerFilter = { m =>
-    val filtered = m.address.flatMap(_.subtract(except))
+  def mSubtract(excepts: Seq[AddressSet]): ManagerFilter = { m =>
+    val filtered = excepts.foldLeft(m.address) { (a,e) => a.flatMap(_.subtract(e)) }
     val alignment: BigInt = if (filtered.isEmpty) 0 else filtered.map(_.alignment).min
     transferSizeHelper(m, filtered, alignment)
+  }
+
+  def mSubtract(except: AddressSet): ManagerFilter = { m =>
+    mSubtract(Seq(except))(m)
   }
 
   // adjust supported transfer sizes based on filtered intersection


### PR DESCRIPTION
Enables filtering out multiple ranges at once.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
