### PR TITLE
Support custom bundles in Trace

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -812,7 +812,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   csr.io.rw.addr := wb_reg_inst(31,20)
   csr.io.rw.cmd := CSR.maskCmd(wb_reg_valid, wb_ctrl.csr)
   csr.io.rw.wdata := wb_reg_wdata
-  io.trace := csr.io.trace
+  io.trace.insns := csr.io.trace
   for (((iobpw, wphit), bp) <- io.bpwatch zip wb_reg_wphit zip csr.io.bp) {
     iobpw.valid(0) := wphit
     iobpw.action := bp.control.action

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -813,6 +813,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   csr.io.rw.cmd := CSR.maskCmd(wb_reg_valid, wb_ctrl.csr)
   csr.io.rw.wdata := wb_reg_wdata
   io.trace.insns := csr.io.trace
+  io.trace.time := csr.io.time
   for (((iobpw, wphit), bp) <- io.bpwatch zip wb_reg_wphit zip csr.io.bp) {
     iobpw.valid(0) := wphit
     iobpw.action := bp.control.action

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -283,10 +283,10 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
 
   protected def traceRetireWidth = tileParams.core.retireWidth
   /** Node for the core to drive legacy "raw" instruction trace. */
-  val traceSourceNode = BundleBridgeSource(() => Vec(traceRetireWidth, new TracedInstruction()))
-  private val traceNexus = BundleBroadcast[Vec[TracedInstruction]]() // backwards compatiblity; not blocked during stretched reset
+  val traceSourceNode = BundleBridgeSource(() => new TraceBundle)
+  private val traceNexus = BundleBroadcast[TraceBundle]() // backwards compatiblity; not blocked during stretched reset
   /** Node for external consumers to source a legacy instruction trace from the core. */
-  val traceNode: BundleBridgeOutwardNode[Vec[TracedInstruction]] = traceNexus := traceSourceNode
+  val traceNode: BundleBridgeOutwardNode[TraceBundle] = traceNexus := traceSourceNode
 
   protected def traceCoreParams = new TraceCoreParams()
   /** Node for core to drive instruction trace conforming to RISC-V Processor Trace spec V1.0 */

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -150,6 +150,11 @@ class CoreInterrupts(implicit p: Parameters) extends TileInterrupts()(p) {
   val buserror = tileParams.beuAddr.map(a => Bool())
 }
 
+// This is a raw commit trace from the core, not the TraceCoreInterface
+class TraceBundle(implicit val p: Parameters) extends Bundle with HasCoreParameters {
+  val insns = Vec(coreParams.retireWidth, new TracedInstruction)
+}
+
 trait HasCoreIO extends HasTileParameters {
   implicit val p: Parameters
   val io = new CoreBundle()(p) {
@@ -161,7 +166,7 @@ trait HasCoreIO extends HasTileParameters {
     val ptw = new DatapathPTWIO().flip
     val fpu = new FPUCoreIO().flip
     val rocc = new RoCCCoreIO().flip
-    val trace = Vec(coreParams.retireWidth, new TracedInstruction).asOutput
+    val trace = Output(new TraceBundle)
     val bpwatch = Vec(coreParams.nBreakpoints, new BPWatch(coreParams.retireWidth)).asOutput
     val cease = Bool().asOutput
     val wfi = Bool().asOutput

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -55,6 +55,7 @@ trait CoreParams {
   val mtvecInit: Option[BigInt]
   val mtvecWritable: Boolean
   val traceHasWdata: Boolean
+  def traceCustom: Option[Data] = None
   def customIsaExt: Option[String] = None
   def customCSRs(implicit p: Parameters): CustomCSRs = new CustomCSRs
 
@@ -154,6 +155,7 @@ class CoreInterrupts(implicit p: Parameters) extends TileInterrupts()(p) {
 class TraceBundle(implicit val p: Parameters) extends Bundle with HasCoreParameters {
   val insns = Vec(coreParams.retireWidth, new TracedInstruction)
   val time = UInt(64.W)
+  val custom = coreParams.traceCustom
 }
 
 trait HasCoreIO extends HasTileParameters {

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -153,6 +153,7 @@ class CoreInterrupts(implicit p: Parameters) extends TileInterrupts()(p) {
 // This is a raw commit trace from the core, not the TraceCoreInterface
 class TraceBundle(implicit val p: Parameters) extends Bundle with HasCoreParameters {
   val insns = Vec(coreParams.retireWidth, new TracedInstruction)
+  val time = UInt(64.W)
 }
 
 trait HasCoreIO extends HasTileParameters {

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -50,13 +50,13 @@ abstract class TilePRCIDomain[T <: BaseTile](
   private val traceSignalName = "trace"
   private val traceCoreSignalName = "tracecore"
   /** Node to broadcast legacy "raw" instruction trace while surpressing it during (async) reset. */
-  val traceNode: BundleBridgeIdentityNode[Vec[TracedInstruction]] = BundleBridgeNameNode(traceSignalName)
+  val traceNode: BundleBridgeIdentityNode[TraceBundle] = BundleBridgeNameNode(traceSignalName)
   /** Node to broadcast standardized instruction trace while surpressing it during (async) reset. */
   val traceCoreNode: BundleBridgeIdentityNode[TraceCoreInterface] = BundleBridgeNameNode(traceCoreSignalName)
 
   /** Function to handle all trace crossings when tile is instantiated inside domains */
   def crossTracesOut(): Unit = this {
-    val traceNexusNode = BundleBridgeBlockDuringReset[Vec[TracedInstruction]](
+    val traceNexusNode = BundleBridgeBlockDuringReset[TraceBundle](
       resetCrossingType = crossingParams.resetCrossingType,
       name = Some(traceSignalName))
     traceNode :*= traceNexusNode := tile.traceNode

--- a/src/main/scala/util/Blockable.scala
+++ b/src/main/scala/util/Blockable.scala
@@ -64,7 +64,7 @@ object Blockable {
 
   implicit object BlockableTraceBundle extends Blockable[TraceBundle] {
     def blockWhile(enable_blocking: Bool, data: TraceBundle) = {
-      val blocked = Wire(chiselTypeOf(data))
+      val blocked = WireInit(data)
       blocked.insns := implicitly[Blockable[Vec[TracedInstruction]]].blockWhile(enable_blocking, data.insns)
       blocked
     }

--- a/src/main/scala/util/Blockable.scala
+++ b/src/main/scala/util/Blockable.scala
@@ -4,6 +4,8 @@ package freechips.rocketchip.util
 
 import chisel3._
 import chisel3.util.DecoupledIO
+import freechips.rocketchip.tile.{TraceBundle}
+import freechips.rocketchip.rocket.{TracedInstruction}
 
 /** A trait supplying a function allowing the contents of data
   * to be supressed for a time period, i.e. be blocked.
@@ -56,6 +58,14 @@ object Blockable {
           g.itype := TraceItype.ITNothing
         }
       }
+      blocked
+    }
+  }
+
+  implicit object BlockableTraceBundle extends Blockable[TraceBundle] {
+    def blockWhile(enable_blocking: Bool, data: TraceBundle) = {
+      val blocked = Wire(chiselTypeOf(data))
+      blocked.insns := implicitly[Blockable[Vec[TracedInstruction]]].blockWhile(enable_blocking, data.insns)
       blocked
     }
   }


### PR DESCRIPTION
An alternative approach to #3355, core implementations can set a custom `traceCustom` field to pull out extra information out of the `TraceBundle`.

@bgottschall does this look OK for you?

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
