### PR TITLE
Make AsyncQueue use Rawmodule

### DIFF
--- a/src/main/scala/util/AsyncQueue.scala
+++ b/src/main/scala/util/AsyncQueue.scala
@@ -221,13 +221,8 @@ object ToAsyncBundle
 
 class AsyncQueue[T <: Data](gen: T, params: AsyncQueueParams = AsyncQueueParams()) extends Crossing[T] {
   val io = IO(new CrossingIO(gen))
-  val source = Module(new AsyncQueueSource(gen, params))
-  val sink   = Module(new AsyncQueueSink  (gen, params))
-
-  source.clock := io.enq_clock
-  source.reset := io.enq_reset
-  sink.clock := io.deq_clock
-  sink.reset := io.deq_reset
+  val source = withClockAndReset(io.enq_clock, io.enq_reset) { Module(new AsyncQueueSource(gen, params)) }
+  val sink   = withClockAndReset(io.deq_clock, io.deq_reset) { Module(new AsyncQueueSink  (gen, params)) }
 
   source.io.enq <> io.enq
   io.deq <> sink.io.deq

--- a/src/main/scala/util/Crossing.scala
+++ b/src/main/scala/util/Crossing.scala
@@ -16,6 +16,6 @@ class CrossingIO[T <: Data](gen: T) extends Bundle {
   val deq = Decoupled(gen)
 }
 
-abstract class Crossing[T <: Data] extends Module {
+abstract class Crossing[T <: Data] extends RawModule {
   val io: CrossingIO[T]
 }


### PR DESCRIPTION
This makes AsyncQueue easier to use in other RawModules.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**:   implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
