### PR TITLE
TLB: vsstatus.SUM check should not apply to Stage-2 fault before Stage-1 response

### DIFF
--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -100,6 +100,7 @@ class TLBEntryData(implicit p: Parameters) extends CoreBundle()(p) {
     */
   val ae_ptw = Bool()
   val ae_final = Bool()
+  val ae_stage2 = Bool()
   /** page fault */
   val pf = Bool()
   /** guest page fault */
@@ -443,6 +444,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
     newEntry.g := pte.g && pte.v
     newEntry.ae_ptw := io.ptw.resp.bits.ae_ptw
     newEntry.ae_final := io.ptw.resp.bits.ae_final
+    newEntry.ae_stage2 := io.ptw.resp.bits.ae_final && io.ptw.resp.bits.gpa_is_pte && r_stage2_en
     newEntry.pf := io.ptw.resp.bits.pf
     newEntry.gf := io.ptw.resp.bits.gf
     newEntry.hr := io.ptw.resp.bits.hr
@@ -503,7 +505,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   // if in hypervisor/machine mode, other than user pages, all pages are executable.
   // if in superviosr/user mode, only user page can execute.
   val priv_x_ok = Mux(priv_s, ~entries.map(_.u).asUInt, entries.map(_.u).asUInt)
-  val stage1_bypass = Fill(entries.size, usingHypervisor.B && !stage1_en)
+  val stage1_bypass = Fill(entries.size, usingHypervisor.B) & (Fill(entries.size, !stage1_en) | entries.map(_.ae_stage2).asUInt)
   val mxr = io.ptw.status.mxr | Mux(priv_v, io.ptw.gstatus.mxr, false.B)
   // "The vsstatus field MXR, which makes execute-only pages readable, only overrides VS-stage page protection.(from spec)"
   val r_array = Cat(true.B, (priv_rw_ok & (entries.map(_.sr).asUInt | Mux(mxr, entries.map(_.sx).asUInt, 0.U))) | stage1_bypass)


### PR DESCRIPTION
**Related issue**: The L1TLB (ITLB or DTLB) erroneously applies the `vsstatus.SUM` check to the PTW returned PTE `U` bit, even when the PTW returned `ae_final && stage2 && !stage2_final`: an access exception on Stage-2 PTW for Stage-1 PTE, i.e. before the final Stage-1 PTW (and its included `U` bit) was completed.

**Type of change**: bug report

**Impact**: functional change

**Development Phase**: implementation

**Release Notes**
L1TLB (ITLB and DTLB): add a new flop bit `ae_stage2` to OR into `stage1_bypass` when the PTW responds `ae_final && stage2 && !stage2_final`.