### PR TITLE
CSR: optionally set delegable hypervisor exceptions

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -424,7 +424,7 @@ class CSRFile(
 
     (sup.asUInt | supported_high_interrupts, del.asUInt)
   }
-  val delegable_exceptions = Seq(
+  val delegable_base_exceptions = Seq(
     Causes.misaligned_fetch,
     Causes.fetch_page_fault,
     Causes.breakpoint,
@@ -434,11 +434,18 @@ class CSRFile(
     Causes.misaligned_store,
     Causes.illegal_instruction,
     Causes.user_ecall,
+  )
+  val delegable_hypervisor_exceptions = Seq(
     Causes.virtual_supervisor_ecall,
     Causes.fetch_guest_page_fault,
     Causes.load_guest_page_fault,
     Causes.virtual_instruction,
-    Causes.store_guest_page_fault).map(1 << _).sum.U
+    Causes.store_guest_page_fault,
+  )
+  val delegable_exceptions = (
+    delegable_base_exceptions
+    ++ (if (usingHypervisor) delegable_hypervisor_exceptions else Seq())
+  ).map(1 << _).sum.U
 
   val hs_delegable_exceptions = Seq(
     Causes.misaligned_fetch,


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

The rocket-chip `medeleg` CSR is intentionally designed to hold only legal values. Given that `usingHypervisor` is used to distinguish whether the hardware supports hypervisor extensions (as seen from the source code everywhere), we should use it for the delegable exceptions as well.