### PR TITLE
PTW: set ae_ptw for out-of-range non-leaf PTEs

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -720,6 +720,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
           resp_valid(r_req_dest) := true.B
         }
 
+        resp_ae_ptw := ae && count < (pgLevels-1).U && pte.table()
         resp_ae_final := ae
         resp_pf := pf && !stage2
         resp_gf := gf || (pf && stage2)


### PR DESCRIPTION
For PTEs whose physical address is out-of-range, we need to set `ae_ptw` instead of `ae_final` to raise access-fault.

Because non-leaf PTEs will not have R or X bits set, `ae_final` will be overrided by page-fault exceptions.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
See https://github.com/chipsalliance/rocket-chip/issues/3402#issuecomment-1614229185 for more information.