### PR TITLE
Remove GenericParameterizedBundle since we already have autoclonetype in chisel

### DIFF
--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.util._
 
-abstract class AXI4BundleBase(params: AXI4BundleParameters) extends GenericParameterizedBundle(params)
+abstract class AXI4BundleBase(val params: AXI4BundleParameters) extends Bundle
 
 /**
   * Common signals of AW and AR channels of AXI4 protocol

--- a/src/main/scala/devices/tilelink/PhysicalFilter.scala
+++ b/src/main/scala/devices/tilelink/PhysicalFilter.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.util._
 case class DevicePMPParams(addressBits: Int, pageBits: Int)
 
 /** Defines the fields of the Device PMP registers */
-class DevicePMP(params: DevicePMPParams) extends GenericParameterizedBundle(params)
+class DevicePMP(val params: DevicePMPParams) extends Bundle
 {
   require (params.addressBits > params.pageBits)
 

--- a/src/main/scala/interrupts/Bundles.scala
+++ b/src/main/scala/interrupts/Bundles.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.interrupts
 import chisel3._
 import freechips.rocketchip.util._
 
-class SyncInterrupts(params: IntEdge) extends GenericParameterizedBundle(params)
+class SyncInterrupts(val params: IntEdge) extends Bundle
 {
   val sync = Vec(params.source.num, Bool())
 }

--- a/src/main/scala/tilelink/AtomicAutomata.scala
+++ b/src/main/scala/tilelink/AtomicAutomata.scala
@@ -288,15 +288,15 @@ object TLAtomicAutomata
 
   case class CAMParams(a: TLBundleParameters, domainsNeedingHelp: Int)
 
-  class CAM_S(params: CAMParams) extends GenericParameterizedBundle(params) {
+  class CAM_S(val params: CAMParams) extends Bundle {
     val state = UInt(2.W)
   }
-  class CAM_A(params: CAMParams) extends GenericParameterizedBundle(params) {
+  class CAM_A(val params: CAMParams) extends Bundle {
     val bits    = new TLBundleA(params.a)
     val fifoId  = UInt(log2Up(params.domainsNeedingHelp).W)
     val lut     = UInt(4.W)
   }
-  class CAM_D(params: CAMParams) extends GenericParameterizedBundle(params) {
+  class CAM_D(val params: CAMParams) extends Bundle {
     val data    = UInt(params.a.dataBits.W)
     val denied  = Bool()
     val corrupt = Bool()

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -9,7 +9,7 @@ import chisel3.util.Decoupled
 import chisel3.util.DecoupledIO
 import chisel3.experimental.DataMirror
 
-abstract class TLBundleBase(params: TLBundleParameters) extends GenericParameterizedBundle(params)
+abstract class TLBundleBase(val params: TLBundleParameters) extends Bundle
 
 // common combos in lazy policy:
 //   Put + Acquire
@@ -289,7 +289,7 @@ object TLBundle
   def apply(params: TLBundleParameters) = new TLBundle(params)
 }
 
-class TLAsyncBundleBase(params: TLAsyncBundleParameters) extends GenericParameterizedBundle(params)
+class TLAsyncBundleBase(val params: TLAsyncBundleParameters) extends Bundle
 
 class TLAsyncBundle(params: TLAsyncBundleParameters) extends TLAsyncBundleBase(params)
 {

--- a/src/main/scala/tilelink/RAMModel.scala
+++ b/src/main/scala/tilelink/RAMModel.scala
@@ -345,11 +345,11 @@ object TLRAMModel
 
   case class MonitorParameters(addressBits: Int, sizeBits: Int)
 
-  class ByteMonitor(params: MonitorParameters) extends GenericParameterizedBundle(params) {
+  class ByteMonitor(val params: MonitorParameters) extends Bundle {
     val valid = Bool()
     val value = UInt(8.W)
   }
-  class FlightMonitor(params: MonitorParameters) extends GenericParameterizedBundle(params) {
+  class FlightMonitor(val params: MonitorParameters) extends Bundle {
     val base    = UInt(params.addressBits.W)
     val size    = UInt(params.sizeBits.W)
     val opcode  = UInt(3.W)

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -46,7 +46,7 @@ case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends
       requestKeys    = AMBAProt +: sp.requestKeys)
   })
 
-class AHBControlBundle(params: TLEdge) extends GenericParameterizedBundle(params)
+class AHBControlBundle(val params: TLEdge) extends Bundle
 {
   val full   = Bool()
   val send   = Bool() // => full+data

--- a/src/main/scala/util/GenericParameterizedBundle.scala
+++ b/src/main/scala/util/GenericParameterizedBundle.scala
@@ -1,8 +1,0 @@
-// See LICENSE.SiFive for license details.
-
-package freechips.rocketchip.util
-
-import chisel3._
-
-@deprecated("GenericParameterizedBundle is useless anymore after autoclonetype2 is on.", "Rocket Chip 2021.04")
-abstract class GenericParameterizedBundle[+T <: Object](val params: T) extends Bundle


### PR DESCRIPTION
Chisel compiler plugin provides autoclonetype.
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
