### PR TITLE
remove linting package from RegisteredLibrary

### DIFF
--- a/src/main/resources/META-INF/services/firrtl.options.RegisteredLibrary
+++ b/src/main/resources/META-INF/services/firrtl.options.RegisteredLibrary
@@ -1,5 +1,1 @@
 firrtl.passes.memlib.MemLibOptions
-freechips.rocketchip.linting.LintReporter
-freechips.rocketchip.linting.rule.LintAnonymousRegisters
-freechips.rocketchip.linting.rule.LintTruncatingWidths
-freechips.rocketchip.linting.rule.LintConflictingModuleNames


### PR DESCRIPTION
**Type of change**:  other enhancement

**Impact**: no functional change

**Development Phase**: implementation

remove linting package from RegisteredLibrary since we have already removed the entire SFC in #3379 .