### PR TITLE
Support rocket cache rowBits != sbusWidth

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -10,6 +10,7 @@ import chisel3.experimental.SourceInfo
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tile._
+import freechips.rocketchip.tilelink.{TLWidthWidget}
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property
 
@@ -383,7 +384,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   val module: HasICacheFrontendModule
   val frontend = LazyModule(new Frontend(tileParams.icache.get, staticIdForMetadataUseOnly))
-  tlMasterXbar.node := frontend.masterNode
+  tlMasterXbar.node := TLWidthWidget(tileParams.icache.get.rowBits/8) := frontend.masterNode
   connectTLSlave(frontend.slaveNode, tileParams.core.fetchBytes)
   frontend.icache.hartIdSinkNodeOpt.foreach { _ := hartIdNexusNode }
   frontend.icache.mmioAddressPrefixSinkNodeOpt.foreach { _ := mmioAddressPrefixNexusNode }

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -237,6 +237,8 @@ class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
   dontTouch(io.cpu.resp) // Users like to monitor these fields even if the core ignores some signals
   dontTouch(io.cpu.s1_data)
 
+  require(rowBits == edge.bundle.dataBits)
+
   private val fifoManagers = edge.manager.managers.filter(TLFIFOFixer.allVolatile)
   fifoManagers.foreach { m =>
     require (m.fifoId == fifoManagers.head.fifoId,
@@ -266,7 +268,7 @@ trait HasHellaCache { this: BaseTile =>
   var nDCachePorts = 0
   lazy val dcache: HellaCache = LazyModule(p(BuildHellaCache)(this)(p))
 
-  tlMasterXbar.node := dcache.node
+  tlMasterXbar.node := TLWidthWidget(tileParams.dcache.get.rowBits/8) := dcache.node
   dcache.hartIdSinkNodeOpt.map { _ := hartIdNexusNode }
   dcache.mmioAddressPrefixSinkNodeOpt.map { _ := mmioAddressPrefixNexusNode }
   InModuleBody {

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -257,6 +257,16 @@ class WithL1DCacheWays(ways: Int) extends Config((site, here, up) => {
   }
 })
 
+
+class WithRocketCacheRowBits(n: Int) extends Config((site, here, up) => {
+  case TilesLocated(InSubsystem) => up(TilesLocated(InSubsystem), site) map {
+    case tp: RocketTileAttachParams => tp.copy(tileParams = tp.tileParams.copy(
+      dcache = tp.tileParams.dcache.map(_.copy(rowBits = n)),
+      icache = tp.tileParams.icache.map(_.copy(rowBits = n))))
+    case t => t
+  }
+})
+
 class WithCacheBlockBytes(linesize: Int) extends Config((site, here, up) => {
   case CacheBlockBytes => linesize
 })

--- a/src/main/scala/tile/L1Cache.scala
+++ b/src/main/scala/tile/L1Cache.scala
@@ -34,7 +34,7 @@ trait HasL1CacheParameters extends HasTileParameters {
   def nTLBSets = cacheParams.nTLBSets
   def nTLBWays = cacheParams.nTLBWays
 
-  def cacheDataBits = tlBundleParams.dataBits
+  def cacheDataBits = cacheParams.rowBits
   def cacheDataBytes = cacheDataBits / 8
   def cacheDataBeats = (cacheBlockBytes * 8) / cacheDataBits
   def refillCycles = cacheDataBeats


### PR DESCRIPTION
This is useful for designs with wide system interconnect, but narrow caches.

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
