### PR TITLE
Make StoreGen support narrow typ field

### DIFF
--- a/src/main/scala/rocket/AMOALU.scala
+++ b/src/main/scala/rocket/AMOALU.scala
@@ -8,7 +8,8 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 
 class StoreGen(typ: UInt, addr: UInt, dat: UInt, maxSize: Int) {
-  val size = typ(log2Up(log2Up(maxSize)+1)-1,0)
+  val size = Wire(UInt(log2Up(log2Up(maxSize)+1).W))
+  size := typ
   def misaligned: Bool =
     (addr & ((1.U << size) - 1.U)(log2Up(maxSize)-1,0)).orR
 


### PR DESCRIPTION
This makes it a bit easier to use the StoreGen circuit. StoreGen shouldn't error if the `typ` argument is narrower than `maxSize` would normally permit.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
