### PR TITLE
Fix the missing flow argument in TileLink/ToAXI4

### DIFF
--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -145,8 +145,8 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       val depth = if (combinational) 1 else 2
       val out_arw = Wire(Decoupled(new AXI4BundleARW(out.params)))
       val out_w = Wire(chiselTypeOf(out.w))
-      out.w :<>= Queue.irrevocable(out_w, entries=depth, combinational)
-      val queue_arw = Queue.irrevocable(out_arw, entries=depth, combinational)
+      out.w :<>= Queue.irrevocable(out_w, entries=depth, flow=combinational)
+      val queue_arw = Queue.irrevocable(out_arw, entries=depth, flow=combinational)
 
       // Fan out the ARW channel to AR and AW
       out.ar.bits := queue_arw.bits


### PR DESCRIPTION
`flow` must be explicitly passed to `Queue.irrevocable` to avoid mismatching the arguments.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #3287

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
