### PR TITLE
SContext is remaps to HContext when in VSMode

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -846,10 +846,17 @@ class CSRFile(
     val unvirtualized_mapping = (for (((k, _), v) <- read_mapping zip decoded) yield k -> v.asBool).toMap
 
     for ((k, v) <- unvirtualized_mapping) yield k -> {
-      val alt = CSR.mode(k) match {
-        case PRV.S => unvirtualized_mapping.lift(k + (1 << CSR.modeLSB))
-        case PRV.H => unvirtualized_mapping.lift(k - (1 << CSR.modeLSB))
-        case _ => None
+      val alt: Option[Bool] = CSR.mode(k) match {
+        // hcontext was assigned an unfortunate address; it lives where a
+        // hypothetical vscontext will live.  Exclude them from the S/VS remapping.
+        // (on separate lines so scala-lint doesnt do something stupid)
+        case _ if k == CSRs.scontext => None
+        case _ if k == CSRs.hcontext => None
+        // When V=1, if a corresponding VS CSR exists, access it instead...
+        case PRV.H                   => unvirtualized_mapping.lift(k - (1 << CSR.modeLSB))
+        // ...and don't access the original S-mode version.
+        case PRV.S                   => unvirtualized_mapping.contains(k + (1 << CSR.modeLSB)).option(false.B)
+        case _                       => None
       }
       alt.map(Mux(reg_mstatus.v, _, v)).getOrElse(v)
     }


### PR DESCRIPTION
* Fix the mapping when we access scontext or hcontext to ensure we don't switch targets.
    * hcontext is assigned an address in the middle of the VS register address range and should be excluded from the S->VS mapping.
* Add comment to clarify why we are mapping the S to VS and VS to S.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: functional fix

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
The previous code would have remapped `SContext` on to `HContext` when in VSMode. This is an error, unfortunately HContext was assigned the address that may have been given to `VSContext` if added in the future. The adjusted code will no longer map this incorrectly.
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
