### PR TITLE
Update ECC SRAM to improve throughput on full write

### DIFF
--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -229,8 +229,9 @@ class TLRAM(
     val r_ready = !d_wb && !r_replay && (!d_full || d_ready) && (!r_respond || (!d_win && in.d.ready))
     in.a.ready := !(d_full && d_wb) && (!r_full || r_ready) && (!r_full || !(r_atomic || r_sublane))
 
+    // ignore sublane if mask is all set
     val a_sublane = if (eccBytes == 1) false.B else
-      in.a.bits.opcode === TLMessages.PutPartialData ||
+      ((in.a.bits.opcode === TLMessages.PutPartialData) && (~in.a.bits.mask.andR)) ||
       in.a.bits.size < log2Ceil(eccBytes).U
     val a_atomic = if (!atomics) false.B else
       in.a.bits.opcode === TLMessages.ArithmeticData ||


### PR DESCRIPTION
**Type of change**: feature request

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Enhance ECC SRAM write throughput when eccBytes > 1 by 2 cycles per write when utilizing the full bus.
