### PR TITLE
Fix build.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -141,7 +141,6 @@ trait Emulator extends Cross.Module2[String, String] {
       os.proc("firtool",
         generator.chirrtl().path,
         s"--annotation-file=${generator.chiselAnno().path}",
-        "-disable-infer-rw",
         "--disable-annotation-unknown",
         "-dedup",
         "-O=debug",


### PR DESCRIPTION
 Option "-disable-infer-rw" was removed before firtool 1.37.0 used by Chisel 3.6.0 was release.
This patch fixes the build.