### PR TITLE
Remove deprecated RegisterRouter APIs

### DIFF
--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -68,50 +68,6 @@ case class AHBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes:
   }
 }
 
-// These convenience methods below combine to make it possible to create a AHB
-// register mapped device from a totally abstract register mapped device.
-
-@deprecated("Use HasAHBControlRegMap+HasInterruptSources traits in place of AHBRegisterRouter+AHBRegBundle+AHBRegModule", "rocket-chip 1.3")
-abstract class AHBRegisterRouterBase(address: AddressSet, interrupts: Int, concurrency: Int, beatBytes: Int, undefZero: Boolean, executable: Boolean)(implicit p: Parameters) extends LazyModule
-{
-  val node = AHBRegisterNode(address, concurrency, beatBytes, undefZero, executable)
-  val intnode = IntSourceNode(IntSourcePortSimple(num = interrupts))
-}
-
-@deprecated("AHBRegBundleArg is no longer necessary, use IO(...) to make any additional IOs", "rocket-chip 1.3")
-case class AHBRegBundleArg()(implicit val p: Parameters)
-
-@deprecated("AHBRegBundleBase is no longer necessary, use IO(...) to make any additional IOs", "rocket-chip 1.3")
-class AHBRegBundleBase(arg: AHBRegBundleArg) extends Bundle
-{
-  implicit val p = arg.p
-}
-
-@deprecated("Use HasAHBControlRegMap+HasInterruptSources traits in place of AHBRegisterRouter+AHBRegBundle+AHBRegModule", "rocket-chip 1.3")
-class AHBRegBundle[P](val params: P, arg: AHBRegBundleArg) extends AHBRegBundleBase(arg)
-
-@deprecated("Use HasAHBControlRegMap+HasInterruptSources traits in place of AHBRegisterRouter+AHBRegBundle+AHBRegModule", "rocket-chip 1.3")
-class AHBRegModule[P, B <: AHBRegBundleBase](val params: P, bundleBuilder: => B, router: AHBRegisterRouterBase)
-  extends LazyModuleImp(router) with HasRegMap
-{
-  val io = IO(bundleBuilder)
-  val interrupts = if (router.intnode.out.isEmpty) Vec(0, Bool()) else router.intnode.out(0)._1
-  def regmap(mapping: RegField.Map*) = router.node.regmap(mapping:_*)
-}
-
-@deprecated("Use HasAHBControlRegMap+HasInterruptSources traits in place of AHBRegisterRouter+AHBRegBundle+AHBRegModule", "rocket-chip 1.3")
-class AHBRegisterRouter[B <: AHBRegBundleBase, M <: LazyModuleImp]
-   (val base: BigInt, val interrupts: Int = 0, val size: BigInt = 4096, val concurrency: Int = 0, val beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)
-   (bundleBuilder: AHBRegBundleArg => B)
-   (moduleBuilder: (=> B, AHBRegisterRouterBase) => M)(implicit p: Parameters)
-  extends AHBRegisterRouterBase(AddressSet(base, size-1), interrupts, concurrency, beatBytes, undefZero, executable)
-{
-  require (isPow2(size))
-  // require (size >= 4096) ... not absolutely required, but highly recommended
-
-  lazy val module = moduleBuilder(bundleBuilder(AHBRegBundleArg()), this)
-}
-
 /** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
 trait HasAHBControlRegMap { this: RegisterRouter =>
   // Externally, this node should be used to connect the register control port to a bus

--- a/src/main/scala/amba/apb/RegisterRouter.scala
+++ b/src/main/scala/amba/apb/RegisterRouter.scala
@@ -49,50 +49,6 @@ case class APBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes:
   }
 }
 
-// These convenience methods below combine to make it possible to create a APB
-// register mapped device from a totally abstract register mapped device.
-
-@deprecated("Use HasAPBControlRegMap+HasInterruptSources traits in place of APBRegisterRouter+APBRegBundle+APBRegModule", "rocket-chip 1.3")
-abstract class APBRegisterRouterBase(address: AddressSet, interrupts: Int, concurrency: Int, beatBytes: Int, undefZero: Boolean, executable: Boolean)(implicit p: Parameters) extends LazyModule
-{
-  val node = APBRegisterNode(address, concurrency, beatBytes, undefZero, executable)
-  val intnode = IntSourceNode(IntSourcePortSimple(num = interrupts))
-}
-
-@deprecated("APBRegBundleArg is no longer necessary, use IO(...) to make any additional IOs", "rocket-chip 1.3")
-case class APBRegBundleArg()(implicit val p: Parameters)
-
-@deprecated("AXI4RegBundleBase is no longer necessary, use IO(...) to make any additional IOs", "rocket-chip 1.3")
-class APBRegBundleBase(arg: APBRegBundleArg) extends Bundle
-{
-  implicit val p = arg.p
-}
-
-@deprecated("Use HasAPBControlRegMap+HasInterruptSources traits in place of APBRegisterRouter+APBRegBundle+APBRegModule", "rocket-chip 1.3")
-class APBRegBundle[P](val params: P, arg: APBRegBundleArg) extends APBRegBundleBase(arg)
-
-@deprecated("Use HasAPBControlRegMap+HasInterruptSources traits in place of APBRegisterRouter+APBRegBundle+APBRegModule", "rocket-chip 1.3")
-class APBRegModule[P, B <: APBRegBundleBase](val params: P, bundleBuilder: => B, router: APBRegisterRouterBase)
-  extends LazyModuleImp(router) with HasRegMap
-{
-  val io = IO(bundleBuilder)
-  val interrupts = if (router.intnode.out.isEmpty) Vec(0, Bool()) else router.intnode.out(0)._1
-  def regmap(mapping: RegField.Map*) = router.node.regmap(mapping:_*)
-}
-
-@deprecated("Use HasAPBControlRegMap+HasInterruptSources traits in place of APBRegisterRouter+APBRegBundle+APBRegModule", "rocket-chip 1.3")
-class APBRegisterRouter[B <: APBRegBundleBase, M <: LazyModuleImp]
-   (val base: BigInt, val interrupts: Int = 0, val size: BigInt = 4096, val concurrency: Int = 0, val beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)
-   (bundleBuilder: APBRegBundleArg => B)
-   (moduleBuilder: (=> B, APBRegisterRouterBase) => M)(implicit p: Parameters)
-  extends APBRegisterRouterBase(AddressSet(base, size-1), interrupts, concurrency, beatBytes, undefZero, executable)
-{
-  require (isPow2(size))
-  // require (size >= 4096) ... not absolutely required, but highly recommended
-
-  lazy val module = moduleBuilder(bundleBuilder(APBRegBundleArg()), this)
-}
-
 /** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
 trait HasAPBControlRegMap { this: RegisterRouter =>
   // Externally, this node should be used to connect the register control port to a bus

--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -83,50 +83,6 @@ case class AXI4RegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes
   }
 }
 
-// These convenience methods below combine to make it possible to create a AXI4
-// register mapped device from a totally abstract register mapped device.
-
-@deprecated("Use HasAXI4ControlRegMap+HasInterruptSources traits in place of AXI4RegisterRouter+AXI4RegBundle+AXI4RegModule", "rocket-chip 1.3")
-abstract class AXI4RegisterRouterBase(address: AddressSet, interrupts: Int, concurrency: Int, beatBytes: Int, undefZero: Boolean, executable: Boolean)(implicit p: Parameters) extends LazyModule
-{
-  val node = AXI4RegisterNode(address, concurrency, beatBytes, undefZero, executable)
-  val intnode = IntSourceNode(IntSourcePortSimple(num = interrupts))
-}
-
-@deprecated("AXI4RegBundleArg is no longer necessary, use IO(...) to make any additional IOs", "rocket-chip 1.3")
-case class AXI4RegBundleArg()(implicit val p: Parameters)
-
-@deprecated("AXI4RegBundleBase is no longer necessary, use IO(...) to make any additional IOs", "rocket-chip 1.3")
-class AXI4RegBundleBase(arg: AXI4RegBundleArg) extends Bundle
-{
-  implicit val p = arg.p
-}
-
-@deprecated("Use HasAXI4ControlRegMap+HasInterruptSources traits in place of AXI4RegisterRouter+AXI4RegBundle+AXI4RegModule", "rocket-chip 1.3")
-class AXI4RegBundle[P](val params: P, arg: AXI4RegBundleArg) extends AXI4RegBundleBase(arg)
-
-@deprecated("Use HasAXI4ControlRegMap+HasInterruptSources traits in place of AXI4RegisterRouter+AXI4RegBundle+AXI4RegModule", "rocket-chip 1.3")
-class AXI4RegModule[P, B <: AXI4RegBundleBase](val params: P, bundleBuilder: => B, router: AXI4RegisterRouterBase)
-  extends LazyModuleImp(router) with HasRegMap
-{
-  val io = IO(bundleBuilder)
-  val interrupts = if (router.intnode.out.isEmpty) Vec(0, Bool()) else router.intnode.out(0)._1
-  def regmap(mapping: RegField.Map*) = router.node.regmap(mapping:_*)
-}
-
-@deprecated("Use HasAXI4ControlRegMap+HasInterruptSources traits in place of AXI4RegisterRouter+AXI4RegBundle+AXI4RegModule", "rocket-chip 1.3")
-class AXI4RegisterRouter[B <: AXI4RegBundleBase, M <: LazyModuleImp]
-   (val base: BigInt, val interrupts: Int = 0, val size: BigInt = 4096, val concurrency: Int = 0, val beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)
-   (bundleBuilder: AXI4RegBundleArg => B)
-   (moduleBuilder: (=> B, AXI4RegisterRouterBase) => M)(implicit p: Parameters)
-  extends AXI4RegisterRouterBase(AddressSet(base, size-1), interrupts, concurrency, beatBytes, undefZero, executable)
-{
-  require (isPow2(size))
-  // require (size >= 4096) ... not absolutely required, but highly recommended
-
-  lazy val module = moduleBuilder(bundleBuilder(AXI4RegBundleArg()), this)
-}
-
 /** Mix this trait into a RegisterRouter to be able to attach its register map to an AXI4 bus */
 trait HasAXI4ControlRegMap { this: RegisterRouter =>
   protected val controlNode = AXI4RegisterNode(


### PR DESCRIPTION
I could not find users for these that would resist this change

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
