### PR TITLE
Use sortedSlaves in some TL helpers

### DIFF
--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -177,6 +177,7 @@ class TLSlaveParameters private(
                                    // ReleaseAck may NEVER be denied
   extends SimpleProduct
 {
+  def sortedAddress = address.sorted
   override def canEqual(that: Any): Boolean = that.isInstanceOf[TLSlaveParameters]
   override def productPrefix = "TLSlaveParameters"
   // We intentionally omit nodePath for equality testing / formatting
@@ -516,6 +517,7 @@ class TLSlavePortParameters private(
   val responseFields: Seq[BundleFieldBase],
   val requestKeys:    Seq[BundleKeyBase]) extends SimpleProduct
 {
+  def sortedSlaves = slaves.sortBy(_.sortedAddress.head)
   override def canEqual(that: Any): Boolean = that.isInstanceOf[TLSlavePortParameters]
   override def productPrefix = "TLSlavePortParameters"
   def productArity: Int = 6
@@ -596,16 +598,16 @@ class TLSlavePortParameters private(
   def find(address: BigInt) = slaves.find(_.address.exists(_.contains(address)))
 
   // The safe version will check the entire address
-  def findSafe(address: UInt) = VecInit(slaves.map(_.address.map(_.contains(address)).reduce(_ || _)))
+  def findSafe(address: UInt) = VecInit(sortedSlaves.map(_.address.map(_.contains(address)).reduce(_ || _)))
   // The fast version assumes the address is valid (you probably want fastProperty instead of this function)
   def findFast(address: UInt) = {
     val routingMask = AddressDecoder(slaves.map(_.address))
-    VecInit(slaves.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
+    VecInit(sortedSlaves.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
   }
 
   // Compute the simplest AddressSets that decide a key
   def fastPropertyGroup[K](p: TLSlaveParameters => K): Seq[(K, Seq[AddressSet])] = {
-    val groups = groupByIntoSeq(slaves.map(m => (p(m), m.address)))( _._1).map { case (k, vs) =>
+    val groups = groupByIntoSeq(sortedSlaves.map(m => (p(m), m.address)))( _._1).map { case (k, vs) =>
       k -> vs.flatMap(_._2)
     }
     val reductionMask = AddressDecoder(groups.map(_._2))


### PR DESCRIPTION
This avoids cases where identical TLSlavePortParameters (but with different orderings of TLSlaveParameters) produce different, yet logically-equivalent RTL (reduction trees in findSafe, for instance)

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
