### PR TITLE
Prepare to purge resource API

### DIFF
--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -42,6 +42,6 @@ class GroundTestSubsystem(implicit p: Parameters)
 
 class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer) {
   val success = IO(Output(Bool()))
-  val status = dontTouch(DebugCombiner(outer.tileStatusNodes.map(_.bundle).toSeq))
-  success := outer.tileCeaseSinkNode.in.head._1.asUInt.andR
+  val status = dontTouch(DebugCombiner(_outer.tileStatusNodes.map(_.bundle).toSeq))
+  success := _outer.tileCeaseSinkNode.in.head._1.asUInt.andR
 }

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -49,5 +49,7 @@ class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
 }
 
 class RocketSubsystemModuleImp[+L <: RocketSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)
-    with HasHierarchicalElementsRootContextModuleImp
+    with HasHierarchicalElementsRootContextModuleImp {
+  override lazy val outer = _outer
+}
 


### PR DESCRIPTION
I split the traditional Resource Binding out from BareSubsystem, I should not break any dependency on `BaseSubsytem`.
But for a modern API in the future, I prepare to land the brand new `Property` API in Chisel and `OM` API in CIRCT for metadata processing.