### PR TITLE
Purge xbus in BaseSubsystem

### DIFF
--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -105,7 +105,7 @@ trait CanHavePeripheryCLINT { this: BaseSubsystem =>
   val (clintOpt, clintDomainOpt, clintTickOpt) = p(CLINTKey).map { params =>
     val tlbus = locateTLBusWrapper(p(CLINTAttachKey).slaveWhere)
     val clintDomainWrapper = tlbus.generateSynchronousDomain.suggestName("clint_domain")
-    val clint = clintDomainWrapper { LazyModule(new CLINT(params, cbus.beatBytes)) }
+    val clint = clintDomainWrapper { LazyModule(new CLINT(params, tlbus.beatBytes)) }
     clintDomainWrapper { clint.node := tlbus.coupleTo("clint") { TLFragmenter(tlbus) := _ } }
     val clintTick = clintDomainWrapper { InModuleBody {
       val tick = IO(Input(Bool()))

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -21,8 +21,8 @@ class GroundTestSubsystem(implicit p: Parameters)
   with HasTileInputConstants
   with CanHaveMasterAXI4MemPort
 {
-  val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), beatBytes=pbus.beatBytes))
-  pbus.coupleTo("TestRAM") { testram.node := TLFragmenter(pbus) := _ }
+  val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), beatBytes=tlBusWrapperLocationMap.get(PBUS).getOrElse(tlBusWrapperLocationMap(p(TLManagerViewpointLocated(location)))).beatBytes))
+  tlBusWrapperLocationMap.lift(PBUS).getOrElse(tlBusWrapperLocationMap(p(TLManagerViewpointLocated(location)))).coupleTo("TestRAM") { testram.node := TLFragmenter(tlBusWrapperLocationMap.lift(PBUS).getOrElse(tlBusWrapperLocationMap(p(TLManagerViewpointLocated(location))))) := _ }
 
   // No cores to monitor
   def coreMonitorBundles = Nil


### PR DESCRIPTION
There should be no xbus in the API, while users must use Location API to query and attach their own devices.