### PR TITLE
Support pulling out full imul response

### DIFF
--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -17,6 +17,7 @@ class MultiplierReq(dataBits: Int, tagBits: Int, aluFn: ALUFN = new ALUFN) exten
 
 class MultiplierResp(dataBits: Int, tagBits: Int) extends Bundle {
   val data = Bits(dataBits.W)
+  val full_data = Bits((2*dataBits).W)
   val tag = UInt(tagBits.W)
 }
 
@@ -175,6 +176,7 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32, aluFn: ALUFN = new A
   io.resp.bits.tag := req.tag
 
   io.resp.bits.data := Cat(hiOut, loOut)
+  io.resp.bits.full_data := Cat(remainder(2*w, w+1), remainder(w-1, 0))
   io.resp.valid := (state === s_done_mul || state === s_done_div)
   io.req.ready := state === s_ready
 }
@@ -205,4 +207,5 @@ class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32, aluFn: ALUFN
   io.resp.valid := resp.valid
   io.resp.bits.tag := resp.bits.tag
   io.resp.bits.data := Pipe(in.valid, muxed, latency-1).bits
+  io.resp.bits.full_data := Pipe(in.valid, prod, latency-1).bits.asUInt
 }


### PR DESCRIPTION
Some area-minimal implementations will want to use the iterative multiplier, but need the full accumulator.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
