### PR TITLE
Fix performance bug in NBDCache

### DIFF
--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -102,7 +102,7 @@ class IOMSHR(id: Int)(implicit edge: TLEdgeOut, p: Parameters) extends L1HellaCa
   io.mem_access.valid := (state === s_mem_access)
   io.mem_access.bits := Mux(isAMO(req.cmd), atomics, Mux(isRead(req.cmd), get, put))
 
-  io.replay_next := (state === s_mem_ack) || io.resp.valid && !io.resp.ready
+  io.replay_next := io.resp.valid && !io.resp.ready
   io.resp.valid := (state === s_resp)
   io.resp.bits.addr := req.addr
   io.resp.bits.idx.foreach(_ := req.idx.get)


### PR DESCRIPTION
NBDCache shouldn't request replays indefinitely until ack is received

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
