### PR TITLE
Support managers with < pageSize alignment

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -552,7 +552,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
       require(TLBPageLookup.homogeneous(edge.manager.managers, pgSize), s"All memory regions must be $pgSize-byte aligned")
       true.B
     } else {
-      TLBPageLookup(edge.manager.managers, xLen, p(CacheBlockBytes), pgSize)(r_pte.ppn << pgIdxBits).homogeneous
+      TLBPageLookup(edge.manager.managers, xLen, p(CacheBlockBytes), pgSize, xLen/8)(r_pte.ppn << pgIdxBits).homogeneous
     }
   }
   val pmaHomogeneous = pmaPgLevelHomogeneous(count)

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -412,7 +412,8 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   pma.io.paddr := mpu_physaddr
   // todo: using DataScratchpad doesn't support cacheable.
   val cacheable = pma.io.resp.cacheable && (instruction || !usingDataScratchpad).B
-  val homogeneous = TLBPageLookup(edge.manager.managers, xLen, p(CacheBlockBytes), BigInt(1) << pgIdxBits)(mpu_physaddr).homogeneous
+  val homogeneous = TLBPageLookup(edge.manager.managers, xLen, p(CacheBlockBytes), BigInt(1) << pgIdxBits, 1 << lgMaxSize)(mpu_physaddr).homogeneous
+  // In M mode, if access DM address(debug module program buffer)
   val deny_access_to_debug = mpu_priv <= PRV.M.U && p(DebugModuleKey).map(dmp => dmp.address.contains(mpu_physaddr)).getOrElse(false.B)
   val prot_r = pma.io.resp.r && !deny_access_to_debug && pmp.io.r
   val prot_w = pma.io.resp.w && !deny_access_to_debug && pmp.io.w

--- a/src/main/scala/rocket/TLBPermissions.scala
+++ b/src/main/scala/rocket/TLBPermissions.scala
@@ -51,13 +51,13 @@ object TLBPageLookup
   }
 
   // Unmapped memory is considered to be inhomogeneous
-  def apply(managers: Seq[TLManagerParameters], xLen: Int, cacheBlockBytes: Int, pageSize: BigInt): UInt => TLBPermissions = {
+  def apply(managers: Seq[TLManagerParameters], xLen: Int, cacheBlockBytes: Int, pageSize: BigInt, maxRequestBytes: Int): UInt => TLBPermissions = {
     require (isPow2(xLen) && xLen >= 8)
     require (isPow2(cacheBlockBytes) && cacheBlockBytes >= xLen/8)
     require (isPow2(pageSize) && pageSize >= cacheBlockBytes)
 
     val xferSizes = TransferSizes(cacheBlockBytes, cacheBlockBytes)
-    val allSizes = TransferSizes(1, cacheBlockBytes)
+    val allSizes = TransferSizes(1, maxRequestBytes)
     val amoSizes = TransferSizes(4, xLen/8)
 
     val permissions = managers.foreach { m =>


### PR DESCRIPTION
Previously, the rocket permissions checker assumed that Rocket could generate Get/Put requests up to CacheBlockBytes in size. This is actually not possible, Rocket by itself will not generate requests > xLen in size.

This relaxes the check within rocket to check for a maxSize of xLen/8. 

Implementations which may perform > xLen/8 byte accesses simply set a higher lgMaxSize for the TLB.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
