### PR TITLE
Fix missing no_resp field in TraceGen hella-cache req

### DIFF
--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -533,6 +533,7 @@ class TraceGenerator(val params: TraceGenParams)(implicit val p: Parameters) ext
   io.mem.req.bits.tag  := reqTag
   io.mem.req.bits.no_alloc := false.B
   io.mem.req.bits.no_xcpt := false.B
+  io.mem.req.bits.no_resp := false.B
   io.mem.req.bits.mask := ~(0.U((numBitsInWord / 8).W))
   io.mem.req.bits.phys := false.B
   io.mem.req.bits.dprv := PRV.M.U


### PR DESCRIPTION
Spot fix for the API addition in #3588 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
