### PR TITLE
PTW Hypervisor bug fixes: check GPA bits higher than HGATP.Mode

### DIFF
--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -589,9 +589,9 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   val pf_ld_array = Mux(cmd_read, ((~Mux(cmd_readx, x_array, r_array) & ~ptw_ae_array) | ptw_pf_array) & ~ptw_gf_array, 0.U)
   val pf_st_array = Mux(cmd_write_perms, ((~w_array & ~ptw_ae_array) | ptw_pf_array) & ~ptw_gf_array, 0.U)
   val pf_inst_array = ((~x_array & ~ptw_ae_array) | ptw_pf_array) & ~ptw_gf_array
-  val gf_ld_array = Mux(priv_v && cmd_read, ~Mux(cmd_readx, hx_array, hr_array) & ~ptw_ae_array, 0.U)
-  val gf_st_array = Mux(priv_v && cmd_write_perms, ~hw_array & ~ptw_ae_array, 0.U)
-  val gf_inst_array = Mux(priv_v, ~hx_array & ~ptw_ae_array, 0.U)
+  val gf_ld_array = Mux(priv_v && cmd_read, (~Mux(cmd_readx, hx_array, hr_array) | ptw_gf_array) & ~ptw_ae_array, 0.U)
+  val gf_st_array = Mux(priv_v && cmd_write_perms, (~hw_array | ptw_gf_array) & ~ptw_ae_array, 0.U)
+  val gf_inst_array = Mux(priv_v, (~hx_array | ptw_gf_array) & ~ptw_ae_array, 0.U)
 
   val gpa_hits = {
     val need_gpa_mask = if (instruction) gf_inst_array else gf_ld_array | gf_st_array

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -18,6 +18,12 @@ package object util {
     def isOneOf(u1: UInt, u2: UInt*): Bool = isOneOf(u1 +: u2.toSeq)
   }
 
+  implicit class VecToAugmentedVec[T <: Data](private val x: Vec[T]) extends AnyVal {
+
+    /** Like Vec.apply(idx), but tolerates indices of mismatched width */
+    def extract(idx: UInt): T = x((idx | 0.U(log2Ceil(x.size).W)).extract(log2Ceil(x.size) - 1, 0))
+  }
+
   implicit class SeqToAugmentedSeq[T <: Data](private val x: Seq[T]) extends AnyVal {
     def apply(idx: UInt): T = {
       if (x.size <= 1) {
@@ -33,6 +39,8 @@ package object util {
         x.zipWithIndex.tail.foldLeft(x.head) { case (prev, (cur, i)) => Mux(truncIdx === i.U, cur, prev) }
       }
     }
+
+    def extract(idx: UInt): T = VecInit(x).extract(idx)
 
     def asUInt: UInt = Cat(x.map(_.asUInt).reverse)
 


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

**Type of change**: bug report

**Impact**: functional fix

**Development Phase**: implementation

**Release Notes**
1. The PTE Cache is supposed to cache the address being requested from memory.
2. The RISC-V Privileged ISA spec states that, for _every_ Stage-2 walk at _every level_ of Stage-1 walk, we need to check
> For Sv39x4, ... Address bits 63:41 must all be zeros, ...
> For Sv48x4, ... Address bits 63:50 must all be zeros, ...
> For Sv57x4, ... Address bits 63:59 must all be zeros, ...
> or else a guest-page-fault exception occurs.
