### PR TITLE
Allow TLFragmenter to fragment from non-probable masters

### DIFF
--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -92,8 +92,9 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         val beatBytes = manager.beatBytes
         val fifoId = managers(0).fifoId
         require (fifoId.isDefined && managers.map(_.fifoId == fifoId).reduce(_ && _))
-        require (!manager.anySupportAcquireB)
-
+        require (!manager.anySupportAcquireB || !edgeOut.client.anySupportProbe,
+          s"TLFragmenter (with parent $parent) can't fragment a caching client's requests into a cacheable region")
+        
         require (minSize >= beatBytes, s"TLFragmenter (with parent $parent) can't support fragmenting ($minSize) to sub-beat ($beatBytes) accesses")
         // We can't support devices which are cached on both sides of us
         require (!edgeOut.manager.anySupportAcquireB || !edgeIn.client.anySupportProbe)


### PR DESCRIPTION
This should be safe. TLFragmenter can't fragment caching requests. But masters which are non-probable (non-caching) will only generate non-caching requests, which are fragmentable.


**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
