### PR TITLE
Migrate diplomacy imports to standalone diplomacy

### DIFF
--- a/src/main/scala/devices/debug/APB.scala
+++ b/src/main/scala/devices/debug/APB.scala
@@ -1,10 +1,13 @@
 // See LICENSE.SiFive for license details.
 
 package freechips.rocketchip.devices.debug
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.amba.apb.{APBRegisterNode}
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.apb.APBRegisterNode
+import freechips.rocketchip.diplomacy.AddressSet
+import freechips.rocketchip.regmapper.RegField
 
 case object APBDebugRegistersKey extends Field[Map[Int, Seq[RegField]]](Map())
 

--- a/src/main/scala/devices/debug/Custom.scala
+++ b/src/main/scala/devices/debug/Custom.scala
@@ -3,10 +3,13 @@
 package freechips.rocketchip.devices.debug
 
 import chisel3._
+import chisel3.experimental._
 import chisel3.util._
-import chisel3.experimental.SourceInfo
-import freechips.rocketchip.diplomacy._
-import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
 
 case class DebugCustomParams(
   addrs: List[Int],

--- a/src/main/scala/devices/debug/DMI.scala
+++ b/src/main/scala/devices/debug/DMI.scala
@@ -4,10 +4,13 @@ package freechips.rocketchip.devices.debug
 
 import chisel3._
 import chisel3.util._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.util._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.TransferSizes
+import freechips.rocketchip.tilelink.{TLClientNode, TLMasterParameters, TLMasterPortParameters, TLMasterToSlaveTransferSizes}
+import freechips.rocketchip.util.ParameterizedBundle
 
 /** Constant values used by both Debug Bus Response & Request
   */

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -5,24 +5,28 @@ package freechips.rocketchip.devices.debug
 
 import chisel3._
 import chisel3.util._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.apb.{APBFanout, APBToTL}
+import freechips.rocketchip.devices.debug.systembusaccess.{SBToTL, SystemBusAccessModule}
+import freechips.rocketchip.devices.tilelink.{DevNullParams, TLBusBypass, TLError}
+import freechips.rocketchip.diplomacy.{AddressSet, BufferParams, Description, Device, Resource, ResourceBindings, ResourceString, SimpleDevice}
+import freechips.rocketchip.interrupts.{IntNexusNode, IntSinkParameters, IntSinkPortParameters, IntSourceParameters, IntSourcePortParameters, IntSyncCrossingSource, IntSyncIdentityNode}
+import freechips.rocketchip.regmapper.{RegField, RegFieldAccessType, RegFieldDesc, RegFieldGroup, RegFieldWrType, RegReadFn, RegWriteFn}
 import freechips.rocketchip.rocket.{CSRs, Instructions}
 import freechips.rocketchip.tile.MaxHartIdBits
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.devices.tilelink.{DevNullParams, TLError}
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.util._
-import freechips.rocketchip.devices.debug.systembusaccess._
-import freechips.rocketchip.devices.tilelink.TLBusBypass
-import freechips.rocketchip.amba.apb.{APBToTL, APBFanout}
+import freechips.rocketchip.tilelink.{TLAsyncCrossingSink, TLAsyncCrossingSource, TLBuffer, TLRegisterNode, TLXbar}
+import freechips.rocketchip.util.{Annotated, AsyncBundle, AsyncQueueParams, AsyncResetSynchronizerShiftReg, FromAsyncBundle, ParameterizedBundle, ResetSynchronizerShiftReg, ToAsyncBundle}
+
+import freechips.rocketchip.util.SeqBoolBitwiseOps
+import freechips.rocketchip.util.SeqToAugmentedSeq
 import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
 object DsbBusConsts {
   def sbAddrWidth = 12
-  def sbIdWidth   = 10 
-
+  def sbIdWidth   = 10
 }
 
 object DsbRegAddrs{

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -3,18 +3,21 @@
 package freechips.rocketchip.devices.debug
 
 import chisel3._
-import chisel3.experimental.{IntParam, noPrefix}
+import chisel3.experimental._
 import chisel3.util._
-import chisel3.util.HasBlackBoxResource
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.amba.apb._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.jtag._
-import freechips.rocketchip.util._
-import freechips.rocketchip.prci.{ClockSinkParameters, ClockSinkNode}
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.interrupts.{NullIntSyncSource, IntSyncXbar}
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.apb.{APBBundle, APBBundleParameters, APBMasterNode, APBMasterParameters, APBMasterPortParameters}
+import freechips.rocketchip.interrupts.{IntSyncXbar, NullIntSyncSource}
+import freechips.rocketchip.jtag.JTAGIO
+import freechips.rocketchip.prci.{ClockSinkNode, ClockSinkParameters}
+import freechips.rocketchip.subsystem.{BaseSubsystem, CBUS, FBUS, ResetSynchronous, SubsystemResetSchemeKey, TLBusWrapperLocation}
+import freechips.rocketchip.tilelink.{TLFragmenter, TLWidthWidget}
+import freechips.rocketchip.util.{AsyncResetSynchronizerShiftReg, CanHavePSDTestModeIO, ClockGate, PSDTestMode, PlusArg, ResetSynchronizerShiftReg}
+
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
 /** Protocols used for communicating with external debugging tools */
 sealed trait DebugExportProtocol

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -4,13 +4,16 @@ package freechips.rocketchip.devices.debug.systembusaccess
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.amba._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
+import freechips.rocketchip.devices.debug.{DebugModuleKey, RWNotify, SBCSFields, WNotifyVal}
+import freechips.rocketchip.diplomacy.TransferSizes
+import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup, RegFieldWrType}
+import freechips.rocketchip.tilelink.{TLClientNode, TLMasterParameters, TLMasterPortParameters}
 import freechips.rocketchip.util.property
-import freechips.rocketchip.devices.debug._
 
 object SystemBusAccessState extends scala.Enumeration {
    type SystemBusAccessState = Value

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -3,11 +3,15 @@
 package freechips.rocketchip.devices.tilelink
 
 import chisel3._
-import chisel3.util.log2Ceil
-import org.chipsalliance.cde.config.{Field, Parameters}
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, RegionType, Resource, SimpleDevice, TransferSizes}
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import freechips.rocketchip.tilelink.{TLFragmenter, TLManagerNode, TLSlaveParameters, TLSlavePortParameters}
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}

--- a/src/main/scala/devices/tilelink/BusBlocker.scala
+++ b/src/main/scala/devices/tilelink/BusBlocker.scala
@@ -3,10 +3,13 @@
 package freechips.rocketchip.devices.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp, SimpleDevice}
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, SimpleDevice}
 import freechips.rocketchip.regmapper.{RegField, RegFieldDesc}
-import freechips.rocketchip.tilelink.{TLFragmenter, TLRegisterNode, TLBusWrapper, TLNameNode, TLNode}
+import freechips.rocketchip.tilelink.{TLBusWrapper, TLFragmenter, TLNameNode, TLNode, TLRegisterNode}
 
 /** Parameterize a BasicBusBlocker.
   *

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -3,14 +3,17 @@
 package freechips.rocketchip.devices.tilelink
 
 import chisel3._
-import chisel3.util.ShiftRegister
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, Resource, SimpleDevice}
+import freechips.rocketchip.interrupts.{IntNexusNode, IntSinkParameters, IntSinkPortParameters, IntSourceParameters, IntSourcePortParameters}
+import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup}
+import freechips.rocketchip.subsystem.{BaseSubsystem, CBUS, TLBusWrapperLocation}
+import freechips.rocketchip.tilelink.{TLFragmenter, TLRegisterNode}
+import freechips.rocketchip.util.Annotated
 
 object CLINTConsts
 {

--- a/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
+++ b/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
@@ -2,9 +2,11 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, BufferParams}
+import freechips.rocketchip.tilelink.{HasTLBusParams, TLBuffer, TLCacheCork, TLCacheCorkParams, TLFragmenter, TLOutwardNode, TLTempNode}
 
 case class BuiltInZeroDeviceParams(
   addr: AddressSet,
@@ -63,4 +65,3 @@ object BuiltInDevices {
 trait CanHaveBuiltInDevices {
   def builtInDevices: BuiltInDevices
 }
-

--- a/src/main/scala/devices/tilelink/ClockBlocker.scala
+++ b/src/main/scala/devices/tilelink/ClockBlocker.scala
@@ -3,12 +3,14 @@
 package freechips.rocketchip.devices.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.prci._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, SimpleDevice}
+import freechips.rocketchip.prci.ClockAdapterNode
+import freechips.rocketchip.regmapper.{RegField, RegFieldDesc}
+import freechips.rocketchip.tilelink.TLRegisterNode
+import freechips.rocketchip.util.ClockGate
 
 /** This device extends a basic bus blocker by allowing it to gate the clocks of the device
   * whose tilelink port is being blocked. For now it is only possible to block

--- a/src/main/scala/devices/tilelink/DevNull.scala
+++ b/src/main/scala/devices/tilelink/DevNull.scala
@@ -2,9 +2,13 @@
 
 package freechips.rocketchip.devices.tilelink
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, HasClockDomainCrossing, RegionType, SimpleDevice, TransferSizes}
+import freechips.rocketchip.tilelink.{TLManagerNode, TLSlaveParameters, TLSlavePortParameters}
+
+import freechips.rocketchip.tilelink.TLClockDomainCrossing
 
 case class DevNullParams(
   address: Seq[AddressSet],

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -4,9 +4,12 @@ package freechips.rocketchip.devices.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.SimpleDevice
+import freechips.rocketchip.tilelink.{TLArbiter, TLMessages, TLPermissions}
 
 /** Adds a /dev/null slave that generates TL error response messages */
 class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters)

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -4,11 +4,16 @@ package freechips.rocketchip.devices.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, RegionType, SimpleDevice, TransferSizes}
 import freechips.rocketchip.subsystem.{Attachable, HierarchicalLocation, TLBusWrapperLocation}
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import freechips.rocketchip.tilelink.{TLFragmenter, TLManagerNode, TLSlaveParameters, TLSlavePortParameters, TLWidthWidget}
+import freechips.rocketchip.util.{ROMConfig, ROMGenerator}
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 case class MaskROMParams(address: BigInt, name: String, depth: Int = 2048, width: Int = 32)
 

--- a/src/main/scala/devices/tilelink/MasterMux.scala
+++ b/src/main/scala/devices/tilelink/MasterMux.scala
@@ -3,9 +3,17 @@
 package freechips.rocketchip.devices.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes}
+import freechips.rocketchip.tilelink.{
+  LFSR64, TLBundleA, TLBundleC, TLBundleE, TLClientNode, TLCustomNode, TLFilter, TLFragmenter,
+  TLFuzzer, TLMasterParameters, TLMasterPortParameters, TLPermissions, TLRAM, TLRAMModel,
+  TLSlaveParameters, TLSlavePortParameters
+}
 
 class MasterMuxNode(uFn: Seq[TLMasterPortParameters] => TLMasterPortParameters)(implicit valName: ValName) extends TLCustomNode
 {

--- a/src/main/scala/devices/tilelink/PhysicalFilter.scala
+++ b/src/main/scala/devices/tilelink/PhysicalFilter.scala
@@ -4,11 +4,15 @@ package freechips.rocketchip.devices.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, SimpleDevice}
+import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup, RegFieldWrType, RegReadFn, RegWriteFn}
+import freechips.rocketchip.tilelink.{TLAdapterNode, TLMessages, TLPermissions, TLRegisterNode}
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 case class DevicePMPParams(addressBits: Int, pageBits: Int)
 

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -3,18 +3,23 @@
 package freechips.rocketchip.devices.tilelink
 
 import chisel3._
+import chisel3.experimental._
 import chisel3.util._
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
-import chisel3.experimental.SourceInfo
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, Description, Resource, ResourceBinding, ResourceBindings, ResourceInt, SimpleDevice}
+import freechips.rocketchip.interrupts.{IntNexusNode, IntSinkParameters, IntSinkPortParameters, IntSourceParameters, IntSourcePortParameters}
+import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldRdAction, RegFieldWrType, RegReadFn, RegWriteFn}
+import freechips.rocketchip.subsystem.{BaseSubsystem, CBUS, TLBusWrapperLocation}
+import freechips.rocketchip.tilelink.{TLFragmenter, TLRegisterNode}
+import freechips.rocketchip.util.{Annotated, MuxT, property}
 
 import scala.math.min
+
+import freechips.rocketchip.util.UIntToAugmentedUInt
+import freechips.rocketchip.util.SeqToAugmentedSeq
 
 class GatewayPLICIO extends Bundle {
   val valid = Output(Bool())

--- a/src/main/scala/devices/tilelink/TestRAM.scala
+++ b/src/main/scala/devices/tilelink/TestRAM.scala
@@ -4,9 +4,12 @@ package freechips.rocketchip.devices.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, MemoryDevice, RegionType, TransferSizes}
+import freechips.rocketchip.tilelink.{TLDelayer, TLFuzzer, TLManagerNode, TLMessages, TLRAMModel, TLSlaveParameters, TLSlavePortParameters}
 
 // Do not use this for synthesis! Only for simulation.
 class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4, trackCorruption: Boolean = true)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/devices/tilelink/Zero.scala
+++ b/src/main/scala/devices/tilelink/Zero.scala
@@ -4,8 +4,11 @@ package freechips.rocketchip.devices.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, RegionType, SimpleDevice}
 import freechips.rocketchip.tilelink.TLMessages
 
 /** This /dev/null device accepts single beat gets/puts, as well as atomics.

--- a/src/main/scala/examples/ExampleDevice.scala
+++ b/src/main/scala/examples/ExampleDevice.scala
@@ -3,10 +3,12 @@
 package freechips.rocketchip.examples
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.amba.ahb.HasAHBControlRegMap
 import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
-import freechips.rocketchip.diplomacy.LazyModuleImp
 import freechips.rocketchip.interrupts.HasInterruptSources
 import freechips.rocketchip.tilelink.HasTLControlRegMap
 import freechips.rocketchip.regmapper.{IORegisterRouter, RegisterRouterParams, RegField, RegFieldDesc}

--- a/src/main/scala/formal/FormalUtils.scala
+++ b/src/main/scala/formal/FormalUtils.scala
@@ -2,9 +2,10 @@
 package freechips.rocketchip.formal
 
 import chisel3._
-import chisel3.util._
 import chisel3.experimental.{SourceInfo, SourceLine}
-import org.chipsalliance.cde.config.Field
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
 
 sealed abstract class MonitorDirection(name: String) {
   override def toString: String = name

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -3,7 +3,8 @@
 
 package freechips.rocketchip.groundtest
 
-import org.chipsalliance.cde.config.Config
+import org.chipsalliance.cde.config._
+
 import freechips.rocketchip.devices.tilelink.{CLINTKey, PLICKey}
 import freechips.rocketchip.devices.debug.{DebugModuleKey}
 import freechips.rocketchip.subsystem._

--- a/src/main/scala/groundtest/DummyPTW.scala
+++ b/src/main/scala/groundtest/DummyPTW.scala
@@ -4,9 +4,9 @@
 package freechips.rocketchip.groundtest
 
 import chisel3._
-import chisel3.util.{RRArbiter, Valid, log2Up, RegEnable}
+import chisel3.util._
 
-import org.chipsalliance.cde.config.Parameters
+import org.chipsalliance.cde.config._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tile.CoreModule
 import freechips.rocketchip.util.ParameterizedBundle

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -3,8 +3,12 @@
 package freechips.rocketchip.groundtest
 
 import chisel3._
-import org.chipsalliance.cde.config.{Parameters}
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.AddressSet
+
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tile.{NMI}
 import freechips.rocketchip.devices.tilelink.{CLINTConsts}

--- a/src/main/scala/groundtest/TestHarness.scala
+++ b/src/main/scala/groundtest/TestHarness.scala
@@ -3,8 +3,10 @@
 package freechips.rocketchip.groundtest
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy.LazyModule
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.system.SimAXIMem
 
 class TestHarness(implicit p: Parameters) extends Module {

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -4,8 +4,12 @@
 package freechips.rocketchip.groundtest
 
 import chisel3._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{ClockCrossingType, SimpleDevice}
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket.{BuildHellaCache, DCache, DCacheModule, ICacheParams, NonBlockingDCache, NonBlockingDCacheModule, RocketCoreParams}
 import freechips.rocketchip.tile._

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -20,9 +20,11 @@
 package freechips.rocketchip.groundtest
  
 import chisel3._
-import chisel3.util.{log2Up, MuxLookup, Cat, log2Ceil, Enum}
-import org.chipsalliance.cde.config.{Parameters}
-import freechips.rocketchip.diplomacy.{ClockCrossingType}
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+
+import freechips.rocketchip.diplomacy.ClockCrossingType
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/interrupts/BlockDuringReset.scala
+++ b/src/main/scala/interrupts/BlockDuringReset.scala
@@ -2,8 +2,9 @@
 
 package freechips.rocketchip.interrupts
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.util.BlockDuringReset
 
 /** BlockDuringReset ensures that no interrupt is raised while reset is raised. */

--- a/src/main/scala/interrupts/Crossing.scala
+++ b/src/main/scala/interrupts/Crossing.scala
@@ -4,9 +4,10 @@ package freechips.rocketchip.interrupts
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.util.{SynchronizerShiftReg, AsyncResetReg}
-import freechips.rocketchip.diplomacy._
 
 @deprecated("IntXing does not ensure interrupt source is glitch free. Use IntSyncSource and IntSyncSink", "rocket-chip 1.2")
 class IntXing(sync: Int = 3)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/interrupts/CrossingHelper.scala
+++ b/src/main/scala/interrupts/CrossingHelper.scala
@@ -2,8 +2,10 @@
 
 package freechips.rocketchip.interrupts
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{CrossingType, ClockCrossingType, NoCrossing, AsynchronousCrossing, RationalCrossing, SynchronousCrossing, CreditedCrossing}
 import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing, StretchedResetCrossing}
 import freechips.rocketchip.util.CreditedDelay
 

--- a/src/main/scala/interrupts/Nodes.scala
+++ b/src/main/scala/interrupts/Nodes.scala
@@ -4,8 +4,10 @@ package freechips.rocketchip.interrupts
 
 import chisel3._
 import chisel3.experimental.SourceInfo
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.nodes._
 
 object IntImp extends SimpleNodeImp[IntSourcePortParameters, IntSinkPortParameters, IntEdge, Vec[Bool]]
 {

--- a/src/main/scala/interrupts/NullIntSource.scala
+++ b/src/main/scala/interrupts/NullIntSource.scala
@@ -3,8 +3,9 @@
 package freechips.rocketchip.interrupts
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
 
 /** Useful for stubbing out parts of an interrupt interface where certain devices might be missing */
 class NullIntSource(num: Int = 1, ports: Int = 1, sources: Int = 1)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/interrupts/Parameters.scala
+++ b/src/main/scala/interrupts/Parameters.scala
@@ -3,8 +3,11 @@
 package freechips.rocketchip.interrupts
 
 import chisel3.experimental.SourceInfo
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.Resource
 
 // A potentially empty half-open range; [start, end)
 case class IntRange(start: Int, end: Int)

--- a/src/main/scala/interrupts/RegisterRouter.scala
+++ b/src/main/scala/interrupts/RegisterRouter.scala
@@ -3,7 +3,11 @@
 package freechips.rocketchip.interrupts
 
 import chisel3._
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.Resource
+
 import freechips.rocketchip.regmapper._
 
 /** Mix this trait into a RegisterRouter to be able to attach its interrupt sources to an interrupt bus */

--- a/src/main/scala/interrupts/Xbar.scala
+++ b/src/main/scala/interrupts/Xbar.scala
@@ -2,8 +2,8 @@
 
 package freechips.rocketchip.interrupts
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
 
 class IntXbar()(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/interrupts/package.scala
+++ b/src/main/scala/interrupts/package.scala
@@ -2,9 +2,13 @@
 
 package freechips.rocketchip
 
-import chisel3.{Bool, Vec}
-import freechips.rocketchip.diplomacy.{HasClockDomainCrossing, _}
-import freechips.rocketchip.prci.{HasResetDomainCrossing}
+import chisel3._
+
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.HasClockDomainCrossing
+import freechips.rocketchip.prci.HasResetDomainCrossing
 
 package object interrupts
 {

--- a/src/main/scala/prci/BundleBridgeBlockDuringReset.scala
+++ b/src/main/scala/prci/BundleBridgeBlockDuringReset.scala
@@ -3,9 +3,13 @@
 package freechips.rocketchip.prci
 
 import chisel3._
-import org.chipsalliance.cde.config.{Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomacy.BundleBridgeNexus.fillN
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import org.chipsalliance.diplomacy.bundlebridge.BundleBridgeNexus.fillN
+
 import freechips.rocketchip.util.{BlockDuringReset, Blockable}
 
 object BundleBridgeBlockDuringReset {

--- a/src/main/scala/prci/ClockDivider.scala
+++ b/src/main/scala/prci/ClockDivider.scala
@@ -2,9 +2,11 @@
 package freechips.rocketchip.prci
 
 import chisel3._
-import chisel3.util.isPow2
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.util.{ClockDivider3, Pow2ClockDivider}
 
 /* An example clock adapter that divides all clocks passed through this node by an integer factor

--- a/src/main/scala/prci/ClockDomain.scala
+++ b/src/main/scala/prci/ClockDomain.scala
@@ -1,8 +1,12 @@
 package freechips.rocketchip.prci
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{HasClockDomainCrossing, HasDomainCrossing}
 
 abstract class Domain(implicit p: Parameters) extends LazyModule with HasDomainCrossing
 {

--- a/src/main/scala/prci/ClockGroup.scala
+++ b/src/main/scala/prci/ClockGroup.scala
@@ -1,8 +1,12 @@
 // See LICENSE.SiFive for license details.
 package freechips.rocketchip.prci
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.FixedClockResource
 
 case class ClockGroupingNode(groupName: String)(implicit valName: ValName)
   extends MixedNexusNode(ClockGroupImp, ClockImp)(

--- a/src/main/scala/prci/ClockNodes.scala
+++ b/src/main/scala/prci/ClockNodes.scala
@@ -2,8 +2,14 @@
 package freechips.rocketchip.prci
 
 import chisel3.experimental.SourceInfo
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.FixedClockResource
 
 object ClockImp extends SimpleNodeImp[ClockSourceParameters, ClockSinkParameters, ClockEdgeParameters, ClockBundle]
 {

--- a/src/main/scala/prci/IOHelper.scala
+++ b/src/main/scala/prci/IOHelper.scala
@@ -3,7 +3,10 @@
 package freechips.rocketchip.prci
 
 import chisel3._
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{ClockCrossingType, SynchronousCrossing}
 
 object IOHelper {
 

--- a/src/main/scala/prci/ResetCrossingType.scala
+++ b/src/main/scala/prci/ResetCrossingType.scala
@@ -1,8 +1,10 @@
 // See LICENSE.SiFive for license details.
 package freechips.rocketchip.prci
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy.{CrossingType, HasDomainCrossing, LazyModule}
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{CrossingType, HasDomainCrossing}
 
 trait HasResetDomainCrossing extends HasDomainCrossing { this: LazyModule =>
   type DomainCrossingType = ResetCrossingType

--- a/src/main/scala/prci/ResetStretcher.scala
+++ b/src/main/scala/prci/ResetStretcher.scala
@@ -2,9 +2,10 @@
 package freechips.rocketchip.prci
 
 import chisel3._
-import chisel3.util.log2Ceil
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp, ValName}
+import chisel3.util._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
 
 /** This adapter takes an input reset and stretches it.
   *

--- a/src/main/scala/prci/ResetSynchronizer.scala
+++ b/src/main/scala/prci/ResetSynchronizer.scala
@@ -1,9 +1,11 @@
 // See LICENSE for license details.
 package freechips.rocketchip.prci
 
-import org.chipsalliance.cde.config.{Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util.{ResetCatchAndSync}
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.util.ResetCatchAndSync
 
 /**
   * Synchronizes the reset of a diplomatic clock-reset pair to its accompanying clock.

--- a/src/main/scala/prci/ResetWrangler.scala
+++ b/src/main/scala/prci/ResetWrangler.scala
@@ -4,8 +4,9 @@ package freechips.rocketchip.prci
 import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.util.{AsyncResetReg, ResetCatchAndSync}
 
 class ResetWrangler(debounceNs: Double = 100000)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/prci/TestClockSource.scala
+++ b/src/main/scala/prci/TestClockSource.scala
@@ -1,10 +1,11 @@
 package freechips.rocketchip.prci
 
 import chisel3._
-import chisel3.util.HasBlackBoxInline
+import chisel3.util._
 import chisel3.experimental.DoubleParam
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
 
 class ClockSourceIO extends Bundle {
   val power = Input(Bool())

--- a/src/main/scala/prci/package.scala
+++ b/src/main/scala/prci/package.scala
@@ -2,7 +2,9 @@
 
 package freechips.rocketchip
 
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.{ClockCrossingType, AsynchronousCrossing}
 
 package object prci
 {

--- a/src/main/scala/regmapper/RegMapper.scala
+++ b/src/main/scala/regmapper/RegMapper.scala
@@ -4,13 +4,13 @@ package freechips.rocketchip.regmapper
 
 import chisel3._
 import chisel3.experimental.SourceInfo
-import chisel3.util.{DecoupledIO, Decoupled, Queue, Cat, FillInterleaved, UIntToOH}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
+import chisel3.util._
+
+import freechips.rocketchip.diplomacy.AddressDecoder
+
+import freechips.rocketchip.util.{BundleFieldBase, BundleMap, MuxSeq, ReduceOthers, property}
 
 // A bus agnostic register interface to a register-based device
-
 case class RegMapperParams(indexBits: Int, maskBits: Int, extraFields: Seq[BundleFieldBase] = Nil)
 
 class RegMapperInput(val params: RegMapperParams) extends Bundle

--- a/src/main/scala/regmapper/RegisterRouter.scala
+++ b/src/main/scala/regmapper/RegisterRouter.scala
@@ -3,9 +3,13 @@
 package freechips.rocketchip.regmapper
 
 import chisel3._
-import chisel3.util.{isPow2}
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, Description, Device, SimpleDevice, ResourceBindings, ResourceValue, HasClockDomainCrossing}
 
 /** Parameters which apply to any RegisterRouter. */
 case class RegisterRouterParams(

--- a/src/main/scala/regmapper/Test.scala
+++ b/src/main/scala/regmapper/Test.scala
@@ -3,10 +3,12 @@
 package freechips.rocketchip.regmapper
 
 import chisel3._
-import chisel3.util.{Cat, log2Ceil}
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy.LazyModuleImp
-import freechips.rocketchip.util.{Pow2ClockDivider}
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.util.Pow2ClockDivider
 
 object LFSR16Seed
 {

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -4,16 +4,23 @@ package freechips.rocketchip.rocket
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.amba._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tile.{CoreBundle, LookupByHartId}
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
-import chisel3.{DontCare, WireInit, dontTouch, withClock}
 import chisel3.experimental.SourceInfo
-import TLMessages._
+
+import org.chipsalliance.cde.config._
+
+import freechips.rocketchip.amba.AMBAProt
+import freechips.rocketchip.diplomacy.{ClockCrossingType, RationalCrossing, SynchronousCrossing, BufferParams, AsynchronousCrossing, CreditedCrossing}
+import freechips.rocketchip.tile.{CoreBundle, LookupByHartId}
+import freechips.rocketchip.tilelink.{TLFIFOFixer,ClientMetadata, TLBundleA, TLAtomics, TLBundleB, TLPermissions}
+import freechips.rocketchip.tilelink.TLMessages.{AccessAck, HintAck, AccessAckData, Grant, GrantData, ReleaseAck}
+import freechips.rocketchip.util.{CanHaveErrors, ClockGate, IdentityCode, ReplacementPolicy, DescribedSRAM, property}
+
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
+import freechips.rocketchip.util.UIntToAugmentedUInt
+import freechips.rocketchip.util.UIntIsOneOf
+import freechips.rocketchip.util.IntToAugmentedInt
+import freechips.rocketchip.util.SeqToAugmentedSeq
+import freechips.rocketchip.util.SeqBoolBitwiseOps
 
 // TODO: delete this trait once deduplication is smart enough to avoid globally inlining matching circuits
 trait InlineInstance { self: chisel3.experimental.BaseModule =>

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -5,14 +5,17 @@ package freechips.rocketchip.rocket
 
 import chisel3._
 import chisel3.util._
-import chisel3.{withClock,withReset}
 import chisel3.experimental.SourceInfo
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tile._
-import freechips.rocketchip.tilelink.{TLWidthWidget}
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.tile.{CoreBundle, BaseTile}
+import freechips.rocketchip.tilelink.{TLWidthWidget, TLEdgeOut}
+import freechips.rocketchip.util.{ClockGate, ShiftQueue, property}
+
+import freechips.rocketchip.util.UIntToAugmentedUInt
 
 class FrontendReq(implicit p: Parameters) extends CoreBundle()(p) {
   val pc = UInt(vaddrBitsExtended.W)
@@ -80,7 +83,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
     with HasL1ICacheParameters {
   val io = IO(new FrontendBundle(outer))
   val io_reset_vector = outer.resetVectorSinkNode.bundle
-  implicit val edge = outer.masterNode.edges.out(0)
+  implicit val edge: TLEdgeOut = outer.masterNode.edges.out(0)
   val icache = outer.icache.module
   require(fetchWidth*coreInstBytes == outer.icacheParams.fetchBytes)
 

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -3,15 +3,21 @@
 
 package freechips.rocketchip.rocket
 
-import chisel3._
-import chisel3.util.{isPow2,log2Ceil,log2Up,Decoupled,Valid}
-import chisel3.dontTouch
-import freechips.rocketchip.amba._
-import org.chipsalliance.cde.config.{Parameters, Field}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tile._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import chisel3.{dontTouch, _}
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.AMBAProtField
+import freechips.rocketchip.diplomacy.{IdRange, TransferSizes, RegionType}
+import freechips.rocketchip.tile.{L1CacheParams, HasL1CacheParameters, HasCoreParameters, CoreBundle, HasNonDiplomaticTileParameters, BaseTile, HasTileParameters}
+import freechips.rocketchip.tilelink.{TLMasterParameters, TLClientNode, TLMasterPortParameters, TLEdgeOut, TLWidthWidget, TLFIFOFixer, ClientMetadata}
+import freechips.rocketchip.util.{Code, RandomReplacement, ParameterizedBundle}
+
+import freechips.rocketchip.util.{BooleanToAugmentedBoolean, IntToAugmentedInt}
+
 import scala.collection.mutable.ListBuffer
 
 case class DCacheParams(
@@ -231,7 +237,7 @@ class HellaCacheBundle(implicit p: Parameters) extends CoreBundle()(p) {
 
 class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
     with HasL1HellaCacheParameters {
-  implicit val edge = outer.node.edges.out(0)
+  implicit val edge: TLEdgeOut = outer.node.edges.out(0)
   val (tl_out, _) = outer.node.out(0)
   val io = IO(new HellaCacheBundle)
   val io_hartid = outer.hartIdSinkNodeOpt.map(_.bundle)

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -3,18 +3,25 @@
 
 package freechips.rocketchip.rocket
 
-import chisel3._
-import chisel3.util.{Cat, Decoupled, Mux1H, OHToUInt, RegEnable, Valid, isPow2, log2Ceil, log2Up, PopCount}
-import freechips.rocketchip.amba._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tile._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util.{DescribedSRAM, _}
-import freechips.rocketchip.util.property
-import chisel3.experimental.SourceInfo
-import chisel3.dontTouch
+import chisel3.{dontTouch, _}
+import chisel3.util._
 import chisel3.util.random.LFSR
+import chisel3.experimental.SourceInfo
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
+import freechips.rocketchip.diplomacy.{IdRange, SimpleDevice, ResourceBindings, Description, AddressSet, Binding, ResourceAddress, ResourceString, ResourceValue, RegionType, TransferSizes}
+import freechips.rocketchip.tile.{L1CacheParams, HasL1CacheParameters, HasCoreParameters, CoreBundle, TileKey, LookupByHartId}
+import freechips.rocketchip.tilelink.{TLClientNode, TLMasterPortParameters, TLManagerNode, TLSlavePortParameters, TLSlaveParameters, TLMasterParameters, TLHints}
+import freechips.rocketchip.util.{Code, CanHaveErrors, DescribedSRAM, RandomReplacement, Split, IdentityCode, property}
+
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
+import freechips.rocketchip.util.UIntToAugmentedUInt
+import freechips.rocketchip.util.SeqToAugmentedSeq
+import freechips.rocketchip.util.OptionUIntToAugmentedOptionUInt
 
 /** Parameter of [[ICache]].
   *

--- a/src/main/scala/rocket/PMA.scala
+++ b/src/main/scala/rocket/PMA.scala
@@ -5,16 +5,15 @@ package freechips.rocketchip.rocket
 
 import chisel3._
 import chisel3.util._
-
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.subsystem.CacheBlockBytes
-import freechips.rocketchip.diplomacy.RegionType
-import freechips.rocketchip.tile.{CoreModule, CoreBundle}
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
-import freechips.rocketchip.devices.debug.DebugModuleKey
 import chisel3.experimental.SourceInfo
+
+import org.chipsalliance.cde.config._
+
+import freechips.rocketchip.devices.debug.DebugModuleKey
+import freechips.rocketchip.diplomacy.RegionType
+import freechips.rocketchip.subsystem.CacheBlockBytes
+import freechips.rocketchip.tile.{CoreModule, CoreBundle}
+import freechips.rocketchip.tilelink.{TLSlavePortParameters, TLManagerParameters}
 
 class PMAChecker(manager: TLSlavePortParameters)(implicit p: Parameters) extends CoreModule()(p) {
   val io = IO(new Bundle {

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -4,10 +4,16 @@ package freechips.rocketchip.rocket
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, RegionType, TransferSizes, SimpleDevice}
+
+import freechips.rocketchip.tilelink.{TLManagerNode, TLSlavePortParameters, TLSlaveParameters, TLBundleA, TLMessages, TLAtomics}
+
+import freechips.rocketchip.util.UIntIsOneOf
+import freechips.rocketchip.util.DataToAugmentedData
 
 /* This adapter converts between diplomatic TileLink and non-diplomatic HellaCacheIO */
 class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) extends LazyModule {

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -5,16 +5,23 @@ package freechips.rocketchip.rocket
 
 import chisel3._
 import chisel3.util._
+import chisel3.experimental.SourceInfo
 
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.subsystem.CacheBlockBytes
+import org.chipsalliance.cde.config._
+
+import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.diplomacy.RegionType
+import freechips.rocketchip.subsystem.CacheBlockBytes
 import freechips.rocketchip.tile.{CoreModule, CoreBundle}
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
-import freechips.rocketchip.devices.debug.DebugModuleKey
-import chisel3.experimental.SourceInfo
+import freechips.rocketchip.util.{OptimizationBarrier, SetAssocLRU, PseudoLRU, PopCountAtLeast, property}
+
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
+import freechips.rocketchip.util.IntToAugmentedInt
+import freechips.rocketchip.util.UIntToAugmentedUInt
+import freechips.rocketchip.util.UIntIsOneOf
+import freechips.rocketchip.util.SeqToAugmentedSeq
+import freechips.rocketchip.util.SeqBoolBitwiseOps
 
 case object PgLevels extends Field[Int](2)
 case object ASIdBits extends Field[Int](0)

--- a/src/main/scala/rocket/TLBPermissions.scala
+++ b/src/main/scala/rocket/TLBPermissions.scala
@@ -3,10 +3,10 @@
 package freechips.rocketchip.rocket
 
 import chisel3._
-import chisel3.util.isPow2
+import chisel3.util._
 
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes, RegionType, AddressDecoder}
+import freechips.rocketchip.tilelink.TLManagerParameters
 
 case class TLBPermissions(
   homogeneous: Bool, // if false, the below are undefined

--- a/src/main/scala/subsystem/Attachable.scala
+++ b/src/main/scala/subsystem/Attachable.scala
@@ -2,8 +2,9 @@
 
 package freechips.rocketchip.subsystem
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy.{LazyModule, LazyScope}
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.prci.ClockGroupNode
 import freechips.rocketchip.tilelink.TLBusWrapper
 import freechips.rocketchip.util.{Location, LocationMap}

--- a/src/main/scala/subsystem/BankedCoherenceParams.scala
+++ b/src/main/scala/subsystem/BankedCoherenceParams.scala
@@ -2,13 +2,21 @@
 
 package freechips.rocketchip.subsystem
 
-import chisel3.util.isPow2
+import chisel3.util._
+
 import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.devices.tilelink.BuiltInDevices
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import freechips.rocketchip.diplomacy.AddressSet
+import freechips.rocketchip.interrupts.IntOutwardNode
+import freechips.rocketchip.tilelink.{
+  TLBroadcast, HasTLBusParams, BroadcastFilter, TLBusWrapper, TLBusWrapperInstantiationLike,
+  TLJbar, TLEdge, TLOutwardNode, TLTempNode, TLInwardNode, BankBinder, TLBroadcastParams,
+  TLBroadcastControlParams, TLBuffer, TLFragmenter, TLNameNode
+}
+import freechips.rocketchip.util.Location
+
 import CoherenceManagerWrapper._
 
 /** Global cache coherence granularity, which applies to all caches, for now. */

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -2,13 +2,20 @@
 
 package freechips.rocketchip.subsystem
 
-import chisel3.{Flipped, IO}
+import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.prci._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{
+  BindingScope, DTS, DTB, ResourceBinding, JSON, ResourceInt,
+  DTSModel, DTSCompat, DTSTimebase, ResourceString, Resource,
+  ResourceAnchors, AddressMapEntry, AddressRange
+}
+import freechips.rocketchip.prci.{ClockGroupIdentityNode, ClockGroupAggregator, ClockGroupSourceNode, ClockGroupSourceParameters}
 import freechips.rocketchip.tilelink.TLBusWrapper
-import freechips.rocketchip.util._
+import freechips.rocketchip.util.{Location, ElaborationArtefacts, PlusArgArtefacts, RecordMap, Annotated}
 
 case object SubsystemDriveClockGroupsFromIO extends Field[Boolean](true)
 case class TLNetworkTopologyLocated(where: HierarchicalLocation) extends Field[Seq[CanInstantiateWithinContextThatHasTileLinkLocations with CanConnectWithinContextThatHasTileLinkLocations]]

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -2,9 +2,11 @@
 
 package freechips.rocketchip.subsystem
 
-import org.chipsalliance.cde.config.Field
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.{ClockCrossingType, NoCrossing, SynchronousCrossing}
+import freechips.rocketchip.tilelink.{TLBusWrapper, TLBusWrapperTopology, TLBusWrapperConnection}
 import freechips.rocketchip.util.Location
 
 // These fields control parameters of the five traditional tilelink bus wrappers.

--- a/src/main/scala/subsystem/Cluster.scala
+++ b/src/main/scala/subsystem/Cluster.scala
@@ -3,16 +3,18 @@ package freechips.rocketchip.subsystem
 import chisel3._
 import chisel3.util._
 
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.prci._
-import freechips.rocketchip.tile.{RocketTile, NMI, TraceBundle}
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.devices.debug.{TLDebugModule}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.util._
+import freechips.rocketchip.diplomacy.{ClockCrossingType, NoCrossing, FlipRendering}
+import freechips.rocketchip.interrupts.{IntIdentityNode, IntSyncIdentityNode, NullIntSource}
+import freechips.rocketchip.prci.{ClockSinkParameters, ClockGroupIdentityNode, BundleBridgeBlockDuringReset}
+import freechips.rocketchip.tile.{RocketTile, NMI, TraceBundle}
+import freechips.rocketchip.tilelink.TLWidthWidget
+import freechips.rocketchip.util.TraceCoreInterface
+
 import scala.collection.immutable.SortedMap
 
 case class ClustersLocated(loc: HierarchicalLocation) extends Field[Seq[CanAttachCluster]](Nil)

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -4,13 +4,23 @@
 package freechips.rocketchip.subsystem
 
 import chisel3.util._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.devices.debug._
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.rocket._
-import freechips.rocketchip.tile._
-import freechips.rocketchip.util._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.debug.{DebugModuleKey, DefaultDebugModuleParams, ExportDebug, JTAG, APB}
+import freechips.rocketchip.devices.tilelink.{
+  BuiltInErrorDeviceParams, BootROMLocated, BootROMParams, CLINTKey, DevNullDevice, CLINTParams, PLICKey, PLICParams, DevNullParams
+}
+import freechips.rocketchip.diplomacy.{
+  AddressSet, SynchronousCrossing, AsynchronousCrossing, RationalCrossing, MonitorsEnabled,
+  DTSModel, DTSCompat, DTSTimebase, ClockCrossingType, BigIntHexContext
+}
+import freechips.rocketchip.rocket.{PgLevels, RocketCoreParams, MulDivParams, DCacheParams, ICacheParams, BTBParams, DebugROBParams}
+import freechips.rocketchip.tile.{
+  XLen, MaxHartIdBits, RocketTileParams, BuildRoCC, AccumulatorExample, OpcodeSet, TranslatorExample, CharacterCountExample, BlackBoxExample
+}
+import freechips.rocketchip.util.ClockGateModelFile
 
 class BaseSubsystemConfig extends Config ((site, here, up) => {
   // Tile parameters

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -2,12 +2,19 @@
 
 package freechips.rocketchip.subsystem
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.amba.axi4._
-import freechips.rocketchip.interrupts._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.axi4.{AXI4InwardNode, AXI4OutwardNode}
+import freechips.rocketchip.diplomacy.{ClockCrossingType, HasClockDomainCrossing}
+import freechips.rocketchip.tilelink.{TLInwardNode, TLOutwardNode}
+import freechips.rocketchip.interrupts.{IntInwardNode, IntOutwardNode}
 import freechips.rocketchip.prci.{HasResetDomainCrossing, ResetCrossingType}
+
+import freechips.rocketchip.tilelink.TLClockDomainCrossing
+import freechips.rocketchip.tilelink.TLResetDomainCrossing
+import freechips.rocketchip.interrupts.IntClockDomainCrossing
+import freechips.rocketchip.interrupts.IntResetDomainCrossing
 
 @deprecated("Only use this trait if you are confident you island will only ever be crossed to a single clock", "rocket-chip 1.3")
 trait HasCrossing extends CrossesToOnlyOneClockDomain { this: LazyModule => }

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -2,10 +2,11 @@
 
 package freechips.rocketchip.subsystem
 
-import org.chipsalliance.cde.config.{Parameters}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.tilelink.{BuiltInErrorDeviceParams, BuiltInZeroDeviceParams, BuiltInDevices, HasBuiltInDeviceParams}
+import freechips.rocketchip.tilelink.{HasTLBusParams, TLBusWrapper, TLBusWrapperInstantiationLike, HasTLXbarPhy}
 import freechips.rocketchip.util.{Location}
 
 case class FrontBusParams(

--- a/src/main/scala/subsystem/HasHierarchicalElements.scala
+++ b/src/main/scala/subsystem/HasHierarchicalElements.scala
@@ -3,17 +3,24 @@
 package freechips.rocketchip.subsystem
 
 import chisel3._
-import chisel3.dontTouch
-import org.chipsalliance.cde.config.{Field, Parameters}
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.devices.debug.{TLDebugModule, HasPeripheryDebug}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tile._
-import freechips.rocketchip.tilelink._
+import freechips.rocketchip.devices.tilelink.{BasicBusBlocker, BasicBusBlockerParams, CLINT, TLPLIC, CLINTConsts}
+import freechips.rocketchip.diplomacy.ClockCrossingType
+import freechips.rocketchip.interrupts.{
+  IntNode, IntSyncNode, IntEphemeralNode, NullIntSource, IntNexusNode, IntSourcePortParameters,
+  IntSourceParameters, IntSinkPortParameters, IntSinkParameters, IntSyncIdentityNode, NullIntSyncSource
+}
+import freechips.rocketchip.tile.{TileParams, TilePRCIDomain, BaseTile, NMI, TraceBundle}
+import freechips.rocketchip.tilelink.{TLNode, TLBuffer, TLCacheCork, TLTempNode, TLFragmenter}
 import freechips.rocketchip.prci.{ClockGroup, ResetCrossingType, ClockGroupNode, ClockDomain}
-import freechips.rocketchip.util._
-import freechips.rocketchip.rocket.{TracedInstruction}
+import freechips.rocketchip.rocket.TracedInstruction
+import freechips.rocketchip.util.TraceCoreInterface
+
 import scala.collection.immutable.SortedMap
 
 /** A default implementation of parameterizing the connectivity of the port where the tile is the master.

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -3,17 +3,20 @@
 package freechips.rocketchip.subsystem
 
 import chisel3._
-import chisel3.dontTouch
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.devices.debug.{TLDebugModule}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tile._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.prci._
-import freechips.rocketchip.util._
-import freechips.rocketchip.rocket.{TracedInstruction}
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.debug.TLDebugModule
+import freechips.rocketchip.diplomacy.{DisableMonitors, NoCrossing, SynchronousCrossing, CreditedCrossing, RationalCrossing, AsynchronousCrossing, FlipRendering}
+import freechips.rocketchip.interrupts.{IntXbar, IntSinkNode, IntSinkPortSimple, IntSyncAsyncCrossingSink}
+import freechips.rocketchip.tile.{MaxHartIdBits, BaseTile, InstantiableTileParams, TileParams, TilePRCIDomain, TraceBundle, PriorityMuxHartIdFromSeq}
+import freechips.rocketchip.tilelink.TLWidthWidget
+import freechips.rocketchip.prci.{ClockGroup, BundleBridgeBlockDuringReset}
+import freechips.rocketchip.rocket.TracedInstruction
+import freechips.rocketchip.util.TraceCoreInterface
+
 import scala.collection.immutable.SortedMap
 
 /** Entry point for Config-uring the presence of Tiles */

--- a/src/main/scala/subsystem/HierarchicalElement.scala
+++ b/src/main/scala/subsystem/HierarchicalElement.scala
@@ -3,16 +3,15 @@ package freechips.rocketchip.subsystem
 import chisel3._
 import chisel3.util._
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.prci._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.debug.TLDebugModule
+import freechips.rocketchip.diplomacy.{BufferParams, ClockCrossingType}
+import freechips.rocketchip.interrupts.IntXbar
+import freechips.rocketchip.prci.{ClockSinkParameters, ResetCrossingType}
 import freechips.rocketchip.tile.{LookupByHartIdImpl, TraceBundle}
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
-import freechips.rocketchip.devices.debug.{TLDebugModule}
-import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.tilelink.{TLNode, TLIdentityNode, TLXbar, TLBuffer, TLInwardNode, TLOutwardNode}
 
 trait HierarchicalElementParams {
   val baseName: String // duplicated instances shouuld share a base name

--- a/src/main/scala/subsystem/HierarchicalElementPRCIDomain.scala
+++ b/src/main/scala/subsystem/HierarchicalElementPRCIDomain.scala
@@ -3,17 +3,21 @@ package freechips.rocketchip.subsystem
 import chisel3._
 import chisel3.util._
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.prci._
-import freechips.rocketchip.tile.{RocketTile, TraceBundle}
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.devices.debug.{TLDebugModule}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.util.{TraceCoreInterface}
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
 
+import freechips.rocketchip.devices.debug.TLDebugModule
+import freechips.rocketchip.diplomacy.{ClockCrossingType, DisableMonitors, FlipRendering}
+import freechips.rocketchip.interrupts.{IntInwardNode, IntOutwardNode}
+import freechips.rocketchip.prci.{ResetCrossingType, ResetDomain, ClockSinkNode, ClockSinkParameters, ClockIdentityNode, FixedClockBroadcast, ClockDomain}
+import freechips.rocketchip.tile.{RocketTile, TraceBundle}
+import freechips.rocketchip.tilelink.{TLInwardNode, TLOutwardNode}
+import freechips.rocketchip.util.TraceCoreInterface
+
+import freechips.rocketchip.tilelink.TLClockDomainCrossing
+import freechips.rocketchip.tilelink.TLResetDomainCrossing
+import freechips.rocketchip.interrupts.IntClockDomainCrossing
+import freechips.rocketchip.interrupts.IntResetDomainCrossing
 
 /** A wrapper containing all logic within a managed reset domain for a element.
   *

--- a/src/main/scala/subsystem/InterruptBus.scala
+++ b/src/main/scala/subsystem/InterruptBus.scala
@@ -3,10 +3,15 @@
 package freechips.rocketchip.subsystem
 
 import chisel3._
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.prci.{ClockSinkDomain}
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{ClockCrossingType, AsynchronousCrossing, RationalCrossing, Device, DeviceInterrupts, Description, ResourceBindings}
+import freechips.rocketchip.interrupts.{IntInwardNode, IntOutwardNode, IntXbar, IntNameNode, IntSourceNode, IntSourcePortSimple}
+import freechips.rocketchip.prci.ClockSinkDomain
+
+import freechips.rocketchip.interrupts.IntClockDomainCrossing
 
 /** Collects interrupts from internal and external devices and feeds them into the PLIC */ 
 class InterruptBusWrapper(implicit p: Parameters) extends ClockSinkDomain {

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -3,10 +3,15 @@
 package freechips.rocketchip.subsystem
 
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.tilelink.{BuiltInDevices, HasBuiltInDeviceParams, BuiltInErrorDeviceParams, BuiltInZeroDeviceParams}
+import freechips.rocketchip.tilelink.{
+  ReplicatedRegion, HasTLBusParams, HasRegionReplicatorParams, TLBusWrapper,
+  TLBusWrapperInstantiationLike, RegionReplicator, TLXbar, TLInwardNode,
+  TLOutwardNode, ProbePicker, TLEdge, TLFIFOFixer
+}
+import freechips.rocketchip.util.Location
 
 /** Parameterization of the memory-side bus created for each memory channel */
 case class MemoryBusParams(

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -2,11 +2,17 @@
 
 package freechips.rocketchip.subsystem
 
-import org.chipsalliance.cde.config.{Parameters}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.tilelink.{BuiltInZeroDeviceParams, BuiltInErrorDeviceParams, HasBuiltInDeviceParams, BuiltInDevices}
+import freechips.rocketchip.diplomacy.BufferParams
+import freechips.rocketchip.tilelink.{
+  RegionReplicator, ReplicatedRegion, HasTLBusParams, HasRegionReplicatorParams, TLBusWrapper,
+  TLBusWrapperInstantiationLike, TLFIFOFixer, TLNode, TLXbar, TLInwardNode, TLOutwardNode,
+  TLBuffer, TLWidthWidget, TLAtomicAutomata, TLEdge
+}
+import freechips.rocketchip.util.Location
 
 case class BusAtomics(
   arithmetic: Boolean = true,

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -4,11 +4,28 @@ package freechips.rocketchip.subsystem
 
 import chisel3._
 
-import org.chipsalliance.cde.config.Field
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.amba.axi4._
-import freechips.rocketchip.util._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.axi4.{
+  AXI4SlaveNode, AXI4SlavePortParameters, AXI4SlaveParameters, AXI4UserYanker, AXI4Buffer,
+  AXI4Deinterleaver, AXI4IdIndexer, AXI4MasterNode, AXI4MasterPortParameters, AXI4ToTL,
+  AXI4Fragmenter, AXI4MasterParameters
+}
+import freechips.rocketchip.diplomacy.{
+  MemoryDevice, AddressSet, RegionType, TransferSizes, SimpleBus, IdRange, BufferParams
+}
+import freechips.rocketchip.tilelink.{
+  TLXbar, RegionReplicator, ReplicatedRegion, TLWidthWidget, TLFilter, TLToAXI4, TLBuffer,
+  TLFIFOFixer, TLSlavePortParameters, TLManagerNode, TLSlaveParameters, TLClientNode,
+  TLSourceShrinker, TLMasterParameters, TLMasterPortParameters
+}
+import freechips.rocketchip.util.StringToAugmentedString
+
+import freechips.rocketchip.tilelink.TLClockDomainCrossing
+import freechips.rocketchip.tilelink.TLResetDomainCrossing
 
 /** Specifies the size and width of external memory ports */
 case class MasterPortParams(

--- a/src/main/scala/subsystem/RTC.scala
+++ b/src/main/scala/subsystem/RTC.scala
@@ -3,8 +3,11 @@
 package freechips.rocketchip.subsystem
 
 import chisel3._
-import chisel3.util.Counter
-import freechips.rocketchip.diplomacy.{LazyRawModuleImp, DTSTimebase}
+import chisel3.util._
+
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.DTSTimebase
 import freechips.rocketchip.devices.tilelink.{CLINTAttachKey, CanHavePeripheryCLINT}
 
 trait HasRTCModuleImp extends LazyRawModuleImp {

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -2,13 +2,14 @@
 
 package freechips.rocketchip.subsystem
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing}
-import freechips.rocketchip.tile._
-import freechips.rocketchip.devices.debug.{HasPeripheryDebug}
-import freechips.rocketchip.util.{HasCoreMonitorBundles}
+import org.chipsalliance.cde.config._
+
+import freechips.rocketchip.devices.debug.HasPeripheryDebug
 import freechips.rocketchip.devices.tilelink.{CanHavePeripheryCLINT, CanHavePeripheryPLIC}
+import freechips.rocketchip.diplomacy.{SynchronousCrossing, ClockCrossingType}
+import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing}
+import freechips.rocketchip.tile.{RocketTile, RocketTileParams}
+import freechips.rocketchip.util.HasCoreMonitorBundles
 
 case class RocketCrossingParams(
   crossingType: ClockCrossingType = SynchronousCrossing(),

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -2,11 +2,18 @@
 
 package freechips.rocketchip.subsystem
 
-import org.chipsalliance.cde.config.{Parameters}
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.tilelink.{
+  BuiltInDevices, BuiltInZeroDeviceParams, BuiltInErrorDeviceParams, HasBuiltInDeviceParams
+}
+import freechips.rocketchip.tilelink.{
+  TLArbiter, RegionReplicator, ReplicatedRegion, HasTLBusParams, TLBusWrapper,
+  TLBusWrapperInstantiationLike, TLXbar, TLEdge, TLInwardNode, TLOutwardNode,
+  TLFIFOFixer, TLTempNode
+}
+import freechips.rocketchip.util.Location
 
 case class SystemBusParams(
     beatBytes: Int,

--- a/src/main/scala/system/SimAXIMem.scala
+++ b/src/main/scala/system/SimAXIMem.scala
@@ -3,10 +3,13 @@
 package freechips.rocketchip.system // TODO this should really be in a testharness package
 
 import chisel3._
-import freechips.rocketchip.amba._
-import freechips.rocketchip.amba.axi4._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.amba.AMBACorrupt
+import freechips.rocketchip.amba.axi4.{AXI4RAM, AXI4MasterNode, AXI4EdgeParameters, AXI4Xbar, AXI4Buffer, AXI4Fragmenter}
+import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.subsystem.{CanHaveMasterAXI4MMIOPort, CanHaveMasterAXI4MemPort, ExtBus, ExtMem}
 
 /** Memory with AXI port for use in elaboratable test harnesses.

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -3,9 +3,11 @@
 package freechips.rocketchip.system
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.devices.debug.Debug
-import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.util.AsyncResetReg
 
 class TestHarness()(implicit p: Parameters) extends Module {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -4,15 +4,27 @@ package freechips.rocketchip.tile
 
 import chisel3._
 import chisel3.util.{log2Ceil, log2Up}
-import org.chipsalliance.cde.config._
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.diplomacy._
 
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.rocket._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
-import freechips.rocketchip.prci.{ClockSinkParameters}
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.bundlebridge._
+
+
+import freechips.rocketchip.diplomacy.{ClockCrossingType, PropertyMap, PropertyOption, ResourceReference, DTSTimebase}
+import freechips.rocketchip.interrupts.{IntInwardNode, IntOutwardNode}
+import freechips.rocketchip.rocket.{ICacheParams, DCacheParams, BTBParams, PgLevels, ASIdBits, VMIdBits, TraceAux, BPWatch}
+import freechips.rocketchip.subsystem.{
+  HierarchicalElementParams, InstantiableHierarchicalElementParams, HierarchicalElementCrossingParamsLike,
+  CacheBlockBytes, SystemBusKey, BaseHierarchicalElement, InsertTimingClosureRegistersOnHartIds, BaseHierarchicalElementModuleImp
+}
+import freechips.rocketchip.tilelink.{TLEphemeralNode, TLOutwardNode, TLNode, TLFragmenter, EarlyAck, TLWidthWidget, TLManagerParameters, ManagerUnification}
+import freechips.rocketchip.prci.ClockSinkParameters
+import freechips.rocketchip.util.{TraceCoreParams, TraceCoreInterface}
+
+import freechips.rocketchip.diplomacy.BigIntToProperty
+import freechips.rocketchip.diplomacy.IntToProperty
+import freechips.rocketchip.diplomacy.StringToProperty
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
 case object TileVisibilityNodeKey extends Field[TLEphemeralNode]
 case object TileKey extends Field[TileParams]

--- a/src/main/scala/tile/BusErrorUnit.scala
+++ b/src/main/scala/tile/BusErrorUnit.scala
@@ -3,17 +3,16 @@
 package freechips.rocketchip.tile
 
 import chisel3._
-import chisel3.util.log2Ceil
-// TODO: remove this import
-import chisel3.util.ImplicitConversions._
-import chisel3.util.Valid
-import chisel3.DontCare
+import chisel3.util._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.rocket._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.interrupts._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.rocket.{DCacheErrors, ICacheErrors}
+import freechips.rocketchip.diplomacy.{AddressSet, SimpleDevice}
+import freechips.rocketchip.regmapper.{DescribedReg, RegField, RegFieldDesc, RegFieldGroup}
+import freechips.rocketchip.tilelink.TLRegisterNode
+import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 import freechips.rocketchip.util.property
 
 trait BusErrors extends Bundle {
@@ -95,17 +94,17 @@ class BusErrorUnit[T <: BusErrors](t: => T, params: BusErrorUnitParams)(implicit
     new_value := DontCare
     for ((((s, en), acc), i) <- (sources zip enable zip accrued).zipWithIndex; if s.nonEmpty) {
       when (s.get.valid) {
-        acc := true
+        acc := true.B
         when (en) {
-          cause_wen := true
-          new_cause := i
+          cause_wen := true.B
+          new_cause := i.asUInt
           new_value := s.get.bits
         }
         property.cover(en, s"BusErrorCause_$i", s"Core;;BusErrorCause $i covered")
       }
     }
 
-    when (cause === 0 && cause_wen) {
+    when (cause === 0.asUInt && cause_wen) {
       cause := new_cause
       value := new_value
     }
@@ -129,10 +128,10 @@ class BusErrorUnit[T <: BusErrors](t: => T, params: BusErrorUnitParams)(implicit
 
     // hardwire mask bits for unsupported sources to 0
     for ((s, i) <- sources.zipWithIndex; if s.isEmpty) {
-      enable(i) := false
-      global_interrupt(i) := false
-      accrued(i) := false
-      local_interrupt(i) := false
+      enable(i) := false.B
+      global_interrupt(i) := false.B
+      accrued(i) := false.B
+      local_interrupt(i) := false.B
     }
   }
 }

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -3,11 +3,17 @@
 package freechips.rocketchip.tile
 
 import chisel3._
-import chisel3.util.{RegEnable, log2Ceil}
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.util._
+import chisel3.util._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+
+import freechips.rocketchip.diplomacy.{Device, DeviceSnippet, Description, ResourceBinding, ResourceInt}
+import freechips.rocketchip.interrupts.{IntIdentityNode, IntSinkNode, IntSinkPortSimple, IntSourceNode, IntSourcePortSimple}
+import freechips.rocketchip.util.CanHaveErrors
+
+import freechips.rocketchip.diplomacy.IntToProperty
+import freechips.rocketchip.diplomacy.StringToProperty
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
 class NMI(val w: Int) extends Bundle {
   val rnmi = Bool()

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -5,12 +5,18 @@ package freechips.rocketchip.tile
 
 import chisel3._
 import chisel3.util._
-import chisel3.util.HasBlackBoxResource
 import chisel3.experimental.IntParam
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.rocket._
-import freechips.rocketchip.tilelink._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.rocket.{
+  MStatus, HellaCacheIO, TLBPTWIO, CanHavePTW, CanHavePTWModule,
+  SimpleHellaCacheIF, M_XRD, PTE, PRV, M_SZ
+}
+import freechips.rocketchip.tilelink.{
+  TLNode, TLIdentityNode, TLClientNode, TLMasterParameters, TLMasterPortParameters
+}
 import freechips.rocketchip.util.InOrderArbiter
 
 case object BuildRoCC extends Field[Seq[Parameters => LazyRoCC]](Nil)

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -4,15 +4,27 @@
 package freechips.rocketchip.tile
 
 import chisel3._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.rocket._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.devices.tilelink.{BasicBusBlockerParams, BasicBusBlocker}
+import freechips.rocketchip.diplomacy.{
+  AddressSet, ClockCrossingType, DisableMonitors, SimpleDevice, Description,
+  ResourceAnchors, ResourceBindings, ResourceBinding, Resource, ResourceAddress,
+  RationalCrossing, BufferParams
+}
+import freechips.rocketchip.interrupts.IntIdentityNode
+import freechips.rocketchip.tilelink.{TLIdentityNode, TLBuffer}
+import freechips.rocketchip.rocket.{
+  RocketCoreParams, ICacheParams, DCacheParams, BTBParams, HasHellaCache,
+  HasICacheFrontend, ScratchpadSlavePort, HasICacheFrontendModule, Rocket
+}
 import freechips.rocketchip.subsystem.HierarchicalElementCrossingParamsLike
-import freechips.rocketchip.util._
-import freechips.rocketchip.prci.{ClockSinkParameters}
+import freechips.rocketchip.prci.ClockSinkParameters
+import freechips.rocketchip.util.Annotated
+
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
 case class RocketTileBoundaryBufferParams(force: Boolean = false)
 

--- a/src/main/scala/tile/TilePRCIDomain.scala
+++ b/src/main/scala/tile/TilePRCIDomain.scala
@@ -2,15 +2,14 @@
 
 package freechips.rocketchip.tile
 
-import chisel3.Vec
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.prci._
-import freechips.rocketchip.rocket.{TracedInstruction}
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util.{TraceCoreInterface}
+import chisel3._
+
+import org.chipsalliance.cde.config._
+
+import freechips.rocketchip.prci.ClockSinkParameters
+import freechips.rocketchip.rocket.TracedInstruction
+import freechips.rocketchip.subsystem.{HierarchicalElementCrossingParamsLike, HierarchicalElementPRCIDomain}
+import freechips.rocketchip.util.TraceCoreInterface
 
 
 /** A wrapper containing all logic necessary to safely place a tile

--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -4,8 +4,12 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.AddressSet
 
 class AddressAdjuster(
     val params: ReplicatedRegion, // only devices in this region get adjusted

--- a/src/main/scala/tilelink/AsyncCrossing.scala
+++ b/src/main/scala/tilelink/AsyncCrossing.scala
@@ -3,11 +3,13 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, AsynchronousCrossing, NodeHandle}
 import freechips.rocketchip.subsystem.CrossingWrapper
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
+import freechips.rocketchip.util.{AsyncQueueParams, ToAsyncBundle, FromAsyncBundle, Pow2ClockDivider, property}
 
 class TLAsyncCrossingSource(sync: Option[Int])(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/AtomicAutomata.scala
+++ b/src/main/scala/tilelink/AtomicAutomata.scala
@@ -3,11 +3,15 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes}
+import freechips.rocketchip.util.leftOR
+
 import scala.math.{min,max}
-import chisel3.util.{PriorityMux, Cat, FillInterleaved, Mux1H, MuxLookup, log2Up}
 
 // Ensures that all downstream RW managers support Atomic operations.
 // If !passthrough, intercept all Atomics. Otherwise, only intercept those unsupported downstream.

--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -2,8 +2,11 @@
 
 package freechips.rocketchip.tilelink
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, TransferSizes}
 
 case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCustomNode
 {

--- a/src/main/scala/tilelink/BlockDuringReset.scala
+++ b/src/main/scala/tilelink/BlockDuringReset.scala
@@ -3,8 +3,10 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.util.BlockDuringReset
 
 /** BlockDuringReset ensures that no channel admits to be ready or valid while reset is raised. */

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -4,12 +4,18 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.interrupts._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.amba.AMBAProt
+import freechips.rocketchip.diplomacy.{AddressDecoder, AddressSet, IdRange, RegionType, SimpleDevice, TransferSizes}
+import freechips.rocketchip.regmapper.RegField
+import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
+import freechips.rocketchip.util.leftOR
+
+import freechips.rocketchip.util.DataToAugmentedData
+
 import scala.math.{min,max}
 
 case class TLBroadcastControlParams(

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -3,8 +3,12 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.BufferParams
 
 class TLBufferNode (
   a: BufferParams,

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -4,15 +4,28 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.{AddressSet, ClockCrossingType, NoCrossing, NoHandle, NodeHandle, NodeBinding}
 
 // TODO This class should be moved to package subsystem to resolve
 //      the dependency awkwardness of the following imports
-import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.prci._
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.util._
+import freechips.rocketchip.devices.tilelink.{BuiltInDevices, CanHaveBuiltInDevices}
+import freechips.rocketchip.prci.{
+  ClockParameters, ClockDomain, ClockGroup, ClockGroupAggregator, ClockSinkNode,
+  FixedClockBroadcast, ClockGroupEdgeParameters, ClockSinkParameters, ClockSinkDomain,
+  ClockGroupEphemeralNode, asyncMux
+}
+import freechips.rocketchip.subsystem.{
+  HasTileLinkLocations, CanConnectWithinContextThatHasTileLinkLocations,
+  CanInstantiateWithinContextThatHasTileLinkLocations
+}
+import freechips.rocketchip.util.Location
 
 /** Specifies widths of various attachement points in the SoC */
 trait HasTLBusParams {

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -4,10 +4,18 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import TLMessages._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{IdRange, RegionType, TransferSizes}
+import freechips.rocketchip.tilelink.TLMessages.{
+  AcquireBlock, AcquirePerm, Get, PutFullData, PutPartialData, Release,
+  ReleaseData, Grant, GrantData, AccessAck, AccessAckData, ReleaseAck
+}
+import freechips.rocketchip.util.IDPool
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 case class TLCacheCorkParams(
   unsafe: Boolean = false,

--- a/src/main/scala/tilelink/Credited.scala
+++ b/src/main/scala/tilelink/Credited.scala
@@ -3,11 +3,14 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import chisel3.util.Decoupled
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, CreditedCrossing}
 import freechips.rocketchip.subsystem.CrossingWrapper
-import freechips.rocketchip.util._
+import freechips.rocketchip.util.{CreditedDelay, CreditedIO}
 
 class TLCreditedBuffer(delay: TLCreditedDelay)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/CrossingHelper.scala
+++ b/src/main/scala/tilelink/CrossingHelper.scala
@@ -2,9 +2,14 @@
 
 package freechips.rocketchip.tilelink
 
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.prci._
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{
+  AsynchronousCrossing, CrossingType, ClockCrossingType, NoCrossing,
+  RationalCrossing, CreditedCrossing, SynchronousCrossing
+}
+import freechips.rocketchip.prci.{ResetCrossingType, NoResetCrossing, StretchedResetCrossing}
 
 trait TLOutwardCrossingHelper {
   type HelperCrossingType <: CrossingType

--- a/src/main/scala/tilelink/Delayer.scala
+++ b/src/main/scala/tilelink/Delayer.scala
@@ -4,8 +4,9 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
 
 // q is the probability to delay a request
 class TLDelayer(q: Double)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/ErrorEvaluator.scala
+++ b/src/main/scala/tilelink/ErrorEvaluator.scala
@@ -3,9 +3,14 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.AddressSet
+import freechips.rocketchip.util.UIntToOH1
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 // Check if a request satisfies some interesting property
 class RequestPattern(test: TLBundleA => Bool)

--- a/src/main/scala/tilelink/FIFOFixer.scala
+++ b/src/main/scala/tilelink/FIFOFixer.scala
@@ -4,8 +4,12 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
+
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.RegionType
 import freechips.rocketchip.util.property
 
 class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -3,8 +3,11 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, RegionType, TransferSizes}
 
 class TLFilter(
   mfilter: TLFilter.ManagerFilter = TLFilter.mIdentity,

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -4,10 +4,17 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, BufferParams, IdRange, TransferSizes}
+import freechips.rocketchip.util.{Repeater, OH1ToUInt, UIntToOH1}
+
 import scala.math.min
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 object EarlyAck {
   sealed trait T

--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -4,9 +4,14 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, IdRange}
+import freechips.rocketchip.util.{leftOR, UIntToOH1}
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 class IDMapGenerator(numIds: Int) extends Module {
   require (numIds > 0)

--- a/src/main/scala/tilelink/HintHandler.scala
+++ b/src/main/scala/tilelink/HintHandler.scala
@@ -3,9 +3,12 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, RegionType, IdRange, TransferSizes}
+import freechips.rocketchip.util.Repeater
 import freechips.rocketchip.devices.tilelink.TLROM
 
 // Acks Hints for managers that don't support them or Acks all Hints if !passthrough

--- a/src/main/scala/tilelink/Isolation.scala
+++ b/src/main/scala/tilelink/Isolation.scala
@@ -3,8 +3,10 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.util.AsyncBundle
 
 // READ the comments in the TLIsolation object before you instantiate this module

--- a/src/main/scala/tilelink/Jbar.scala
+++ b/src/main/scala/tilelink/Jbar.scala
@@ -3,8 +3,11 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.AddressSet
 
 class TLJbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/Map.scala
+++ b/src/main/scala/tilelink/Map.scala
@@ -3,8 +3,11 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.AddressSet
 
 // Moves the AddressSets of slave devices around
 // Combine with TLFilter to remove slaves or reduce their size

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -5,10 +5,13 @@ package freechips.rocketchip.tilelink
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.SourceLine
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+
+import freechips.rocketchip.diplomacy.EnableMonitors
+import freechips.rocketchip.formal.{MonitorDirection, IfThen, Property, PropertyClass, TestplanTestType, TLMonitorStrictMode}
 import freechips.rocketchip.util.PlusArg
-import freechips.rocketchip.formal._
 
 case class TLMonitorArgs(edge: TLEdge)
 

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -4,8 +4,11 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.experimental.SourceInfo
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.nodes._
+
 import freechips.rocketchip.util.{AsyncQueueParams,RationalDirection}
 
 case object TLMonitorBuilder extends Field[TLMonitorArgs => TLMonitorBase](args => new TLMonitor(args))

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -5,9 +5,19 @@ package freechips.rocketchip.tilelink
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.SourceInfo
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.{
+  AddressDecoder, AddressSet, BufferParams, DirectedBuffers, IdMap, IdMapEntry,
+  IdRange, RegionType, Resource, ResourceAddress, ResourcePermissions, TransferSizes
+}
+import freechips.rocketchip.util.{
+  AsyncQueueParams, BundleField, BundleFieldBase, BundleKeyBase,
+  CreditedDelay, groupByIntoSeq, RationalDirection, SimpleProduct
+}
+
 import scala.math.max
 
 //These transfer sizes describe requests issued from masters on the A channel that will be responded by slaves on the D channel

--- a/src/main/scala/tilelink/PatternPusher.scala
+++ b/src/main/scala/tilelink/PatternPusher.scala
@@ -4,9 +4,11 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 trait Pattern {
   def address: BigInt
@@ -73,7 +75,7 @@ class TLPatternPusher(name: String, pattern: Seq[Pattern])(implicit p: Parameter
     }
 
     val (plegal, pbits) = pattern.map(_.bits(edgeOut)).unzip
-    assert (end || VecInit(plegal)(step), s"Pattern pusher ${name} tried to push an illegal request")
+    assert (end || VecInit(plegal)(step), s"Pattern pusher ${this.name} tried to push an illegal request")
 
     a.valid := io.run && ready && !end && !flight
     a.bits  := VecInit(pbits)(step)

--- a/src/main/scala/tilelink/ProbePicker.scala
+++ b/src/main/scala/tilelink/ProbePicker.scala
@@ -4,8 +4,11 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, IdRange}
 
 /* A ProbePicker is used to unify multiple cache banks into one logical cache  */
 class ProbePicker(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/RAMModel.scala
+++ b/src/main/scala/tilelink/RAMModel.scala
@@ -4,9 +4,13 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.util.{CRC, UIntToOH1}
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 // We detect concurrent puts that put memory into an undefined state.
 // put0, put0Ack, put1, put1Ack => ok: defined

--- a/src/main/scala/tilelink/RationalCrossing.scala
+++ b/src/main/scala/tilelink/RationalCrossing.scala
@@ -10,9 +10,15 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, NodeHandle}
+import freechips.rocketchip.util.{
+  FromRational, ToRational, RationalDirection, Symmetric, FastToSlow, SlowToFast, Pow2ClockDivider, ClockDivider3
+}
+
 
 class TLRationalCrossingSource(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/RegionReplication.scala
+++ b/src/main/scala/tilelink/RegionReplication.scala
@@ -3,8 +3,12 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.AddressSet
 
 /* Address inside the 'local' space are replicated to fill the 'remote' space.
  */

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -4,11 +4,14 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import chisel3.RawModule
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.{AddressSet, Device, TransferSizes, Resource, NoCrossing, ResourceBindings}
+import freechips.rocketchip.regmapper.{RegField, RegMapper, RegMapperParams, RegMapperInput, RegisterRouter}
+import freechips.rocketchip.util.{BundleField, ControlKey, ElaborationArtefacts, GenRegDescsAnno}
 
 import scala.math.min
 

--- a/src/main/scala/tilelink/RegisterRouterTest.scala
+++ b/src/main/scala/tilelink/RegisterRouterTest.scala
@@ -3,10 +3,12 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
 import freechips.rocketchip.regmapper.{RRTest0, RRTest1}
-import freechips.rocketchip.unittest._
+import freechips.rocketchip.unittest.{UnitTest, UnitTestModule}
 
 class TLRRTest0(address: BigInt)(implicit p: Parameters)
   extends RRTest0(address)

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -4,10 +4,16 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import freechips.rocketchip.util.property
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.bundlebridge._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressSet, Device, DeviceRegName, DiplomaticSRAM, RegionType, TransferSizes, HasJustOneSeqMem}
+import freechips.rocketchip.util.{CanHaveErrors, ECCParams, property, SECDEDCode}
+
+import freechips.rocketchip.util.DataToAugmentedData
+import freechips.rocketchip.util.BooleanToAugmentedBoolean
 
 class TLRAMErrors(val params: ECCParams, val addrBits: Int) extends Bundle with CanHaveErrors {
   val correctable   = (params.code.canCorrect && params.notifyErrors).option(Valid(UInt(addrBits.W)))

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -4,9 +4,14 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.IdRange
+import freechips.rocketchip.util.leftOR
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyModule
 {

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -4,13 +4,17 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.amba._
-import freechips.rocketchip.amba.ahb._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import AHBParameters._
-import chisel3.util.{RegEnable, Queue, Cat, log2Ceil}
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
+import freechips.rocketchip.amba.ahb.{AHBImpMaster, AHBParameters, AHBMasterParameters, AHBMasterPortParameters}
+import freechips.rocketchip.amba.ahb.AHBParameters.{BURST_INCR, BURST_SINGLE, TRANS_NONSEQ, TRANS_SEQ, TRANS_IDLE, TRANS_BUSY, PROT_DEFAULT}
+import freechips.rocketchip.diplomacy.TransferSizes
+import freechips.rocketchip.util.{BundleMap, UIntToOH1}
 
 case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImpMaster)(
   dFn = { cp =>

--- a/src/main/scala/tilelink/ToAPB.scala
+++ b/src/main/scala/tilelink/ToAPB.scala
@@ -3,12 +3,17 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.amba.apb._
-import freechips.rocketchip.amba._
-import APBParameters._
 import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.TransferSizes
+import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
+import freechips.rocketchip.amba.apb.{APBImp, APBMasterParameters, APBMasterPortParameters}
+import freechips.rocketchip.amba.apb.APBParameters.PROT_DEFAULT
 
 case class TLToAPBNode()(implicit valName: ValName) extends MixedAdapterNode(TLImp, APBImp)(
   dFn = { cp =>

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -3,12 +3,19 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
-import freechips.rocketchip.amba.axi4._
-import freechips.rocketchip.amba._
-import chisel3.util.{log2Ceil, UIntToOH, Queue, Decoupled, Cat}
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.amba.{AMBACorrupt, AMBACorruptField, AMBAProt, AMBAProtField}
+import freechips.rocketchip.amba.axi4.{AXI4BundleARW, AXI4MasterParameters, AXI4MasterPortParameters, AXI4Parameters, AXI4Imp}
+import freechips.rocketchip.diplomacy.{IdMap, IdMapEntry, IdRange}
+import freechips.rocketchip.util.{BundleField, ControlKey, ElaborationArtefacts, UIntToOH1}
+
+import freechips.rocketchip.util.DataToAugmentedData
 
 class AXI4TLStateBundle(val sourceBits: Int) extends Bundle {
   val size   = UInt(4.W)

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -3,10 +3,13 @@
 package freechips.rocketchip.tilelink
 
 import chisel3._
-import chisel3.util.{DecoupledIO, log2Ceil, Cat, RegEnable}
-import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+import chisel3.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.AddressSet
+import freechips.rocketchip.util.{Repeater, UIntToOH1}
 
 // innBeatBytes => the new client-facing bus width
 class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyModule

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -4,9 +4,12 @@ package freechips.rocketchip.tilelink
 
 import chisel3._
 import chisel3.util._
-import org.chipsalliance.cde.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.util._
+
+import org.chipsalliance.cde.config._
+import org.chipsalliance.diplomacy.lazymodule._
+
+import freechips.rocketchip.diplomacy.{AddressDecoder, AddressSet, RegionType, IdRange, TriStateValue}
+import freechips.rocketchip.util.BundleField
 
 // Trades off slave port proximity against routing resource cost
 object ForceFanout

--- a/src/main/scala/tilelink/package.scala
+++ b/src/main/scala/tilelink/package.scala
@@ -2,8 +2,11 @@
 
 package freechips.rocketchip
 
-import freechips.rocketchip.diplomacy.{HasClockDomainCrossing, _}
-import freechips.rocketchip.prci.{HasResetDomainCrossing}
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.nodes._
+
+import freechips.rocketchip.diplomacy.HasClockDomainCrossing
+import freechips.rocketchip.prci.HasResetDomainCrossing
 
 package object tilelink
 {

--- a/src/main/scala/unittest/TestGenerator.scala
+++ b/src/main/scala/unittest/TestGenerator.scala
@@ -3,8 +3,9 @@
 package freechips.rocketchip.unittest
 
 import chisel3._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy._
+import org.chipsalliance.diplomacy.lazymodule._
 
 abstract class LazyUnitTest(implicit p: Parameters) extends LazyModule
 { self =>

--- a/src/main/scala/util/Annotations.scala
+++ b/src/main/scala/util/Annotations.scala
@@ -4,11 +4,13 @@ package freechips.rocketchip.util
 
 import chisel3._
 import chisel3.experimental.{annotate, ChiselAnnotation}
-import chisel3.RawModule
+
 import firrtl.annotations._
 
-import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
+import org.chipsalliance.diplomacy
+
+import freechips.rocketchip.diplomacy.{AddressRange, AddressSet, AddressMapEntry, ResourcePermissions}
+import freechips.rocketchip.regmapper.{RegField, RegFieldDescSer, RegistersSer}
 
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods.{pretty, render}

--- a/src/main/scala/util/PSDTestMode.scala
+++ b/src/main/scala/util/PSDTestMode.scala
@@ -3,8 +3,10 @@
 package freechips.rocketchip.util
 
 import chisel3._
+
 import org.chipsalliance.cde.config._
-import freechips.rocketchip.diplomacy.{BundleBridgeEphemeralNode, ValName}
+import org.chipsalliance.diplomacy._
+import org.chipsalliance.diplomacy.bundlebridge._
 
 case object IncludePSDTest extends Field[Boolean](false)
 case object PSDTestModeBroadcastKey extends Field(


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: no functional change 

**Development Phase**: implementation

**Release Notes**
Updates diplomacy imports to explicitly use standalone diplomacy module.
