### PR TITLE
Update SRAM.scala to improve perf on non-full sized reads

### DIFF
--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -229,14 +229,15 @@ class TLRAM(
     val r_ready = !d_wb && !r_replay && (!d_full || d_ready) && (!r_respond || (!d_win && in.d.ready))
     in.a.ready := !(d_full && d_wb) && (!r_full || r_ready) && (!r_full || !(r_atomic || r_sublane))
 
-    // ignore sublane if mask is all set
+    // ignore sublane if it is a read or mask is all set
+    val a_read = in.a.bits.opcode === TLMessages.Get
     val a_sublane = if (eccBytes == 1) false.B else
-      ((in.a.bits.opcode === TLMessages.PutPartialData) && (~in.a.bits.mask.andR)) ||
-      in.a.bits.size < log2Ceil(eccBytes).U
+      ~a_read && 
+      (((in.a.bits.opcode === TLMessages.PutPartialData) && (~in.a.bits.mask.andR)) ||
+      in.a.bits.size < log2Ceil(eccBytes).U)
     val a_atomic = if (!atomics) false.B else
       in.a.bits.opcode === TLMessages.ArithmeticData ||
       in.a.bits.opcode === TLMessages.LogicalData
-    val a_read = in.a.bits.opcode === TLMessages.Get
 
     // Forward pipeline stage from R to D
     when (d_ready) { d_full := false.B }


### PR DESCRIPTION
**Commit Description:**
Change a_sublane to not count sublanes if it's a read. Reads return full data width, no matter if the A channel size is not the data width

**Comments**
Noticed that when size is not maxed out on a read to the TLRAM, it was translating it to a RMW. Would make sense if there was an ECC error but that should get handled by d_need_fix in d_wb, sublane should not be responsible.

`val d_wb = d_full && (d_sublane || d_atomic || (d_read && d_need_fix))`

![Screenshot 2024-04-10 at 4 17 50 PM](https://github.com/chipsalliance/rocket-chip/assets/36599815/b1ec0204-ec81-4889-9fab-f42d7c5723ef)