### PR TITLE
Use SV48 when possible

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -14,7 +14,7 @@ import freechips.rocketchip.util._
 
 class BaseSubsystemConfig extends Config ((site, here, up) => {
   // Tile parameters
-  case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
+  case PgLevels => if (site(XLen) == 64) 4 /* Sv48 */ else 2 /* Sv32 */
   case XLen => 64 // Applies to all cores
   case MaxHartIdBits => log2Up((site(TilesLocated(InSubsystem)).map(_.tileParams.hartId) :+ 0).max+1)
   // Interconnect parameters


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
This bumps the default Rocket core to use SV48 instead of SV39. This has been tested in a Chipyard/FireSim environment to boot Linux (buildroot Linux and Ubuntu Linux). 
