### PR TITLE
Set parameterized desiredName on many system components

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -671,7 +671,7 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
 
   val cfg = p(DebugModuleKey).get
 
-  val dmiXbar = LazyModule (new TLXbar())
+  val dmiXbar = LazyModule (new TLXbar(nameSuffix = Some("dmixbar")))
 
   val dmi2tlOpt = (!p(ExportDebug).apb).option({
     val dmi2tl = LazyModule(new DMIToTL())

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -87,7 +87,7 @@ trait HasPeripheryDebug { this: BaseSubsystem =>
   lazy val debugOpt = p(DebugModuleKey).map { params =>
     val tlDM = LazyModule(new TLDebugModule(tlbus.beatBytes))
 
-    tlDM.node := tlbus.coupleTo("debug"){ TLFragmenter(tlbus) := _ }
+    tlDM.node := tlbus.coupleTo("debug"){ TLFragmenter(tlbus.beatBytes, tlbus.blockBytes, nameSuffix = Some("Debug")) := _ }
     tlDM.dmInner.dmInner.customNode := debugCustomXbarOpt.get.node
 
     (apbDebugNodeOpt zip tlDM.apbNodeOpt) foreach { case (master, slave) =>

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -85,7 +85,7 @@ object BootROM {
       LazyModule(new TLROM(params.address, params.size, contents, true, tlbus.beatBytes))
     }
 
-    bootrom.node := tlbus.coupleTo("bootrom"){ TLFragmenter(tlbus) := _ }
+    bootrom.node := tlbus.coupleTo("bootrom"){ TLFragmenter(tlbus, Some("BootROM")) := _ }
     // Drive the `subsystem` reset vector to the `hang` address of this Boot ROM.
     subsystem.tileResetVectorNexusNode := bootROMResetVectorSourceNode
     InModuleBody {

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -109,7 +109,7 @@ trait CanHavePeripheryCLINT { this: BaseSubsystem =>
     val tlbus = locateTLBusWrapper(p(CLINTAttachKey).slaveWhere)
     val clintDomainWrapper = tlbus.generateSynchronousDomain("CLINT").suggestName("clint_domain")
     val clint = clintDomainWrapper { LazyModule(new CLINT(params, tlbus.beatBytes)) }
-    clintDomainWrapper { clint.node := tlbus.coupleTo("clint") { TLFragmenter(tlbus) := _ } }
+    clintDomainWrapper { clint.node := tlbus.coupleTo("clint") { TLFragmenter(tlbus, Some("CLINT")) := _ } }
     val clintTick = clintDomainWrapper { InModuleBody {
       val tick = IO(Input(Bool()))
       clint.module.io.rtcTick := tick

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -364,7 +364,7 @@ trait CanHavePeripheryPLIC { this: BaseSubsystem =>
     val plicDomainWrapper = tlbus.generateSynchronousDomain("PLIC").suggestName("plic_domain")
 
     val plic = plicDomainWrapper { LazyModule(new TLPLIC(params, tlbus.beatBytes)) }
-    plicDomainWrapper { plic.node := tlbus.coupleTo("plic") { TLFragmenter(tlbus) := _ } }
+    plicDomainWrapper { plic.node := tlbus.coupleTo("plic") { TLFragmenter(tlbus, Some("PLIC")) := _ } }
     plicDomainWrapper { plic.intnode :=* ibus.toPLIC }
 
     (plic, plicDomainWrapper)

--- a/src/main/scala/interrupts/Crossing.scala
+++ b/src/main/scala/interrupts/Crossing.scala
@@ -39,11 +39,15 @@ class IntSyncCrossingSource(alreadyRegistered: Boolean = false)(implicit p: Para
   lazy val module = if (alreadyRegistered) (new ImplRegistered) else (new Impl)
 
   class Impl extends LazyModuleImp(this) {
+    def outSize = node.out.headOption.map(_._1.sync.size).getOrElse(0)
+    override def desiredName = s"IntSyncCrossingSource_n${node.out.size}x${outSize}"
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out.sync := AsyncResetReg(Cat(in.reverse)).asBools
     }
   }
   class ImplRegistered extends LazyRawModuleImp(this) {
+    def outSize = node.out.headOption.map(_._1.sync.size).getOrElse(0)
+    override def desiredName = s"IntSyncCrossingSource_n${node.out.size}x${outSize}_Registered"
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out.sync := in
     }
@@ -68,6 +72,7 @@ class IntSyncAsyncCrossingSink(sync: Int = 3)(implicit p: Parameters) extends La
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
+    override def desiredName = s"IntSyncAsyncCrossingSink_n${node.out.size}x${node.out.head._1.size}"
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out := SynchronizerShiftReg(in.sync, sync)
     }
@@ -89,6 +94,8 @@ class IntSyncSyncCrossingSink()(implicit p: Parameters) extends LazyModule
 
   lazy val module = new Impl
   class Impl extends LazyRawModuleImp(this) {
+    def outSize = node.out.headOption.map(_._1.size).getOrElse(0)
+    override def desiredName = s"IntSyncSyncCrossingSink_n${node.out.size}x${outSize}"
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out := in.sync
     }
@@ -110,6 +117,8 @@ class IntSyncRationalCrossingSink()(implicit p: Parameters) extends LazyModule
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
+    def outSize = node.out.headOption.map(_._1.size).getOrElse(0)
+    override def desiredName = s"IntSyncRationalCrossingSink_n${node.out.size}x${outSize}"
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out := RegNext(in.sync)
     }

--- a/src/main/scala/interrupts/Xbar.scala
+++ b/src/main/scala/interrupts/Xbar.scala
@@ -20,6 +20,7 @@ class IntXbar()(implicit p: Parameters) extends LazyModule
 
   lazy val module = new Impl
   class Impl extends LazyRawModuleImp(this) {
+    override def desiredName = s"IntXbar_i${intnode.in.size}_o${intnode.out.size}"
     val cat = intnode.in.map { case (i, e) => i.take(e.source.num) }.flatten
     intnode.out.foreach { case (o, _) => o := cat }
   }
@@ -40,6 +41,7 @@ class IntSyncXbar()(implicit p: Parameters) extends LazyModule
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
+    override def desiredName = s"IntSyncXbar_i${intnode.in.size}_o${intnode.out.size}"
     val cat = intnode.in.map { case (i, e) => i.sync.take(e.source.num) }.flatten
     intnode.out.foreach { case (o, _) => o.sync := cat }
   }

--- a/src/main/scala/jtag/JtagShifter.scala
+++ b/src/main/scala/jtag/JtagShifter.scala
@@ -87,6 +87,7 @@ object JtagBypassChain {
   * 4.3.2a TDI captured on TCK rising edge, 6.1.2.1b assumed changes on TCK falling edge
   */
 class CaptureChain[+T <: Data](gen: T)(implicit val p: Parameters) extends Chain {
+  override def desiredName = s"CaptureChain_${gen.typeName}"
   class ModIO extends ChainIO {
     val capture = Capture(gen)
   }
@@ -134,6 +135,7 @@ object CaptureChain {
   * 4.3.2a TDI captured on TCK rising edge, 6.1.2.1b assumed changes on TCK falling edge
   */
 class CaptureUpdateChain[+T <: Data, +V <: Data](genCapture: T, genUpdate: V)(implicit val p: Parameters) extends Chain {
+  override def desiredName = s"CaptureUpdateChain_${genCapture.typeName}_To_${genUpdate.typeName}"
   class ModIO extends ChainIO {
     val capture = Capture(genCapture)
     val update = Valid(genUpdate)  // valid high when in update state (single cycle), contents may change any time after

--- a/src/main/scala/prci/ClockGroup.scala
+++ b/src/main/scala/prci/ClockGroup.scala
@@ -48,7 +48,7 @@ case class ClockGroupAggregateNode(groupName: String)(implicit valName: ValName)
 class ClockGroupAggregator(groupName: String)(implicit p: Parameters) extends LazyModule
 {
   val node = ClockGroupAggregateNode(groupName)
-
+  override lazy val desiredName = s"ClockGroupAggregator_$groupName"
   lazy val module = new Impl
   class Impl extends LazyRawModuleImp(this) {
     val (in, _) = node.in.unzip
@@ -104,6 +104,7 @@ class FixedClockBroadcast(fixedClockOpt: Option[ClockParameters])(implicit p: Pa
   class Impl extends LazyRawModuleImp(this) {
     val (in, _) = node.in(0)
     val (out, _) = node.out.unzip
+    override def desiredName = s"FixedClockBroadcast_${out.size}"
     require (node.in.size == 1, "FixedClockBroadcast can only broadcast a single clock")
     out.foreach { _ := in }
   }

--- a/src/main/scala/prci/ResetStretcher.scala
+++ b/src/main/scala/prci/ResetStretcher.scala
@@ -14,7 +14,7 @@ import org.chipsalliance.diplomacy.lazymodule._
 class ResetStretcher(cycles: Int)(implicit p: Parameters) extends LazyModule {
   val node = ClockAdapterNode()(ValName("reset_stretcher"))
   require(cycles > 1, s"ResetStretcher only supports cycles > 1 but got ${cycles}")
-
+  override lazy val desiredName = s"ResetStretcher$cycles"
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     (node.in zip node.out).foreach { case ((in, _), (out, _)) =>

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -59,7 +59,7 @@ class DCacheDataArray(implicit p: Parameters) extends L1HellaCacheModule()(p) {
   val data_arrays = Seq.tabulate(rowBits / subWordBits) {
     i =>
       DescribedSRAM(
-        name = s"data_arrays_${i}",
+        name = s"${tileParams.baseName}_dcache_data_arrays_${i}",
         desc = "DCache Data Array",
         size = nSets * cacheBlockBytes / rowBytes,
         data = Vec(nWays * (subWordBits / eccBits), UInt(encBits.W))
@@ -134,7 +134,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   val metaArb = Module(new Arbiter(new DCacheMetadataReq, 8) with InlineInstance)
 
   val tag_array = DescribedSRAM(
-    name = "tag_array",
+    name = s"${tileParams.baseName}_dcache_tag_array",
     desc = "DCache Tag Array",
     size = nSets,
     data = Vec(nWays, chiselTypeOf(metaArb.io.out.bits.data))

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -417,7 +417,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
  *   content with `refillError ## tag[19:0]` after ECC
  * */
   val tag_array  = DescribedSRAM(
-    name = "tag_array",
+    name = s"${tileParams.baseName}_icache_tag_array",
     desc = "ICache Tag Array",
     size = nSets,
     data = Vec(nWays, UInt(tECC.width(1 + tagBits).W))
@@ -551,7 +551,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   val data_arrays = Seq.tabulate(tl_out.d.bits.data.getWidth / wordBits) {
     i =>
       DescribedSRAM(
-        name = s"data_arrays_${i}",
+        name = s"${tileParams.baseName}_icache_data_arrays_${i}",
         desc = "ICache Data Array",
         size = nSets * refillCycles,
         data = Vec(nWays, UInt(dECC.width(wordBits).W))

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -142,6 +142,7 @@ class PMPHomogeneityChecker(pmps: Seq[PMP])(implicit p: Parameters) {
 
 class PMPChecker(lgMaxSize: Int)(implicit val p: Parameters) extends Module
     with HasCoreParameters {
+  override def desiredName = s"PMPChecker_s${lgMaxSize}"
   val io = IO(new Bundle {
     val prv = Input(UInt(PRV.SZ.W))
     val pmp = Input(Vec(nPMPs, new PMP))

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -751,10 +751,12 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val dmem_resp_valid = io.dmem.resp.valid && io.dmem.resp.bits.has_data
   val dmem_resp_replay = dmem_resp_valid && io.dmem.resp.bits.replay
 
-  val ll_arb = Module(new Arbiter(new Bundle {
+  class LLWB extends Bundle {
     val data = UInt(xLen.W)
     val tag = UInt(5.W)
-  }, 3)) // div, rocc, vec
+  }
+
+  val ll_arb = Module(new Arbiter(new LLWB, 3)) // div, rocc, vec
   ll_arb.io.in.foreach(_.valid := false.B)
   ll_arb.io.in.foreach(_.bits := DontCare)
   val ll_wdata = WireInit(ll_arb.io.out.bits.data)

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -317,6 +317,7 @@ case class TLBConfig(
   * @param edge collect SoC metadata.
   */
 class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(p) {
+  override def desiredName = if (instruction) "ITLB" else "DTLB"
   val io = IO(new Bundle {
     /** request from Core */
     val req = Flipped(Decoupled(new TLBReq(lgMaxSize)))

--- a/src/main/scala/subsystem/HierarchicalElement.scala
+++ b/src/main/scala/subsystem/HierarchicalElement.scala
@@ -52,8 +52,8 @@ abstract class BaseHierarchicalElement (val crossing: ClockCrossingType)(implici
   def module: BaseHierarchicalElementModuleImp[BaseHierarchicalElement]
 
   protected val tlOtherMastersNode = TLIdentityNode()
-  protected val tlMasterXbar = LazyModule(new TLXbar)
-  protected val tlSlaveXbar = LazyModule(new TLXbar)
+  protected val tlMasterXbar = LazyModule(new TLXbar(nameSuffix = Some(s"MasterXbar_$desiredName")))
+  protected val tlSlaveXbar = LazyModule(new TLXbar(nameSuffix = Some(s"SlaveXbar_$desiredName")))
   protected val intXbar = LazyModule(new IntXbar)
 
   def masterNode: TLOutwardNode

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -44,7 +44,7 @@ class MemoryBus(params: MemoryBusParams, name: String = "memory_bus")(implicit p
     addressPrefixNexusNode
   }
 
-  private val xbar = LazyModule(new TLXbar).suggestName(busName + "_xbar")
+  private val xbar = LazyModule(new TLXbar(nameSuffix = Some(name))).suggestName(busName + "_xbar")
   val inwardNode: TLInwardNode =
     replicator.map(xbar.node :*=* TLFIFOFixer(TLFIFOFixer.all) :*=* _.node)
         .getOrElse(xbar.node :*=* TLFIFOFixer(TLFIFOFixer.all))

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -44,7 +44,7 @@ class SystemBus(params: SystemBusParams, name: String = "system_bus")(implicit p
     addressPrefixNexusNode
   }
 
-  private val system_bus_xbar = LazyModule(new TLXbar(policy = params.policy))
+  private val system_bus_xbar = LazyModule(new TLXbar(policy = params.policy, nameSuffix = Some(name)))
   val inwardNode: TLInwardNode = system_bus_xbar.node :=* TLFIFOFixer(TLFIFOFixer.allVolatile) :=* replicator.map(_.node).getOrElse(TLTempNode())
   val outwardNode: TLOutwardNode = system_bus_xbar.node
   def busView: TLEdge = system_bus_xbar.node.edges.in.head

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -632,6 +632,7 @@ class FPToFP(val latency: Int)(implicit p: Parameters) extends FPUModule()(p) wi
 
 class MulAddRecFNPipe(latency: Int, expWidth: Int, sigWidth: Int) extends Module
 {
+    override def desiredName = s"MulAddRecFNPipe_l${latency}_e${expWidth}_s${sigWidth}"
     require(latency<=2)
 
     val io = IO(new Bundle {
@@ -695,6 +696,7 @@ class MulAddRecFNPipe(latency: Int, expWidth: Int, sigWidth: Int) extends Module
 
 class FPUFMAPipe(val latency: Int, val t: FType)
                 (implicit p: Parameters) extends FPUModule()(p) with ShouldBeRetimed {
+  override def desiredName = s"FPUFMAPipe_l${latency}_f${t.ieeeWidth}"
   require(latency>0)
 
   val io = IO(new Bundle {

--- a/src/main/scala/tilelink/AsyncCrossing.scala
+++ b/src/main/scala/tilelink/AsyncCrossing.scala
@@ -20,6 +20,7 @@ class TLAsyncCrossingSource(sync: Option[Int])(implicit p: Parameters) extends L
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
+    override def desiredName = (Seq("TLAsyncCrossingSource") ++ node.in.headOption.map(_._2.bundle.shortName)).mkString("_")
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       val bce = edgeIn.manager.anySupportAcquireB && edgeIn.client.anySupportProbe
       val psync = sync.getOrElse(edgeOut.manager.async.sync)
@@ -55,6 +56,7 @@ class TLAsyncCrossingSink(params: AsyncQueueParams = AsyncQueueParams())(implici
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
+    override def desiredName = (Seq("TLAsyncCrossingSink") ++ node.out.headOption.map(_._2.bundle.shortName)).mkString("_")
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       val bce = edgeOut.manager.anySupportAcquireB && edgeOut.client.anySupportProbe
 

--- a/src/main/scala/tilelink/AtomicAutomata.scala
+++ b/src/main/scala/tilelink/AtomicAutomata.scala
@@ -284,9 +284,11 @@ class TLAtomicAutomata(logical: Boolean = true, arithmetic: Boolean = true, conc
 
 object TLAtomicAutomata
 {
-  def apply(logical: Boolean = true, arithmetic: Boolean = true, concurrency: Int = 1, passthrough: Boolean = true)(implicit p: Parameters): TLNode =
+  def apply(logical: Boolean = true, arithmetic: Boolean = true, concurrency: Int = 1, passthrough: Boolean = true, nameSuffix: Option[String] = None)(implicit p: Parameters): TLNode =
   {
-    val atomics = LazyModule(new TLAtomicAutomata(logical, arithmetic, concurrency, passthrough))
+    val atomics = LazyModule(new TLAtomicAutomata(logical, arithmetic, concurrency, passthrough) {
+      override lazy val desiredName = (Seq("TLAtomicAutomata") ++ nameSuffix).mkString("_")
+    })
     atomics.node
   }
 

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -38,6 +38,8 @@ class TLBuffer(
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
+    def headBundle = node.out.head._2.bundle
+    override def desiredName = (Seq("TLBuffer") ++ node.out.headOption.map(_._2.bundle.shortName)).mkString("_")
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out.a <> a(in .a)
       in .d <> d(out.d)

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -173,6 +173,7 @@ sealed trait TLAddrChannel extends TLDataChannel
 final class TLBundleA(params: TLBundleParameters)
   extends TLBundleBase(params) with TLAddrChannel
 {
+  override def typeName = s"TLBundleA_${params.shortName}"
   val channelName = "'A' channel"
   // fixed fields during multibeat:
   val opcode  = UInt(3.W)
@@ -190,6 +191,7 @@ final class TLBundleA(params: TLBundleParameters)
 final class TLBundleB(params: TLBundleParameters)
   extends TLBundleBase(params) with TLAddrChannel
 {
+  override def typeName = s"TLBundleB_${params.shortName}"
   val channelName = "'B' channel"
   // fixed fields during multibeat:
   val opcode  = UInt(3.W)
@@ -206,6 +208,7 @@ final class TLBundleB(params: TLBundleParameters)
 final class TLBundleC(params: TLBundleParameters)
   extends TLBundleBase(params) with TLAddrChannel
 {
+  override def typeName = s"TLBundleC_${params.shortName}"
   val channelName = "'C' channel"
   // fixed fields during multibeat:
   val opcode  = UInt(3.W)
@@ -223,6 +226,7 @@ final class TLBundleC(params: TLBundleParameters)
 final class TLBundleD(params: TLBundleParameters)
   extends TLBundleBase(params) with TLDataChannel
 {
+  override def typeName = s"TLBundleD_${params.shortName}"
   val channelName = "'D' channel"
   // fixed fields during multibeat:
   val opcode  = UInt(3.W)
@@ -241,6 +245,7 @@ final class TLBundleD(params: TLBundleParameters)
 final class TLBundleE(params: TLBundleParameters)
   extends TLBundleBase(params) with TLChannel
 {
+  override def typeName = s"TLBundleE_${params.shortName}"
   val channelName = "'E' channel"
   val sink = UInt(params.sinkBits.W) // to
 }

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -95,11 +95,11 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
   protected val addressPrefixNexusNode = BundleBroadcast[UInt](registered = false, default = Some(() => 0.U(1.W)))
 
   def to[T](name: String)(body: => T): T = {
-    this { LazyScope(s"coupler_to_${name}", "TLInterconnectCoupler") { body } }
+    this { LazyScope(s"coupler_to_${name}", s"TLInterconnectCoupler_${busName}_to_${name}") { body } }
   }
 
   def from[T](name: String)(body: => T): T = {
-    this { LazyScope(s"coupler_from_${name}", "TLInterconnectCoupler") { body } }
+    this { LazyScope(s"coupler_from_${name}", s"TLInterconnectCoupler_${busName}_from_${name}") { body } }
   }
 
   def coupleTo[T](name: String)(gen: TLOutwardNode => T): T =
@@ -237,7 +237,7 @@ class TLBusWrapperTopology(
 }
 
 trait HasTLXbarPhy { this: TLBusWrapper =>
-  private val xbar = LazyModule(new TLXbar).suggestName(busName + "_xbar")
+  private val xbar = LazyModule(new TLXbar(nameSuffix = Some(busName))).suggestName(busName + "_xbar")
 
   override def shouldBeInlined = xbar.node.circuitIdentity
   def inwardNode: TLInwardNode = xbar.node

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -1311,6 +1311,9 @@ case class TLBundleParameters(
 
   val addrLoBits = log2Up(dataBits/8)
 
+  // Used to uniquify bus IP names
+  def shortName = s"a${addressBits}d${dataBits}s${sourceBits}k${sinkBits}z${sizeBits}" + (if (hasBCE) "c" else "u")
+
   def union(x: TLBundleParameters) =
     TLBundleParameters(
       max(addressBits, x.addressBits),

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -21,6 +21,8 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
     override def circuitIdentity = edges.out.map(_.manager).forall(noChangeRequired)
   }
 
+  override lazy val desiredName = s"TLWidthWidget$innerBeatBytes"
+
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     def merge[T <: TLDataChannel](edgeIn: TLEdge, in: DecoupledIO[T], edgeOut: TLEdge, out: DecoupledIO[T]) = {

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -33,7 +33,7 @@ object ForceFanout
 private case class ForceFanoutParams(a: Boolean, b: Boolean, c: Boolean, d: Boolean, e: Boolean)
 private case object ForceFanoutKey extends Field(ForceFanoutParams(false, false, false, false, false))
 
-class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters) extends LazyModule
+class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin, nameSuffix: Option[String] = None)(implicit p: Parameters) extends LazyModule
 {
   val node = new TLNexusNode(
     clientFn  = { seq =>
@@ -77,7 +77,8 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
       println (s" Your TLXbar ($name with parent $parent) is very large, with ${node.in.size} Masters and ${node.out.size} Slaves.")
       println (s"!!! WARNING !!!")
     }
-
+    val wide_bundle = TLBundleParameters.union((node.in ++ node.out).map(_._2.bundle))
+    override def desiredName = (Seq("TLXbar") ++ nameSuffix ++ Seq(s"i${node.in.size}_o${node.out.size}_${wide_bundle.shortName}")).mkString("_")
     TLXbar.circuit(policy, node.in, node.out)
   }
 }
@@ -340,9 +341,9 @@ object TLXbar
     }
   }
 
-  def apply(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parameters): TLNode =
+  def apply(policy: TLArbiter.Policy = TLArbiter.roundRobin, nameSuffix: Option[String] = None)(implicit p: Parameters): TLNode =
   {
-    val xbar = LazyModule(new TLXbar(policy))
+    val xbar = LazyModule(new TLXbar(policy, nameSuffix))
     xbar.node
   }
 

--- a/src/main/scala/util/AsyncQueue.scala
+++ b/src/main/scala/util/AsyncQueue.scala
@@ -68,6 +68,8 @@ class AsyncValidSync(sync: Int, desc: String) extends RawModule {
 }
 
 class AsyncQueueSource[T <: Data](gen: T, params: AsyncQueueParams = AsyncQueueParams()) extends Module {
+  override def desiredName = s"AsyncQueueSource_${gen.typeName}"
+
   val io = IO(new Bundle {
     // These come from the source domain
     val enq = Flipped(Decoupled(gen))
@@ -132,6 +134,8 @@ class AsyncQueueSource[T <: Data](gen: T, params: AsyncQueueParams = AsyncQueueP
 }
 
 class AsyncQueueSink[T <: Data](gen: T, params: AsyncQueueParams = AsyncQueueParams()) extends Module {
+  override def desiredName = s"AsyncQueueSink_${gen.typeName}"
+
   val io = IO(new Bundle {
     // These come from the sink domain
     val deq = Decoupled(gen)

--- a/src/main/scala/util/Repeater.scala
+++ b/src/main/scala/util/Repeater.scala
@@ -9,6 +9,7 @@ import chisel3.util.{Decoupled, DecoupledIO}
 // When repeat is asserted, the Repeater copies the input and repeats it next cycle.
 class Repeater[T <: Data](gen: T) extends Module
 {
+  override def desiredName = s"Repeater_${gen.typeName}"
   val io = IO( new Bundle {
     val repeat = Input(Bool())
     val full = Output(Bool())

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -270,7 +270,7 @@ package object util {
         val y = Output(chiselTypeOf(in))
       })
       io.y := io.x
-      override def desiredName = "OptimizationBarrier"
+      override def desiredName = s"OptimizationBarrier_${in.typeName}"
     })
     barrier.io.x := in
     barrier.io.y


### PR DESCRIPTION
This improves the naming stability of generated verilog by adding descriptive suffixes to module names. This makes it easier to determine where many important modules are instantiated.



**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
