### PR TITLE
Interrupts coming outwards from the Tile should cross into a toPlicDomain

### DIFF
--- a/src/main/scala/subsystem/Cluster.scala
+++ b/src/main/scala/subsystem/Cluster.scala
@@ -63,6 +63,7 @@ class Cluster(
   def msipDomain = this
   def meipDomain = this
   def seipDomain = this
+  def toPlicDomain = this
   lazy val msipNodes = totalTileIdList.map { i => (i, IntIdentityNode()) }.to(SortedMap)
   lazy val meipNodes = totalTileIdList.map { i => (i, IntIdentityNode()) }.to(SortedMap)
   lazy val seipNodes = totalTileIdList.map { i => (i, IntIdentityNode()) }.to(SortedMap)

--- a/src/main/scala/subsystem/HasHierarchicalElements.scala
+++ b/src/main/scala/subsystem/HasHierarchicalElements.scala
@@ -168,6 +168,7 @@ trait DefaultHierarchicalElementContextType
   val meipNodes: SortedMap[Int, IntNode]
   def seipDomain: LazyScope
   val seipNodes: SortedMap[Int, IntNode]
+  def toPlicDomain: LazyScope
   val tileToPlicNodes: SortedMap[Int, IntNode]
   val debugNodes: SortedMap[Int, IntSyncNode]
   val nmiNodes: SortedMap[Int, BundleBridgeNode[NMI]]
@@ -192,6 +193,7 @@ trait HasHierarchicalElementsRootContext
   def msipDomain = clintDomainOpt.getOrElse(this)
   def meipDomain = plicDomainOpt.getOrElse(this)
   def seipDomain = plicDomainOpt.getOrElse(this)
+  def toPlicDomain = plicDomainOpt.getOrElse(this)
 
   val msipNodes: SortedMap[Int, IntNode] = (0 until nTotalTiles).map { i =>
     (i, IntEphemeralNode())

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -238,7 +238,7 @@ trait CanAttachTile {
     //    so might need to be synchronized depending on the Tile's crossing type.
     context.tileToPlicNodes.get(domain.element.tileId).foreach { node =>
       FlipRendering { implicit p => domain.element.intOutwardNode.foreach { out =>
-        node := domain.crossIntOut(crossingParams.crossingType, out)
+        context.toPlicDomain { node := domain.crossIntOut(crossingParams.crossingType, out) }
       }}
     }
 


### PR DESCRIPTION
This avoids accidental no-implicit-clock errors, now that BaseSubsystem has no clocks

Resolves #3647 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
