### PR TITLE
PTW: traverse check GPA bits higher than HGATP mode only if leaf

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -695,7 +695,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
       when (do_both_stages && !stage2) { do_switch := true.B }
       count := count + 1.U
     }.otherwise {
-      val gf = (stage2 && !stage2_final && !pte.ur()) || (pte.v && pte.reserved_for_future === 0.U && invalid_gpa)
+      val gf = (stage2 && !stage2_final && !pte.ur()) || (pte.leaf() && pte.reserved_for_future === 0.U && invalid_gpa)
       val ae = pte.v && invalid_paddr
       val pf = pte.v && pte.reserved_for_future =/= 0.U
       val success = pte.v && !ae && !pf && !gf
@@ -723,7 +723,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
         }
 
         resp_ae_ptw := ae && count < (pgLevels-1).U && pte.table()
-        resp_ae_final := ae
+        resp_ae_final := ae && pte.leaf()
         resp_pf := pf && !stage2
         resp_gf := gf || (pf && stage2)
         resp_hr := !stage2 || (!pf && !gf && pte.ur())


### PR DESCRIPTION
**Related issue**: This is a similar bug as https://github.com/chipsalliance/rocket-chip/pull/3625: different bits for a valid-but-table entry in the same last-level FSM state.

**Type of change**: bug report

**Impact**: functional fix

**Development Phase**: implementation

**Release Notes**
 PTW: qualify `invalid_gpa` with `pte.leaf()` instead of just `pte.v`.