### PR TITLE
Solve naming conflict with Yosys

### DIFF
--- a/src/main/scala/rocket/ALU.scala
+++ b/src/main/scala/rocket/ALU.scala
@@ -65,6 +65,8 @@ abstract class AbstractALU[T <: ALUFN](val aluFn: T)(implicit p: Parameters) ext
 }
 
 class ALU(implicit p: Parameters) extends AbstractALU(new ALUFN)(p) {
+  override def desiredName = "RocketALU"
+
   // ADD, SUB
   val in2_inv = Mux(aluFn.isSub(io.fn), ~io.in2, io.in2)
   val in1_xor_in2 = io.in1 ^ in2_inv


### PR DESCRIPTION
Yosys and other synthesis tools already have internal ALU blocks which collide with a module named ALU