### PR TITLE
remove master slave terminology from rocket-chip

### DIFF
--- a/src/main/scala/amba/ahb/AHBLite.scala
+++ b/src/main/scala/amba/ahb/AHBLite.scala
@@ -7,14 +7,14 @@ import org.chipsalliance.cde.config.Parameters
 import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 class AHBLite()(implicit p: Parameters) extends LazyModule {
-  val node = AHBMasterAdapterNode(
-    masterFn = { mp => mp },
-    slaveFn  = { sp => sp.copy(lite = false) })
+  val node = AHBManagerAdapterNode(
+    managerFn = { mp => mp },
+    subordinateFn  = { sp => sp.copy(lite = false) })
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      require (edgeOut.slave.lite) // or else this adapter is pointless
+      require (edgeOut.subordinate.lite) // or else this adapter is pointless
 
       out.hmastlock.get := in.hlock.get
       in.hgrant.get := true.B

--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -5,10 +5,10 @@ package freechips.rocketchip.amba.ahb
 import chisel3._
 import freechips.rocketchip.util._
 
-// Signal directions are from the master's point-of-view
-class AHBSlaveBundle(val params: AHBBundleParameters) extends Bundle
+// Signal directions are from the manager's point-of-view
+class AHBSubordinateBundle(val params: AHBBundleParameters) extends Bundle
 {
-  // Control signals from the arbiter to slave
+  // Control signals from the arbiter to subordinate
   val hmastlock = Output(Bool())
   val hsel      = Output(Bool())
 
@@ -16,7 +16,7 @@ class AHBSlaveBundle(val params: AHBBundleParameters) extends Bundle
   val hready    = Output(Bool()) // from arbiter
   val hreadyout = Input(Bool())  // to arbiter
 
-  // A-phase signals from arbiter to slave
+  // A-phase signals from arbiter to subordinate
   val htrans    = Output(UInt(params.transBits.W))
   val hsize     = Output(UInt(params.sizeBits.W))
   val hburst    = Output(UInt(params.burstBits.W))
@@ -25,27 +25,27 @@ class AHBSlaveBundle(val params: AHBBundleParameters) extends Bundle
   val haddr     = Output(UInt(params.addrBits.W))
   val hauser    = BundleMap(params.requestFields)
 
-  // D-phase signals from arbiter to slave
+  // D-phase signals from arbiter to subordinate
   val hduser    = BundleMap(params.responseFields)
   val hwdata    = Output(UInt(params.dataBits.W))
 
-  // D-phase signals from slave to arbiter
+  // D-phase signals from subordinate to arbiter
   val hresp     = Input(UInt(params.hrespBits.W))
   val hrdata    = Input(UInt(params.dataBits.W))
 
   // Split signals
-  val hmaster   = if (params.lite) None else Some(Output(UInt(4.W)))
+  val hmanager   = if (params.lite) None else Some(Output(UInt(4.W)))
   val hsplit    = if (params.lite) None else Some(Input(UInt(16.W)))
 }
 
-class AHBMasterBundle(val params: AHBBundleParameters) extends Bundle
+class AHBManagerBundle(val params: AHBBundleParameters) extends Bundle
 {
-  // Control signals from master to arbiter
+  // Control signals from manager to arbiter
   val hmastlock = if (params.lite) Some(Output(Bool())) else None
   val hlock     = if (params.lite) None else Some(Output(Bool()))
   val hbusreq   = if (params.lite) None else Some(Output(Bool()))
 
-  // Flow control from arbiter to master
+  // Flow control from arbiter to manager
   val hgrant  = if (params.lite) None else Some(Input(Bool()))
   val hready  = Input(Bool())
 
@@ -54,7 +54,7 @@ class AHBMasterBundle(val params: AHBBundleParameters) extends Bundle
   def busreq(): Bool = if (params.lite) WireInit(true.B) else hbusreq.get
   def grant():  Bool = if (params.lite) WireInit(true.B) else hgrant.get
 
-  // A-phase signals from master to arbiter
+  // A-phase signals from manager to arbiter
   val htrans  = Output(UInt(params.transBits.W))
   val hsize   = Output(UInt(params.sizeBits.W))
   val hburst  = Output(UInt(params.burstBits.W))
@@ -63,21 +63,21 @@ class AHBMasterBundle(val params: AHBBundleParameters) extends Bundle
   val haddr   = Output(UInt(params.addrBits.W))
   val hauser  = BundleMap(params.requestFields)
 
-  // D-phase signals from master to arbiter
+  // D-phase signals from manager to arbiter
   val hduser    = BundleMap(params.responseFields)
   val hwdata  = Output(UInt(params.dataBits.W))
 
-  // D-phase response from arbiter to master
+  // D-phase response from arbiter to manager
   val hresp   = Input(UInt(params.hrespBits.W))
   val hrdata  = Input(UInt(params.dataBits.W))
 }
 
-object AHBSlaveBundle
+object AHBSubordinateBundle
 {
-  def apply(params: AHBBundleParameters) = new AHBSlaveBundle(params)
+  def apply(params: AHBBundleParameters) = new AHBSubordinateBundle(params)
 }
 
-object AHBMasterBundle
+object AHBManagerBundle
 {
-  def apply(params: AHBBundleParameters) = new AHBMasterBundle(params)
+  def apply(params: AHBBundleParameters) = new AHBManagerBundle(params)
 }

--- a/src/main/scala/amba/ahb/Monitor.scala
+++ b/src/main/scala/amba/ahb/Monitor.scala
@@ -4,27 +4,27 @@ package freechips.rocketchip.amba.ahb
 
 import chisel3._
 
-case class AHBSlaveMonitorArgs(edge: AHBEdgeParameters)
+case class AHBSubordinateMonitorArgs(edge: AHBEdgeParameters)
 
-abstract class AHBSlaveMonitorBase(args: AHBSlaveMonitorArgs) extends Module
+abstract class AHBSubordinateMonitorBase(args: AHBSubordinateMonitorArgs) extends Module
 {
   val io = IO(new Bundle {
-    val in = Input(new AHBSlaveBundle(args.edge.bundle))
+    val in = Input(new AHBSubordinateBundle(args.edge.bundle))
   })
 
-  def legalize(bundle: AHBSlaveBundle, edge: AHBEdgeParameters, reset: Reset): Unit
+  def legalize(bundle: AHBSubordinateBundle, edge: AHBEdgeParameters, reset: Reset): Unit
   legalize(io.in, args.edge, reset)
 }
 
 
-case class AHBMasterMonitorArgs(edge: AHBEdgeParameters)
+case class AHBManagerMonitorArgs(edge: AHBEdgeParameters)
 
-abstract class AHBMasterMonitorBase(args: AHBMasterMonitorArgs) extends Module
+abstract class AHBManagerMonitorBase(args: AHBManagerMonitorArgs) extends Module
 {
   val io = IO(new Bundle {
-    val in = Input(new AHBMasterBundle(args.edge.bundle))
+    val in = Input(new AHBManagerBundle(args.edge.bundle))
   })
 
-  def legalize(bundle: AHBMasterBundle, edge: AHBEdgeParameters, reset: Reset): Unit
+  def legalize(bundle: AHBManagerBundle, edge: AHBEdgeParameters, reset: Reset): Unit
   legalize(io.in, args.edge, reset)
 }

--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -10,80 +10,80 @@ import org.chipsalliance.cde.config.{Parameters, Field}
 import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.nodes.{SimpleNodeImp, RenderedEdge, OutwardNode, InwardNode, SourceNode, SinkNode, IdentityNode, AdapterNode, MixedNexusNode, NexusNode}
 
-case object AHBSlaveMonitorBuilder extends Field[AHBSlaveMonitorArgs => AHBSlaveMonitorBase]
+case object AHBSubordinateMonitorBuilder extends Field[AHBSubordinateMonitorArgs => AHBSubordinateMonitorBase]
 
-// From Arbiter to Slave
-object AHBImpSlave extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
+// From Arbiter to Subordinate
+object AHBImpSubordinate extends SimpleNodeImp[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBSubordinateBundle]
 {
-  def edge(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
-  def bundle(e: AHBEdgeParameters) = AHBSlaveBundle(e.bundle)
-  def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
+  def edge(pd: AHBManagerPortParameters, pu: AHBSubordinatePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
+  def bundle(e: AHBEdgeParameters) = AHBSubordinateBundle(e.bundle)
+  def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.subordinate.beatBytes * 8).toString)
 
-  override def monitor(bundle: AHBSlaveBundle, edge: AHBEdgeParameters): Unit = {
-    edge.params.lift(AHBSlaveMonitorBuilder).foreach { builder =>
-      val monitor = Module(builder(AHBSlaveMonitorArgs(edge)))
+  override def monitor(bundle: AHBSubordinateBundle, edge: AHBEdgeParameters): Unit = {
+    edge.params.lift(AHBSubordinateMonitorBuilder).foreach { builder =>
+      val monitor = Module(builder(AHBSubordinateMonitorArgs(edge)))
       monitor.io.in := bundle
     }
   }
 
-  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBSlaveBundle]): AHBMasterPortParameters  =
-   pd.copy(masters = pd.masters.map  { c => c.copy (nodePath = node +: c.nodePath) })
-  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBSlaveBundle]): AHBSlavePortParameters =
-   pu.copy(slaves  = pu.slaves.map { m => m.copy (nodePath = node +: m.nodePath) })
+  override def mixO(pd: AHBManagerPortParameters, node: OutwardNode[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBSubordinateBundle]): AHBManagerPortParameters  =
+   pd.copy(managers = pd.managers.map  { c => c.copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: AHBSubordinatePortParameters, node: InwardNode[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBSubordinateBundle]): AHBSubordinatePortParameters =
+   pu.copy(subordinates  = pu.subordinates.map { m => m.copy (nodePath = node +: m.nodePath) })
 }
 
-case object AHBMasterMonitorBuilder extends Field[AHBMasterMonitorArgs => AHBMasterMonitorBase]
+case object AHBManagerMonitorBuilder extends Field[AHBManagerMonitorArgs => AHBManagerMonitorBase]
 
-// From Master to Arbiter
-object AHBImpMaster extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+// From Manager to Arbiter
+object AHBImpManager extends SimpleNodeImp[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBManagerBundle]
 {
-  def edge(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
-  def bundle(e: AHBEdgeParameters) = AHBMasterBundle(e.bundle)
-  def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
+  def edge(pd: AHBManagerPortParameters, pu: AHBSubordinatePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
+  def bundle(e: AHBEdgeParameters) = AHBManagerBundle(e.bundle)
+  def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.subordinate.beatBytes * 8).toString)
 
-  override def monitor(bundle: AHBMasterBundle, edge: AHBEdgeParameters): Unit = {
-    edge.params.lift(AHBMasterMonitorBuilder).foreach { builder =>
-      val monitor = Module(builder(AHBMasterMonitorArgs(edge)))
+  override def monitor(bundle: AHBManagerBundle, edge: AHBEdgeParameters): Unit = {
+    edge.params.lift(AHBManagerMonitorBuilder).foreach { builder =>
+      val monitor = Module(builder(AHBManagerMonitorArgs(edge)))
       monitor.io.in := bundle
     }
   }
 
-  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBMasterBundle]): AHBMasterPortParameters  =
-   pd.copy(masters = pd.masters.map  { c => c.copy (nodePath = node +: c.nodePath) })
-  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBMasterBundle]): AHBSlavePortParameters =
-   pu.copy(slaves  = pu.slaves.map { m => m.copy (nodePath = node +: m.nodePath) })
+  override def mixO(pd: AHBManagerPortParameters, node: OutwardNode[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBManagerBundle]): AHBManagerPortParameters  =
+   pd.copy(managers = pd.managers.map  { c => c.copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: AHBSubordinatePortParameters, node: InwardNode[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBManagerBundle]): AHBSubordinatePortParameters =
+   pu.copy(subordinates  = pu.subordinates.map { m => m.copy (nodePath = node +: m.nodePath) })
 }
 
 // Nodes implemented inside modules
-case class AHBMasterSourceNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpMaster)(portParams)
-case class AHBSlaveSourceNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpSlave)(portParams)
-case class AHBMasterSinkNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpMaster)(portParams)
-case class AHBSlaveSinkNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpSlave)(portParams)
-case class AHBMasterIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpMaster)()
-case class AHBSlaveIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpSlave)()
+case class AHBManagerSourceNode(portParams: Seq[AHBManagerPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpManager)(portParams)
+case class AHBSubordinateSourceNode(portParams: Seq[AHBManagerPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpSubordinate)(portParams)
+case class AHBManagerSinkNode(portParams: Seq[AHBSubordinatePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpManager)(portParams)
+case class AHBSubordinateSinkNode(portParams: Seq[AHBSubordinatePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpSubordinate)(portParams)
+case class AHBManagerIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpManager)()
+case class AHBSubordinateIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpSubordinate)()
 
-case class AHBMasterAdapterNode(
-  masterFn:       AHBMasterPortParameters => AHBMasterPortParameters,
-  slaveFn:        AHBSlavePortParameters  => AHBSlavePortParameters)(
+case class AHBManagerAdapterNode(
+  managerFn:       AHBManagerPortParameters => AHBManagerPortParameters,
+  subordinateFn:        AHBSubordinatePortParameters  => AHBSubordinatePortParameters)(
   implicit valName: ValName)
-  extends AdapterNode(AHBImpMaster)(masterFn, slaveFn)
+  extends AdapterNode(AHBImpManager)(managerFn, subordinateFn)
 
-case class AHBSlaveAdapterNode(
-  masterFn:       AHBMasterPortParameters => AHBMasterPortParameters,
-  slaveFn:        AHBSlavePortParameters  => AHBSlavePortParameters)(
+case class AHBSubordinateAdapterNode(
+  managerFn:       AHBManagerPortParameters => AHBManagerPortParameters,
+  subordinateFn:        AHBSubordinatePortParameters  => AHBSubordinatePortParameters)(
   implicit valName: ValName)
-  extends AdapterNode(AHBImpMaster)(masterFn, slaveFn)
+  extends AdapterNode(AHBImpManager)(managerFn, subordinateFn)
 
-// From Master to Arbiter to Slave
+// From Manager to Arbiter to Subordinate
 case class AHBArbiterNode(
-  masterFn:       Seq[AHBMasterPortParameters] => AHBMasterPortParameters,
-  slaveFn:        Seq[AHBSlavePortParameters]  => AHBSlavePortParameters)(
+  managerFn:       Seq[AHBManagerPortParameters] => AHBManagerPortParameters,
+  subordinateFn:        Seq[AHBSubordinatePortParameters]  => AHBSubordinatePortParameters)(
   implicit valName: ValName)
-  extends MixedNexusNode(AHBImpMaster, AHBImpSlave)(masterFn, slaveFn)
+  extends MixedNexusNode(AHBImpManager, AHBImpSubordinate)(managerFn, subordinateFn)
 
-// Combine multiple Slaves into one logical Slave (suitable to attach to an Arbiter)
+// Combine multiple Subordinates into one logical Subordinate (suitable to attach to an Arbiter)
 case class AHBFanoutNode(
-  masterFn:       Seq[AHBMasterPortParameters] => AHBMasterPortParameters,
-  slaveFn:        Seq[AHBSlavePortParameters]  => AHBSlavePortParameters)(
+  managerFn:       Seq[AHBManagerPortParameters] => AHBManagerPortParameters,
+  subordinateFn:        Seq[AHBSubordinatePortParameters]  => AHBSubordinatePortParameters)(
   implicit valName: ValName)
-  extends NexusNode(AHBImpSlave)(masterFn, slaveFn)
+  extends NexusNode(AHBImpSubordinate)(managerFn, subordinateFn)

--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -18,8 +18,8 @@ import freechips.rocketchip.util.MaskGen
 import scala.math.min
 
 case class AHBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
-  extends SinkNode(AHBImpSlave)(Seq(AHBSlavePortParameters(
-    Seq(AHBSlaveParameters(
+  extends SinkNode(AHBImpSubordinate)(Seq(AHBSubordinatePortParameters(
+    Seq(AHBSubordinateParameters(
       address       = Seq(address),
       executable    = executable,
       supportsWrite = TransferSizes(1, min(address.alignment.toInt, beatBytes * AHBParameters.maxTransfer)),

--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -22,8 +22,8 @@ class AHBRAM(
     errors: Seq[AddressSet] = Nil)
   (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
-  val node = AHBSlaveSinkNode(Seq(AHBSlavePortParameters(
-    Seq(AHBSlaveParameters(
+  val node = AHBSubordinateSinkNode(Seq(AHBSubordinatePortParameters(
+    Seq(AHBSubordinateParameters(
       address       = List(address) ++ errors,
       resources     = resources,
       regionType    = if (cacheable) RegionType.UNCACHED else RegionType.IDEMPOTENT,

--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -13,19 +13,19 @@ import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 import freechips.rocketchip.amba.{AMBAProtField, AMBAProt}
 import freechips.rocketchip.diplomacy.TransferSizes
-import freechips.rocketchip.tilelink.{TLImp, TLManagerPortParameters, TLMessages, TLManagerParameters, TLManagerToSubordinateTransferSizes}
+import freechips.rocketchip.tilelink.{TLImp, TLClientPortParameters, TLMessages, TLClientParameters, TLClientToManagerTransferSizes}
 import freechips.rocketchip.util.{BundleMap, MaskGen, DataToAugmentedData}
 
 case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImpSubordinate, TLImp)(
   dFn = { case mp =>
-    TLManagerPortParameters.v2(
-      managers = mp.managers.map { m =>
+    TLClientPortParameters.v2(
+      clients = mp.managers.map { m =>
         // This value should be constrained by a data width parameter that flows from managers to subordinates
         // AHB fixed length transfer size maximum is 16384 = 1024 * 16 bits, hsize is capped at 111 = 1024 bit transfer size and hburst is capped at 111 = 16 beat burst
-          TLManagerParameters.v2(
+          TLClientParameters.v2(
             name     = m.name,
             nodePath = m.nodePath,
-            emits    = TLManagerToSubordinateTransferSizes(
+            emits    = TLClientToManagerTransferSizes(
                        get     = TransferSizes(1, 2048),
                        putFull = TransferSizes(1, 2048)
                        )

--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -13,19 +13,19 @@ import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 import freechips.rocketchip.amba.{AMBAProtField, AMBAProt}
 import freechips.rocketchip.diplomacy.TransferSizes
-import freechips.rocketchip.tilelink.{TLImp, TLMasterPortParameters, TLMessages, TLMasterParameters, TLMasterToSlaveTransferSizes}
+import freechips.rocketchip.tilelink.{TLImp, TLManagerPortParameters, TLMessages, TLManagerParameters, TLManagerToSubordinateTransferSizes}
 import freechips.rocketchip.util.{BundleMap, MaskGen, DataToAugmentedData}
 
-case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImpSlave, TLImp)(
+case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImpSubordinate, TLImp)(
   dFn = { case mp =>
-    TLMasterPortParameters.v2(
-      masters = mp.masters.map { m =>
-        // This value should be constrained by a data width parameter that flows from masters to slaves
+    TLManagerPortParameters.v2(
+      managers = mp.managers.map { m =>
+        // This value should be constrained by a data width parameter that flows from managers to subordinates
         // AHB fixed length transfer size maximum is 16384 = 1024 * 16 bits, hsize is capped at 111 = 1024 bit transfer size and hburst is capped at 111 = 16 beat burst
-          TLMasterParameters.v2(
+          TLManagerParameters.v2(
             name     = m.name,
             nodePath = m.nodePath,
-            emits    = TLMasterToSlaveTransferSizes(
+            emits    = TLManagerToSubordinateTransferSizes(
                        get     = TransferSizes(1, 2048),
                        putFull = TransferSizes(1, 2048)
                        )
@@ -34,8 +34,8 @@ case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHB
       requestFields = AMBAProtField() +: mp.requestFields,
       responseKeys  = mp.responseKeys)
   },
-  uFn = { mp => AHBSlavePortParameters(
-    slaves = mp.managers.map { m =>
+  uFn = { mp => AHBSubordinatePortParameters(
+    subordinates = mp.managers.map { m =>
       def adjust(x: TransferSizes) = {
         if (x.contains(mp.beatBytes)) {
           TransferSizes(x.min, m.minAlignment.min(mp.beatBytes * AHBParameters.maxTransfer).toInt)
@@ -44,7 +44,7 @@ case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHB
         }
       }
 
-      AHBSlaveParameters(
+      AHBSubordinateParameters(
         address       = m.address,
         resources     = m.resources,
         regionType    = m.regionType,
@@ -148,7 +148,7 @@ class AHBToTL()(implicit p: Parameters) extends LazyModule
       // We must accept the D-channel beat on the first cycle, as otherwise
       // the failure might be legally retracted on the second cycle.
       // Although the AHB spec says:
-      //   "A slave only has to provide valid data when a transfer completes with
+      //   "A subordinate only has to provide valid data when a transfer completes with
       //    an OKAY response. ERROR responses do not require valid read data."
       // We choose, nevertheless, to provide the read data for the failed request.
       // Unfortunately, this comes at the cost of a bus-wide register.

--- a/src/main/scala/amba/ahb/package.scala
+++ b/src/main/scala/amba/ahb/package.scala
@@ -6,10 +6,10 @@ import org.chipsalliance.diplomacy.nodes.{InwardNodeHandle, OutwardNodeHandle, S
 
 package object ahb
 {
-  type AHBSlaveOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
-  type AHBSlaveInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
-  type AHBSlaveNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
-  type AHBMasterOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
-  type AHBMasterInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
-  type AHBMasterNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+  type AHBSubordinateOutwardNode = OutwardNodeHandle[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBSubordinateBundle]
+  type AHBSubordinateInwardNode = InwardNodeHandle[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBSubordinateBundle]
+  type AHBSubordinateNode = SimpleNodeHandle[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBSubordinateBundle]
+  type AHBManagerOutwardNode = OutwardNodeHandle[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBManagerBundle]
+  type AHBManagerInwardNode = InwardNodeHandle[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBManagerBundle]
+  type AHBManagerNode = SimpleNodeHandle[AHBManagerPortParameters, AHBSubordinatePortParameters, AHBEdgeParameters, AHBManagerBundle]
 }

--- a/src/main/scala/amba/apb/Bundles.scala
+++ b/src/main/scala/amba/apb/Bundles.scala
@@ -5,10 +5,10 @@ package freechips.rocketchip.amba.apb
 import chisel3._
 import freechips.rocketchip.util._
 
-// Signal directions are from the master's point-of-view
+// Signal directions are from the manager's point-of-view
 class APBBundle(val params: APBBundleParameters) extends Bundle
 {
-  // Flow control signals from the master
+  // Flow control signals from the manager
   val psel      = Output(Bool())
   val penable   = Output(Bool())
 

--- a/src/main/scala/amba/apb/RegisterRouter.scala
+++ b/src/main/scala/amba/apb/RegisterRouter.scala
@@ -15,8 +15,8 @@ import freechips.rocketchip.regmapper.{RegField, RegMapperParams, RegMapperInput
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 
 case class APBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
-  extends SinkNode(APBImp)(Seq(APBSlavePortParameters(
-    Seq(APBSlaveParameters(
+  extends SinkNode(APBImp)(Seq(APBSubordinatePortParameters(
+    Seq(APBSubordinateParameters(
       address       = Seq(address),
       executable    = executable,
       supportsWrite = true,

--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -25,8 +25,8 @@ class APBRAM(
     fuzzError: Boolean = false)
   (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
-  val node = APBSlaveNode(Seq(APBSlavePortParameters(
-    Seq(APBSlaveParameters(
+  val node = APBSubordinateNode(Seq(APBSubordinatePortParameters(
+    Seq(APBSubordinateParameters(
       address       = List(address) ++ errors,
       resources     = resources,
       regionType    = if (cacheable) RegionType.UNCACHED else RegionType.IDEMPOTENT,

--- a/src/main/scala/amba/apb/Test.scala
+++ b/src/main/scala/amba/apb/Test.scala
@@ -24,7 +24,7 @@ class APBRRTest1(address: BigInt)(implicit p: Parameters)
 class APBFuzzBridge(aFlow: Boolean, txns: Int)(implicit p: Parameters) extends LazyModule
 {
   val fuzz  = LazyModule(new TLFuzzer(txns))
-  val model = LazyModule(new TLRAMModel("APBFuzzMaster"))
+  val model = LazyModule(new TLRAMModel("APBFuzzManager"))
   val xbar  = LazyModule(new APBFanout)
   val ram   = LazyModule(new APBRAM(AddressSet(0x0, 0xff), fuzzReady = true, fuzzError = true))
   val gpio  = LazyModule(new APBRRTest0(0x100))

--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -13,20 +13,20 @@ import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
 import freechips.rocketchip.diplomacy.TransferSizes
-import freechips.rocketchip.tilelink.{TLImp, TLMessages, TLMasterPortParameters, TLMasterParameters}
+import freechips.rocketchip.tilelink.{TLImp, TLMessages, TLManagerPortParameters, TLManagerParameters}
 
 case class APBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(APBImp, TLImp)(
   dFn = { mp =>
-    TLMasterPortParameters.v1(
-      clients = mp.masters.map { m =>
-        TLMasterParameters.v1(name = m.name, nodePath = m.nodePath)
+    TLManagerPortParameters.v1(
+      clients = mp.managers.map { m =>
+        TLManagerParameters.v1(name = m.name, nodePath = m.nodePath)
       },
       requestFields = AMBAProtField() +: mp.requestFields,
       responseKeys  = mp.responseKeys)
   },
-  uFn = { mp => APBSlavePortParameters(
-    slaves = mp.managers.map { m =>
-      APBSlaveParameters(
+  uFn = { mp => APBSubordinatePortParameters(
+    subordinates = mp.managers.map { m =>
+      APBSubordinateParameters(
         address       = m.address,
         resources     = m.resources,
         regionType    = m.regionType,

--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -13,13 +13,13 @@ import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
 import freechips.rocketchip.diplomacy.TransferSizes
-import freechips.rocketchip.tilelink.{TLImp, TLMessages, TLManagerPortParameters, TLManagerParameters}
+import freechips.rocketchip.tilelink.{TLImp, TLMessages, TLClientPortParameters, TLClientParameters}
 
 case class APBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(APBImp, TLImp)(
   dFn = { mp =>
-    TLManagerPortParameters.v1(
+    TLClientPortParameters.v1(
       clients = mp.managers.map { m =>
-        TLManagerParameters.v1(name = m.name, nodePath = m.nodePath)
+        TLClientParameters.v1(name = m.name, nodePath = m.nodePath)
       },
       requestFields = AMBAProtField() +: mp.requestFields,
       responseKeys  = mp.responseKeys)

--- a/src/main/scala/amba/apb/package.scala
+++ b/src/main/scala/amba/apb/package.scala
@@ -6,7 +6,7 @@ import org.chipsalliance.diplomacy.nodes.{InwardNodeHandle, OutwardNodeHandle, S
 
 package object apb
 {
-  type APBOutwardNode = OutwardNodeHandle[APBMasterPortParameters, APBSlavePortParameters, APBEdgeParameters, APBBundle]
-  type APBInwardNode = InwardNodeHandle[APBMasterPortParameters, APBSlavePortParameters, APBEdgeParameters, APBBundle]
-  type APBNode = SimpleNodeHandle[APBMasterPortParameters, APBSlavePortParameters, APBEdgeParameters, APBBundle]
+  type APBOutwardNode = OutwardNodeHandle[APBManagerPortParameters, APBSubordinatePortParameters, APBEdgeParameters, APBBundle]
+  type APBInwardNode = InwardNodeHandle[APBManagerPortParameters, APBSubordinatePortParameters, APBEdgeParameters, APBBundle]
+  type APBNode = SimpleNodeHandle[APBManagerPortParameters, APBSubordinatePortParameters, APBEdgeParameters, APBBundle]
 }

--- a/src/main/scala/amba/axi4/AsyncCrossing.scala
+++ b/src/main/scala/amba/axi4/AsyncCrossing.scala
@@ -16,7 +16,7 @@ import freechips.rocketchip.subsystem.CrossingWrapper
 import freechips.rocketchip.util.{ToAsyncBundle, FromAsyncBundle, AsyncQueueParams, Pow2ClockDivider}
 
 /**
-  * Source(Master) side for AXI4 crossing clock domain
+  * Source(Manager) side for AXI4 crossing clock domain
   *
   * @param sync synchronization stages
   */
@@ -30,8 +30,8 @@ class AXI4AsyncCrossingSource(sync: Option[Int])(implicit p: Parameters) extends
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      val psync = sync.getOrElse(edgeOut.slave.async.sync)
-      val params = edgeOut.slave.async.copy(sync = psync)
+      val psync = sync.getOrElse(edgeOut.subordinate.async.sync)
+      val params = edgeOut.subordinate.async.copy(sync = psync)
       out.ar <> ToAsyncBundle(in.ar, params)
       out.aw <> ToAsyncBundle(in.aw, params)
       out. w <> ToAsyncBundle(in. w, params)
@@ -42,7 +42,7 @@ class AXI4AsyncCrossingSource(sync: Option[Int])(implicit p: Parameters) extends
 }
 
 /**
-  * Sink(Slave) side for AXI4 crossing clock domain
+  * Sink(Subordinate) side for AXI4 crossing clock domain
   *
   * @param params async queue params
   */

--- a/src/main/scala/amba/axi4/Buffer.scala
+++ b/src/main/scala/amba/axi4/Buffer.scala
@@ -30,8 +30,8 @@ class AXI4Buffer(
   def this()(implicit p: Parameters) = this(BufferParams.default)
 
   val node = AXI4AdapterNode(
-    masterFn = { p => p },
-    slaveFn  = { p => p.copy(minLatency = p.minLatency + min(aw.latency,ar.latency) + min(r.latency,b.latency)) })
+    managerFn = { p => p },
+    subordinateFn  = { p => p.copy(minLatency = p.minLatency + min(aw.latency,ar.latency) + min(r.latency,b.latency)) })
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {

--- a/src/main/scala/amba/axi4/Credited.scala
+++ b/src/main/scala/amba/axi4/Credited.scala
@@ -17,8 +17,8 @@ import freechips.rocketchip.util._
 class AXI4CreditedBuffer(delay: AXI4CreditedDelay)(implicit p: Parameters) extends LazyModule
 {
   val node = AXI4CreditedAdapterNode(
-    masterFn = p => p.copy(delay = delay + p.delay),
-    slaveFn  = p => p.copy(delay = delay + p.delay))
+    managerFn = p => p.copy(delay = delay + p.delay),
+    subordinateFn  = p => p.copy(delay = delay + p.delay))
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {

--- a/src/main/scala/amba/axi4/IdIndexer.scala
+++ b/src/main/scala/amba/axi4/IdIndexer.scala
@@ -28,23 +28,23 @@ class AXI4IdIndexer(idBits: Int)(implicit p: Parameters) extends LazyModule
   require (idBits >= 0, s"AXI4IdIndexer: idBits must be > 0, not $idBits")
 
   val node = AXI4AdapterNode(
-    masterFn = { mp =>
-      // Create one new "master" per ID
-      val masters = Array.tabulate(1 << idBits) { i => AXI4MasterParameters(
+    managerFn = { mp =>
+      // Create one new "manager" per ID
+      val managers = Array.tabulate(1 << idBits) { i => AXI4ManagerParameters(
          name      = "",
          id        = IdRange(i, i+1),
          aligned   = true,
          maxFlight = Some(0))
       }
-      // Accumulate the names of masters we squish
+      // Accumulate the names of managers we squish
       val names = Array.fill(1 << idBits) { new scala.collection.mutable.HashSet[String]() }
-      // Squash the information from original masters into new ID masters
-      mp.masters.foreach { m =>
+      // Squash the information from original managers into new ID managers
+      mp.managers.foreach { m =>
         for (i <- m.id.start until m.id.end) {
           val j = i % (1 << idBits)
-          val accumulated = masters(j)
+          val accumulated = managers(j)
           names(j) += m.name
-          masters(j) = accumulated.copy(
+          managers(j) = accumulated.copy(
             aligned   = accumulated.aligned && m.aligned,
             maxFlight = accumulated.maxFlight.flatMap { o => m.maxFlight.map { n => o+n } })
         }
@@ -54,9 +54,9 @@ class AXI4IdIndexer(idBits: Int)(implicit p: Parameters) extends LazyModule
       val field = if (bits > 0) Seq(AXI4ExtraIdField(bits)) else Nil
       mp.copy(
         echoFields = field ++ mp.echoFields,
-        masters    = masters.zip(finalNameStrings).map { case (m, n) => m.copy(name = n) })
+        managers    = managers.zip(finalNameStrings).map { case (m, n) => m.copy(name = n) })
     },
-    slaveFn = { sp => sp
+    subordinateFn = { sp => sp
     })
 
   lazy val module = new Impl
@@ -81,7 +81,7 @@ class AXI4IdIndexer(idBits: Int)(implicit p: Parameters) extends LazyModule
         case (lhs, rhs) => lhs.squeezeAll :<>= rhs.squeezeAll
       }
 
-      val bits = log2Ceil(edgeIn.master.endId) - idBits
+      val bits = log2Ceil(edgeIn.manager.endId) - idBits
       if (bits > 0) {
         // (in.aX.bits.id >> idBits).width = bits > 0
         out.ar.bits.echo(AXI4ExtraId) := in.ar.bits.id >> idBits

--- a/src/main/scala/amba/axi4/Nodes.scala
+++ b/src/main/scala/amba/axi4/Nodes.scala
@@ -14,11 +14,11 @@ import freechips.rocketchip.util.AsyncQueueParams
 
 case object AXI4MonitorBuilder extends Field[AXI4MonitorArgs => AXI4MonitorBase]
 
-object AXI4Imp extends SimpleNodeImp[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
+object AXI4Imp extends SimpleNodeImp[AXI4ManagerPortParameters, AXI4SubordinatePortParameters, AXI4EdgeParameters, AXI4Bundle]
 {
-  def edge(pd: AXI4MasterPortParameters, pu: AXI4SlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4EdgeParameters(pd, pu, p, sourceInfo)
+  def edge(pd: AXI4ManagerPortParameters, pu: AXI4SubordinatePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4EdgeParameters(pd, pu, p, sourceInfo)
   def bundle(e: AXI4EdgeParameters) = AXI4Bundle(e.bundle)
-  def render(e: AXI4EdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label  = (e.slave.beatBytes * 8).toString)
+  def render(e: AXI4EdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label  = (e.subordinate.beatBytes * 8).toString)
 
   override def monitor(bundle: AXI4Bundle, edge: AXI4EdgeParameters): Unit = {
     edge.params.lift(AXI4MonitorBuilder).foreach { builder =>
@@ -27,24 +27,24 @@ object AXI4Imp extends SimpleNodeImp[AXI4MasterPortParameters, AXI4SlavePortPara
     }
   }
 
-  override def mixO(pd: AXI4MasterPortParameters, node: OutwardNode[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4Bundle]): AXI4MasterPortParameters  =
-   pd.copy(masters = pd.masters.map  { c => c.copy (nodePath = node +: c.nodePath) })
-  override def mixI(pu: AXI4SlavePortParameters, node: InwardNode[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4Bundle]): AXI4SlavePortParameters =
-   pu.copy(slaves  = pu.slaves.map { m => m.copy (nodePath = node +: m.nodePath) })
+  override def mixO(pd: AXI4ManagerPortParameters, node: OutwardNode[AXI4ManagerPortParameters, AXI4SubordinatePortParameters, AXI4Bundle]): AXI4ManagerPortParameters  =
+   pd.copy(managers = pd.managers.map  { c => c.copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: AXI4SubordinatePortParameters, node: InwardNode[AXI4ManagerPortParameters, AXI4SubordinatePortParameters, AXI4Bundle]): AXI4SubordinatePortParameters =
+   pu.copy(subordinates  = pu.subordinates.map { m => m.copy (nodePath = node +: m.nodePath) })
 }
 
-case class AXI4MasterNode(portParams: Seq[AXI4MasterPortParameters])(implicit valName: ValName) extends SourceNode(AXI4Imp)(portParams)
-case class AXI4SlaveNode(portParams: Seq[AXI4SlavePortParameters])(implicit valName: ValName) extends SinkNode(AXI4Imp)(portParams)
+case class AXI4ManagerNode(portParams: Seq[AXI4ManagerPortParameters])(implicit valName: ValName) extends SourceNode(AXI4Imp)(portParams)
+case class AXI4SubordinateNode(portParams: Seq[AXI4SubordinatePortParameters])(implicit valName: ValName) extends SinkNode(AXI4Imp)(portParams)
 case class AXI4NexusNode(
-  masterFn:       Seq[AXI4MasterPortParameters] => AXI4MasterPortParameters,
-  slaveFn:        Seq[AXI4SlavePortParameters]  => AXI4SlavePortParameters)(
+  managerFn:       Seq[AXI4ManagerPortParameters] => AXI4ManagerPortParameters,
+  subordinateFn:        Seq[AXI4SubordinatePortParameters]  => AXI4SubordinatePortParameters)(
   implicit valName: ValName)
-  extends NexusNode(AXI4Imp)(masterFn, slaveFn)
+  extends NexusNode(AXI4Imp)(managerFn, subordinateFn)
 case class AXI4AdapterNode(
-  masterFn:  AXI4MasterPortParameters => AXI4MasterPortParameters = { m => m },
-  slaveFn:   AXI4SlavePortParameters  => AXI4SlavePortParameters  = { s => s })(
+  managerFn:  AXI4ManagerPortParameters => AXI4ManagerPortParameters = { m => m },
+  subordinateFn:   AXI4SubordinatePortParameters  => AXI4SubordinatePortParameters  = { s => s })(
   implicit valName: ValName)
-  extends AdapterNode(AXI4Imp)(masterFn, slaveFn)
+  extends AdapterNode(AXI4Imp)(managerFn, subordinateFn)
 case class AXI4IdentityNode()(implicit valName: ValName) extends IdentityNode(AXI4Imp)()
 
 object AXI4NameNode {
@@ -53,27 +53,27 @@ object AXI4NameNode {
   def apply(name: String): AXI4IdentityNode = apply(Some(name))
 }
 
-object AXI4AsyncImp extends SimpleNodeImp[AXI4AsyncMasterPortParameters, AXI4AsyncSlavePortParameters, AXI4AsyncEdgeParameters, AXI4AsyncBundle]
+object AXI4AsyncImp extends SimpleNodeImp[AXI4AsyncManagerPortParameters, AXI4AsyncSubordinatePortParameters, AXI4AsyncEdgeParameters, AXI4AsyncBundle]
 {
-  def edge(pd: AXI4AsyncMasterPortParameters, pu: AXI4AsyncSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4AsyncEdgeParameters(pd, pu, p, sourceInfo)
+  def edge(pd: AXI4AsyncManagerPortParameters, pu: AXI4AsyncSubordinatePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4AsyncEdgeParameters(pd, pu, p, sourceInfo)
   def bundle(e: AXI4AsyncEdgeParameters) = new AXI4AsyncBundle(e.bundle)
-  def render(e: AXI4AsyncEdgeParameters) = RenderedEdge(colour = "#ff0000" /* red */, label = e.slave.async.depth.toString)
+  def render(e: AXI4AsyncEdgeParameters) = RenderedEdge(colour = "#ff0000" /* red */, label = e.subordinate.async.depth.toString)
 
-  override def mixO(pd: AXI4AsyncMasterPortParameters, node: OutwardNode[AXI4AsyncMasterPortParameters, AXI4AsyncSlavePortParameters, AXI4AsyncBundle]): AXI4AsyncMasterPortParameters  =
-   pd.copy(base = pd.base.copy(masters = pd.base.masters.map  { c => c.copy (nodePath = node +: c.nodePath) }))
-  override def mixI(pu: AXI4AsyncSlavePortParameters, node: InwardNode[AXI4AsyncMasterPortParameters, AXI4AsyncSlavePortParameters, AXI4AsyncBundle]): AXI4AsyncSlavePortParameters =
-   pu.copy(base = pu.base.copy(slaves  = pu.base.slaves.map { m => m.copy (nodePath = node +: m.nodePath) }))
+  override def mixO(pd: AXI4AsyncManagerPortParameters, node: OutwardNode[AXI4AsyncManagerPortParameters, AXI4AsyncSubordinatePortParameters, AXI4AsyncBundle]): AXI4AsyncManagerPortParameters  =
+   pd.copy(base = pd.base.copy(managers = pd.base.managers.map  { c => c.copy (nodePath = node +: c.nodePath) }))
+  override def mixI(pu: AXI4AsyncSubordinatePortParameters, node: InwardNode[AXI4AsyncManagerPortParameters, AXI4AsyncSubordinatePortParameters, AXI4AsyncBundle]): AXI4AsyncSubordinatePortParameters =
+   pu.copy(base = pu.base.copy(subordinates  = pu.base.subordinates.map { m => m.copy (nodePath = node +: m.nodePath) }))
 }
 
 case class AXI4AsyncSourceNode(sync: Option[Int])(implicit valName: ValName)
   extends MixedAdapterNode(AXI4Imp, AXI4AsyncImp)(
-    dFn = { p => AXI4AsyncMasterPortParameters(p) },
+    dFn = { p => AXI4AsyncManagerPortParameters(p) },
     uFn = { p => p.base.copy(minLatency = p.base.minLatency + sync.getOrElse(p.async.sync)) })
 
 case class AXI4AsyncSinkNode(async: AsyncQueueParams)(implicit valName: ValName)
   extends MixedAdapterNode(AXI4AsyncImp, AXI4Imp)(
     dFn = { p => p.base },
-    uFn = { p => AXI4AsyncSlavePortParameters(async, p) })
+    uFn = { p => AXI4AsyncSubordinatePortParameters(async, p) })
 
 case class AXI4AsyncIdentityNode()(implicit valName: ValName) extends IdentityNode(AXI4AsyncImp)()
 
@@ -83,33 +83,33 @@ object AXI4AsyncNameNode {
   def apply(name: String): AXI4AsyncIdentityNode = apply(Some(name))
 }
 
-object AXI4CreditedImp extends SimpleNodeImp[AXI4CreditedMasterPortParameters, AXI4CreditedSlavePortParameters, AXI4CreditedEdgeParameters, AXI4CreditedBundle]
+object AXI4CreditedImp extends SimpleNodeImp[AXI4CreditedManagerPortParameters, AXI4CreditedSubordinatePortParameters, AXI4CreditedEdgeParameters, AXI4CreditedBundle]
 {
-  def edge(pd: AXI4CreditedMasterPortParameters, pu: AXI4CreditedSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4CreditedEdgeParameters(pd, pu, p, sourceInfo)
+  def edge(pd: AXI4CreditedManagerPortParameters, pu: AXI4CreditedSubordinatePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4CreditedEdgeParameters(pd, pu, p, sourceInfo)
   def bundle(e: AXI4CreditedEdgeParameters) = new AXI4CreditedBundle(e.bundle)
   def render(e: AXI4CreditedEdgeParameters) = RenderedEdge(colour = "#ffff00" /* yellow */, label = e.delay.toString)
 
-  override def mixO(pd: AXI4CreditedMasterPortParameters, node: OutwardNode[AXI4CreditedMasterPortParameters, AXI4CreditedSlavePortParameters, AXI4CreditedBundle]): AXI4CreditedMasterPortParameters  =
-   pd.copy(base = pd.base.copy(masters = pd.base.masters.map  { c => c.copy (nodePath = node +: c.nodePath) }))
-  override def mixI(pu: AXI4CreditedSlavePortParameters, node: InwardNode[AXI4CreditedMasterPortParameters, AXI4CreditedSlavePortParameters, AXI4CreditedBundle]): AXI4CreditedSlavePortParameters =
-   pu.copy(base = pu.base.copy(slaves  = pu.base.slaves.map { m => m.copy (nodePath = node +: m.nodePath) }))
+  override def mixO(pd: AXI4CreditedManagerPortParameters, node: OutwardNode[AXI4CreditedManagerPortParameters, AXI4CreditedSubordinatePortParameters, AXI4CreditedBundle]): AXI4CreditedManagerPortParameters  =
+   pd.copy(base = pd.base.copy(managers = pd.base.managers.map  { c => c.copy (nodePath = node +: c.nodePath) }))
+  override def mixI(pu: AXI4CreditedSubordinatePortParameters, node: InwardNode[AXI4CreditedManagerPortParameters, AXI4CreditedSubordinatePortParameters, AXI4CreditedBundle]): AXI4CreditedSubordinatePortParameters =
+   pu.copy(base = pu.base.copy(subordinates  = pu.base.subordinates.map { m => m.copy (nodePath = node +: m.nodePath) }))
 }
 
 case class AXI4CreditedSourceNode(delay: AXI4CreditedDelay)(implicit valName: ValName)
   extends MixedAdapterNode(AXI4Imp, AXI4CreditedImp)(
-    dFn = { p => AXI4CreditedMasterPortParameters(delay, p) },
+    dFn = { p => AXI4CreditedManagerPortParameters(delay, p) },
     uFn = { p => p.base.copy(minLatency = 1) })
 
 case class AXI4CreditedSinkNode(delay: AXI4CreditedDelay)(implicit valName: ValName)
   extends MixedAdapterNode(AXI4CreditedImp, AXI4Imp)(
     dFn = { p => p.base },
-    uFn = { p => AXI4CreditedSlavePortParameters(delay, p) })
+    uFn = { p => AXI4CreditedSubordinatePortParameters(delay, p) })
 
 case class AXI4CreditedAdapterNode(
-  masterFn: AXI4CreditedMasterPortParameters => AXI4CreditedMasterPortParameters = { s => s },
-  slaveFn:  AXI4CreditedSlavePortParameters  => AXI4CreditedSlavePortParameters  = { s => s })(
+  managerFn: AXI4CreditedManagerPortParameters => AXI4CreditedManagerPortParameters = { s => s },
+  subordinateFn:  AXI4CreditedSubordinatePortParameters  => AXI4CreditedSubordinatePortParameters  = { s => s })(
   implicit valName: ValName)
-  extends AdapterNode(AXI4CreditedImp)(masterFn, slaveFn)
+  extends AdapterNode(AXI4CreditedImp)(managerFn, subordinateFn)
 
 case class AXI4CreditedIdentityNode()(implicit valName: ValName) extends IdentityNode(AXI4CreditedImp)()
 

--- a/src/main/scala/amba/axi4/RegisterRouter.scala
+++ b/src/main/scala/amba/axi4/RegisterRouter.scala
@@ -20,8 +20,8 @@ case object AXI4RRId extends ControlKey[UInt]("extra_id")
 case class AXI4RRIdField(width: Int) extends SimpleBundleField(AXI4RRId)(Output(UInt((1 max width).W)), 0.U)
 
 case class AXI4RegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
-  extends SinkNode(AXI4Imp)(Seq(AXI4SlavePortParameters(
-    Seq(AXI4SlaveParameters(
+  extends SinkNode(AXI4Imp)(Seq(AXI4SubordinatePortParameters(
+    Seq(AXI4SubordinateParameters(
       address       = Seq(address),
       executable    = executable,
       supportsWrite = TransferSizes(1, beatBytes),

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -15,10 +15,10 @@ import freechips.rocketchip.resources.{DiplomaticSRAM, HasJustOneSeqMem}
 import freechips.rocketchip.util.{BundleMap, SeqMemToAugmentedSeqMem}
 
 /**
-  * AXI4 slave device to provide a RAM storage
+  * AXI4 subordinate device to provide a RAM storage
   *
   * Setting wcorrupt=true is not enough to enable the w.user field
-  * You must also list AMBACorrupt in your master's requestFields
+  * You must also list AMBACorrupt in your manager's requestFields
   *
   * @param address address range
   * @param cacheable whether this ram is cacheable
@@ -39,8 +39,8 @@ class AXI4RAM(
     wcorrupt: Boolean = true)
   (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
-  val node = AXI4SlaveNode(Seq(AXI4SlavePortParameters(
-    Seq(AXI4SlaveParameters(
+  val node = AXI4SubordinateNode(Seq(AXI4SubordinatePortParameters(
+    Seq(AXI4SubordinateParameters(
       address       = List(address) ++ errors,
       resources     = resources,
       regionType    = if (cacheable) RegionType.UNCACHED else RegionType.IDEMPOTENT,

--- a/src/main/scala/amba/axi4/Test.scala
+++ b/src/main/scala/amba/axi4/Test.scala
@@ -100,11 +100,11 @@ trait HasFuzzTarget {
                     AddressSet(0x900, ~0x900)) // ie: 0x900-0x9ff, 0xb00-0xbff, ... 0xf00-0xfff
 }
 
-class AXI4FuzzMaster(txns: Int)(implicit p: Parameters) extends LazyModule with HasFuzzTarget
+class AXI4FuzzManager(txns: Int)(implicit p: Parameters) extends LazyModule with HasFuzzTarget
 {
   val node  = AXI4IdentityNode()
   val fuzz  = LazyModule(new TLFuzzer(txns, overrideAddress = Some(fuzzAddr)))
-  val model = LazyModule(new TLRAMModel("AXI4FuzzMaster"))
+  val model = LazyModule(new TLRAMModel("AXI4FuzzManager"))
 
   (node
     := AXI4UserYanker()
@@ -127,7 +127,7 @@ class AXI4FuzzMaster(txns: Int)(implicit p: Parameters) extends LazyModule with 
   }
 }
 
-class AXI4FuzzSlave()(implicit p: Parameters) extends SimpleLazyModule with HasFuzzTarget
+class AXI4FuzzSubordinate()(implicit p: Parameters) extends SimpleLazyModule with HasFuzzTarget
 {
   val node = AXI4IdentityNode()
   val xbar = LazyModule(new TLXbar)
@@ -151,14 +151,14 @@ class AXI4FuzzSlave()(implicit p: Parameters) extends SimpleLazyModule with HasF
 
 class AXI4FuzzBridge(txns: Int)(implicit p: Parameters) extends LazyModule
 {
-  val master = LazyModule(new AXI4FuzzMaster(txns))
-  val slave  = LazyModule(new AXI4FuzzSlave)
+  val manager = LazyModule(new AXI4FuzzManager(txns))
+  val subordinate  = LazyModule(new AXI4FuzzSubordinate)
 
-  slave.node := master.node
+  subordinate.node := manager.node
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) with UnitTestModule {
-    io.finished := master.module.io.finished
+    io.finished := manager.module.io.finished
   }
 }
 

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -13,7 +13,7 @@ import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 import freechips.rocketchip.amba.{AMBACorrupt, AMBAProt, AMBAProtField}
 import freechips.rocketchip.diplomacy.{IdRange, IdMapEntry, TransferSizes}
-import freechips.rocketchip.tilelink.{TLImp, TLManagerParameters, TLManagerPortParameters, TLArbiter}
+import freechips.rocketchip.tilelink.{TLImp, TLClientParameters, TLClientPortParameters, TLArbiter}
 import freechips.rocketchip.util.{OH1ToUInt, UIntToOH1}
 
 case class AXI4ToTLIdMapEntry(tlId: IdRange, axi4Id: IdRange, name: String)
@@ -30,10 +30,10 @@ case class AXI4ToTLNode(wcorrupt: Boolean)(implicit valName: ValName) extends Mi
   dFn = { case mp =>
     mp.managers.foreach { m => require (m.maxFlight.isDefined, "AXI4 must include a transaction maximum per ID to convert to TL") }
     val maxFlight = mp.managers.map(_.maxFlight.get).max
-    TLManagerPortParameters.v1(
+    TLClientPortParameters.v1(
       clients = mp.managers.filter(_.maxFlight != Some(0)).flatMap { m =>
         for (id <- m.id.start until m.id.end)
-          yield TLManagerParameters.v1(
+          yield TLClientParameters.v1(
             name        = s"${m.name} ID#${id}",
             sourceId    = IdRange(id * maxFlight*2, (id+1) * maxFlight*2), // R+W ids are distinct
             nodePath    = m.nodePath,

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -13,7 +13,7 @@ import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 import freechips.rocketchip.amba.{AMBACorrupt, AMBAProt, AMBAProtField}
 import freechips.rocketchip.diplomacy.{IdRange, IdMapEntry, TransferSizes}
-import freechips.rocketchip.tilelink.{TLImp, TLMasterParameters, TLMasterPortParameters, TLArbiter}
+import freechips.rocketchip.tilelink.{TLImp, TLManagerParameters, TLManagerPortParameters, TLArbiter}
 import freechips.rocketchip.util.{OH1ToUInt, UIntToOH1}
 
 case class AXI4ToTLIdMapEntry(tlId: IdRange, axi4Id: IdRange, name: String)
@@ -28,12 +28,12 @@ case class AXI4ToTLIdMapEntry(tlId: IdRange, axi4Id: IdRange, name: String)
 
 case class AXI4ToTLNode(wcorrupt: Boolean)(implicit valName: ValName) extends MixedAdapterNode(AXI4Imp, TLImp)(
   dFn = { case mp =>
-    mp.masters.foreach { m => require (m.maxFlight.isDefined, "AXI4 must include a transaction maximum per ID to convert to TL") }
-    val maxFlight = mp.masters.map(_.maxFlight.get).max
-    TLMasterPortParameters.v1(
-      clients = mp.masters.filter(_.maxFlight != Some(0)).flatMap { m =>
+    mp.managers.foreach { m => require (m.maxFlight.isDefined, "AXI4 must include a transaction maximum per ID to convert to TL") }
+    val maxFlight = mp.managers.map(_.maxFlight.get).max
+    TLManagerPortParameters.v1(
+      clients = mp.managers.filter(_.maxFlight != Some(0)).flatMap { m =>
         for (id <- m.id.start until m.id.end)
-          yield TLMasterParameters.v1(
+          yield TLManagerParameters.v1(
             name        = s"${m.name} ID#${id}",
             sourceId    = IdRange(id * maxFlight*2, (id+1) * maxFlight*2), // R+W ids are distinct
             nodePath    = m.nodePath,
@@ -43,10 +43,10 @@ case class AXI4ToTLNode(wcorrupt: Boolean)(implicit valName: ValName) extends Mi
       requestFields = AMBAProtField() +: mp.requestFields,
       responseKeys  = mp.responseKeys)
   },
-  uFn = { mp => AXI4SlavePortParameters(
-    slaves = mp.managers.map { m =>
+  uFn = { mp => AXI4SubordinatePortParameters(
+    subordinates = mp.managers.map { m =>
       val maxXfer = TransferSizes(1, mp.beatBytes * (1 << AXI4Parameters.lenBits))
-      AXI4SlaveParameters(
+      AXI4SubordinateParameters(
         address       = m.address,
         resources     = m.resources,
         regionType    = m.regionType,
@@ -62,12 +62,12 @@ case class AXI4ToTLNode(wcorrupt: Boolean)(implicit valName: ValName) extends Mi
   })
 
 /**
-  * Convert AXI4 master to TileLink.
+  * Convert AXI4 manager to TileLink.
   *
-  * You can use this adapter to connect external AXI4 masters to TileLink bus topology.
+  * You can use this adapter to connect external AXI4 managers to TileLink bus topology.
   *
   * Setting wcorrupt=true is insufficient to enable w.user.corrupt.
-  * One must additionally list it in the AXI4 master's requestFields.
+  * One must additionally list it in the AXI4 manager's requestFields.
   *
   * @param wcorrupt enable AMBACorrupt in w.user
   */
@@ -78,15 +78,15 @@ class AXI4ToTL(wcorrupt: Boolean)(implicit p: Parameters) extends LazyModule
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      val numIds = edgeIn.master.endId
+      val numIds = edgeIn.manager.endId
       val beatBytes = edgeOut.manager.beatBytes
       val beatCountBits = AXI4Parameters.lenBits + (1 << AXI4Parameters.sizeBits) - 1
-      val maxFlight = edgeIn.master.masters.map(_.maxFlight.get).max
+      val maxFlight = edgeIn.manager.managers.map(_.maxFlight.get).max
       val logFlight = log2Ceil(maxFlight)
       val txnCountBits = log2Ceil(maxFlight+1) // wrap-around must not block b_allow
       val addedBits = logFlight + 1 // +1 for read vs. write source ID
 
-      require (edgeIn.master.masters(0).aligned)
+      require (edgeIn.manager.managers(0).aligned)
       edgeOut.manager.requireFifo()
 
       // Look for an Error device to redirect bad requests

--- a/src/main/scala/amba/axi4/package.scala
+++ b/src/main/scala/amba/axi4/package.scala
@@ -12,9 +12,9 @@ import freechips.rocketchip.prci.{HasClockDomainCrossing, HasResetDomainCrossing
   */
 package object axi4
 {
-  type AXI4Node = SimpleNodeHandle[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
-  type AXI4OutwardNode = OutwardNodeHandle[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
-  type AXI4InwardNode = InwardNodeHandle[AXI4MasterPortParameters, AXI4SlavePortParameters, AXI4EdgeParameters, AXI4Bundle]
+  type AXI4Node = SimpleNodeHandle[AXI4ManagerPortParameters, AXI4SubordinatePortParameters, AXI4EdgeParameters, AXI4Bundle]
+  type AXI4OutwardNode = OutwardNodeHandle[AXI4ManagerPortParameters, AXI4SubordinatePortParameters, AXI4EdgeParameters, AXI4Bundle]
+  type AXI4InwardNode = InwardNodeHandle[AXI4ManagerPortParameters, AXI4SubordinatePortParameters, AXI4EdgeParameters, AXI4Bundle]
 
   implicit class AXI4ClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
     def crossIn (n: AXI4InwardNode) (implicit valName: ValName) = AXI4InwardClockCrossingHelper(valName.value, x, n)

--- a/src/main/scala/amba/axis/Nodes.scala
+++ b/src/main/scala/amba/axis/Nodes.scala
@@ -8,29 +8,29 @@ import org.chipsalliance.cde.config.Parameters
 import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.nodes.{SimpleNodeImp, SourceNode, SinkNode, NexusNode, AdapterNode, OutwardNode, IdentityNode, RenderedEdge, InwardNode}
 
-object AXISImp extends SimpleNodeImp[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
+object AXISImp extends SimpleNodeImp[AXISManagerPortParameters, AXISSubordinatePortParameters, AXISEdgeParameters, AXISBundle]
 {
-  def edge(pd: AXISMasterPortParameters, pu: AXISSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXISEdgeParameters.v1(pd, pu, p, sourceInfo)
+  def edge(pd: AXISManagerPortParameters, pu: AXISSubordinatePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXISEdgeParameters.v1(pd, pu, p, sourceInfo)
   def bundle(e: AXISEdgeParameters) = AXISBundle(e.bundle)
   def render(e: AXISEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, (e.beatBytes * 8).toString)
 
-  override def mixO(pd: AXISMasterPortParameters, node: OutwardNode[AXISMasterPortParameters, AXISSlavePortParameters, AXISBundle]): AXISMasterPortParameters  =
-    pd.v1copy(masters = pd.masters.map  { c => c.v1copy (nodePath = node +: c.nodePath) })
-  override def mixI(pu: AXISSlavePortParameters, node: InwardNode[AXISMasterPortParameters, AXISSlavePortParameters, AXISBundle]): AXISSlavePortParameters =
-    pu.v1copy(slaves  = pu.slaves.map { m => m.v1copy (nodePath = node +: m.nodePath) })
+  override def mixO(pd: AXISManagerPortParameters, node: OutwardNode[AXISManagerPortParameters, AXISSubordinatePortParameters, AXISBundle]): AXISManagerPortParameters  =
+    pd.v1copy(managers = pd.managers.map  { c => c.v1copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: AXISSubordinatePortParameters, node: InwardNode[AXISManagerPortParameters, AXISSubordinatePortParameters, AXISBundle]): AXISSubordinatePortParameters =
+    pu.v1copy(subordinates  = pu.subordinates.map { m => m.v1copy (nodePath = node +: m.nodePath) })
 }
 
-case class AXISMasterNode(portParams: Seq[AXISMasterPortParameters])(implicit valName: ValName) extends SourceNode(AXISImp)(portParams)
-case class AXISSlaveNode(portParams: Seq[AXISSlavePortParameters])(implicit valName: ValName) extends SinkNode(AXISImp)(portParams)
+case class AXISManagerNode(portParams: Seq[AXISManagerPortParameters])(implicit valName: ValName) extends SourceNode(AXISImp)(portParams)
+case class AXISSubordinateNode(portParams: Seq[AXISSubordinatePortParameters])(implicit valName: ValName) extends SinkNode(AXISImp)(portParams)
 case class AXISNexusNode(
-  masterFn:       Seq[AXISMasterPortParameters] => AXISMasterPortParameters,
-  slaveFn:        Seq[AXISSlavePortParameters]  => AXISSlavePortParameters)(
+  managerFn:       Seq[AXISManagerPortParameters] => AXISManagerPortParameters,
+  subordinateFn:        Seq[AXISSubordinatePortParameters]  => AXISSubordinatePortParameters)(
   implicit valName: ValName)
-  extends NexusNode(AXISImp)(masterFn, slaveFn)
+  extends NexusNode(AXISImp)(managerFn, subordinateFn)
 
 case class AXISAdapterNode(
-  masterFn:  AXISMasterPortParameters => AXISMasterPortParameters = { m => m },
-  slaveFn:   AXISSlavePortParameters  => AXISSlavePortParameters  = { s => s })(
+  managerFn:  AXISManagerPortParameters => AXISManagerPortParameters = { m => m },
+  subordinateFn:   AXISSubordinatePortParameters  => AXISSubordinatePortParameters  = { s => s })(
   implicit valName: ValName)
-  extends AdapterNode(AXISImp)(masterFn, slaveFn)
+  extends AdapterNode(AXISImp)(managerFn, subordinateFn)
 case class AXISIdentityNode()(implicit valName: ValName) extends IdentityNode(AXISImp)()

--- a/src/main/scala/amba/axis/Parameters.scala
+++ b/src/main/scala/amba/axis/Parameters.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.resources.{Resource}
 import freechips.rocketchip.util.{BundleFieldBase, BundleField}
 
 
-class AXISSlaveParameters private (
+class AXISSubordinateParameters private (
   val name:          String,
   val supportsSizes: TransferSizes,
   val destinationId: Int,
@@ -29,7 +29,7 @@ class AXISSlaveParameters private (
       resources:     Seq[Resource] = resources,
       nodePath:      Seq[BaseNode] = nodePath) =
   {
-    new AXISSlaveParameters(
+    new AXISSubordinateParameters(
       name         = name,
       supportsSizes = supportsSizes,
       destinationId = destinationId,
@@ -38,7 +38,7 @@ class AXISSlaveParameters private (
   }
 }
 
-object AXISSlaveParameters {
+object AXISSubordinateParameters {
   def v1(
       name:          String,
       supportsSizes: TransferSizes,
@@ -46,7 +46,7 @@ object AXISSlaveParameters {
       resources:     Seq[Resource] = Nil,
       nodePath:      Seq[BaseNode] = Nil) =
   {
-    new AXISSlaveParameters(
+    new AXISSubordinateParameters(
       name         = name,
       supportsSizes = supportsSizes,
       destinationId = destinationId,
@@ -55,48 +55,48 @@ object AXISSlaveParameters {
   }
 }
 
-class AXISSlavePortParameters private (
-  val slaves:        Seq[AXISSlaveParameters],
+class AXISSubordinatePortParameters private (
+  val subordinates:        Seq[AXISSubordinateParameters],
   val reqAligned:    Boolean, /* 'Position byte's are unsupported */
   val reqContinuous: Boolean, /* 'Null byte's inside transfers unsupported */
   val beatBytes:     Option[Int])
 {
-  require (!slaves.isEmpty)
+  require (!subordinates.isEmpty)
   beatBytes.foreach { b => require(isPow2(b)) }
 
-  val endDestinationId = slaves.map(_.destinationId).max + 1
-  val supportsMinCover = TransferSizes.mincover(slaves.map(_.supportsSizes))
+  val endDestinationId = subordinates.map(_.destinationId).max + 1
+  val supportsMinCover = TransferSizes.mincover(subordinates.map(_.supportsSizes))
 
   def v1copy(
-    slaves:        Seq[AXISSlaveParameters] = slaves,
+    subordinates:        Seq[AXISSubordinateParameters] = subordinates,
     reqAligned:    Boolean                  = reqAligned,
     reqContinuous: Boolean                  = reqContinuous,
     beatBytes:     Option[Int]              = beatBytes) =
   {
-    new AXISSlavePortParameters(
-      slaves        = slaves,
+    new AXISSubordinatePortParameters(
+      subordinates        = subordinates,
       reqAligned    = reqAligned,
       reqContinuous = reqContinuous,
       beatBytes     = beatBytes)
   }
 }
 
-object AXISSlavePortParameters {
+object AXISSubordinatePortParameters {
   def v1(
-    slaves:        Seq[AXISSlaveParameters],
+    subordinates:        Seq[AXISSubordinateParameters],
     reqAligned:    Boolean     = false,
     reqContinuous: Boolean     = false,
     beatBytes:     Option[Int] = None) =
   {
-    new AXISSlavePortParameters(
-      slaves        = slaves,
+    new AXISSubordinatePortParameters(
+      subordinates        = subordinates,
       reqAligned    = reqAligned,
       reqContinuous = reqContinuous,
       beatBytes     = beatBytes)
   }
 }
 
-class AXISMasterParameters private (
+class AXISManagerParameters private (
   val name:       String,
   val emitsSizes: TransferSizes,
   val sourceId:   IdRange,
@@ -113,7 +113,7 @@ class AXISMasterParameters private (
     resources:  Seq[Resource] = resources,
     nodePath:   Seq[BaseNode] = nodePath) =
   {
-    new AXISMasterParameters(
+    new AXISManagerParameters(
       name       = name,
       emitsSizes = emitsSizes,
       sourceId   = sourceId,
@@ -122,7 +122,7 @@ class AXISMasterParameters private (
   }
 }
 
-object AXISMasterParameters {
+object AXISManagerParameters {
   def v1(
     name:       String,
     emitsSizes: TransferSizes,
@@ -130,7 +130,7 @@ object AXISMasterParameters {
     resources:  Seq[Resource] = Nil,
     nodePath:   Seq[BaseNode] = Nil) =
   {
-    new AXISMasterParameters(
+    new AXISManagerParameters(
       name       = name,
       emitsSizes = emitsSizes,
       sourceId   = sourceId,
@@ -139,28 +139,28 @@ object AXISMasterParameters {
   }
 }
 
-class AXISMasterPortParameters private (
-  val masters:      Seq[AXISMasterParameters],
+class AXISManagerPortParameters private (
+  val managers:      Seq[AXISManagerParameters],
   val userFields:   Seq[BundleFieldBase],
   val isAligned:    Boolean, /* there are no 'Position byte's in transfers */
   val isContinuous: Boolean, /* there are no 'Null byte's except at the end of a transfer */
   val beatBytes:    Option[Int])
 {
-  require (!masters.isEmpty)
+  require (!managers.isEmpty)
   beatBytes.foreach { b => require(isPow2(b)) }
 
-  val endSourceId = masters.map(_.sourceId.end).max
-  val emitsMinCover = TransferSizes.mincover(masters.map(_.emitsSizes))
+  val endSourceId = managers.map(_.sourceId.end).max
+  val emitsMinCover = TransferSizes.mincover(managers.map(_.emitsSizes))
 
   def v1copy(
-    masters:      Seq[AXISMasterParameters] = masters,
+    managers:      Seq[AXISManagerParameters] = managers,
     userFields:   Seq[BundleFieldBase]      = userFields,
     isAligned:    Boolean                   = isAligned,
     isContinuous: Boolean                   = isContinuous,
     beatBytes:    Option[Int]               = beatBytes) =
   {
-    new AXISMasterPortParameters(
-      masters      = masters,
+    new AXISManagerPortParameters(
+      managers      = managers,
       userFields   = userFields,
       isAligned    = isAligned,
       isContinuous = isContinuous,
@@ -168,16 +168,16 @@ class AXISMasterPortParameters private (
   }
 }
 
-object AXISMasterPortParameters {
+object AXISManagerPortParameters {
   def v1(
-    masters:      Seq[AXISMasterParameters],
+    managers:      Seq[AXISManagerParameters],
     userFields:   Seq[BundleFieldBase] = Nil,
     isAligned:    Boolean              = false,
     isContinuous: Boolean              = false,
     beatBytes:    Option[Int]          = None) =
   {
-    new AXISMasterPortParameters(
-      masters      = masters,
+    new AXISManagerPortParameters(
+      managers      = managers,
       userFields   = userFields,
       isAligned    = isAligned,
       isContinuous = isContinuous,
@@ -263,38 +263,38 @@ object AXISBundleParameters {
 }
 
 class AXISEdgeParameters private (
-  val master:     AXISMasterPortParameters,
-  val slave:      AXISSlavePortParameters,
+  val manager:     AXISManagerPortParameters,
+  val subordinate:      AXISSubordinatePortParameters,
   val params:     Parameters,
   val sourceInfo: SourceInfo)
 {
-  require (!slave.beatBytes.isEmpty || !master.beatBytes.isEmpty,
-    s"Neither master nor slave port specify a bus width (insert an AXISBusBinder between them?) at ${sourceInfo}")
-  require (slave.beatBytes.isEmpty || master.beatBytes.isEmpty || slave.beatBytes == master.beatBytes,
-    s"Master and slave ports specify incompatible bus widths (insert an AXISWidthWidget between them?) at ${sourceInfo}")
-  require (!slave.reqAligned || master.isAligned, s"Slave port requires aligned stream data at ${sourceInfo}")
-  require (!slave.reqContinuous || master.isContinuous, s"Slave port requires continuous stream data at ${sourceInfo}")
+  require (!subordinate.beatBytes.isEmpty || !manager.beatBytes.isEmpty,
+    s"Neither manager nor subordinate port specify a bus width (insert an AXISBusBinder between them?) at ${sourceInfo}")
+  require (subordinate.beatBytes.isEmpty || manager.beatBytes.isEmpty || subordinate.beatBytes == manager.beatBytes,
+    s"Manager and subordinate ports specify incompatible bus widths (insert an AXISWidthWidget between them?) at ${sourceInfo}")
+  require (!subordinate.reqAligned || manager.isAligned, s"Subordinate port requires aligned stream data at ${sourceInfo}")
+  require (!subordinate.reqContinuous || manager.isContinuous, s"Subordinate port requires continuous stream data at ${sourceInfo}")
 
-  val beatBytes = slave.beatBytes.getOrElse(master.beatBytes.get)
-  val transferSizes = master.emitsMinCover intersect slave.supportsMinCover
+  val beatBytes = subordinate.beatBytes.getOrElse(manager.beatBytes.get)
+  val transferSizes = manager.emitsMinCover intersect subordinate.supportsMinCover
 
   val bundle = AXISBundleParameters.v1(
-    idBits      = log2Ceil(master.endSourceId),
-    destBits    = log2Ceil(slave.endDestinationId),
+    idBits      = log2Ceil(manager.endSourceId),
+    destBits    = log2Ceil(subordinate.endDestinationId),
     dataBits    = beatBytes * 8,
-    userFields  = master.userFields,
+    userFields  = manager.userFields,
     oneBeat     = transferSizes.max <= beatBytes,
-    aligned     = master.isAligned)
+    aligned     = manager.isAligned)
 
   def v1copy(
-    master:     AXISMasterPortParameters = master,
-    slave:      AXISSlavePortParameters  = slave,
+    manager:     AXISManagerPortParameters = manager,
+    subordinate:      AXISSubordinatePortParameters  = subordinate,
     params:     Parameters               = params,
     sourceInfo: SourceInfo               = sourceInfo) =
   {
     new AXISEdgeParameters(
-      master     = master,
-      slave      = slave,
+      manager     = manager,
+      subordinate      = subordinate,
       params     = params,
       sourceInfo = sourceInfo)
   }
@@ -302,14 +302,14 @@ class AXISEdgeParameters private (
 
 object AXISEdgeParameters {
   def v1(
-    master:     AXISMasterPortParameters,
-    slave:      AXISSlavePortParameters,
+    manager:     AXISManagerPortParameters,
+    subordinate:      AXISSubordinatePortParameters,
     params:     Parameters,
     sourceInfo: SourceInfo) =
   {
     new AXISEdgeParameters(
-      master     = master,
-      slave      = slave,
+      manager     = manager,
+      subordinate      = subordinate,
       params     = params,
       sourceInfo = sourceInfo)
   }

--- a/src/main/scala/amba/axis/package.scala
+++ b/src/main/scala/amba/axis/package.scala
@@ -6,7 +6,7 @@ import org.chipsalliance.diplomacy.nodes.{InwardNodeHandle, OutwardNodeHandle, N
 
 package object axis
 {
-  type AXISInwardNode = InwardNodeHandle[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
-  type AXISOutwardNode = OutwardNodeHandle[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
-  type AXISNode = NodeHandle[AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle, AXISMasterPortParameters, AXISSlavePortParameters, AXISEdgeParameters, AXISBundle]
+  type AXISInwardNode = InwardNodeHandle[AXISManagerPortParameters, AXISSubordinatePortParameters, AXISEdgeParameters, AXISBundle]
+  type AXISOutwardNode = OutwardNodeHandle[AXISManagerPortParameters, AXISSubordinatePortParameters, AXISEdgeParameters, AXISBundle]
+  type AXISNode = NodeHandle[AXISManagerPortParameters, AXISSubordinatePortParameters, AXISEdgeParameters, AXISBundle, AXISManagerPortParameters, AXISSubordinatePortParameters, AXISEdgeParameters, AXISBundle]
 }

--- a/src/main/scala/amba/package.scala
+++ b/src/main/scala/amba/package.scala
@@ -13,7 +13,7 @@ package object amba {
     val readalloc  = Bool()
     val writealloc = Bool()
     val privileged = Bool() // machine_mode=true,   user_mode=false
-    val secure     = Bool() // secure_master=true,  normal=false
+    val secure     = Bool() // secure_manager=true,  normal=false
     val fetch      = Bool() // instruct_fetch=true, load/store=false
   }
 

--- a/src/main/scala/devices/debug/DMI.scala
+++ b/src/main/scala/devices/debug/DMI.scala
@@ -9,7 +9,7 @@ import org.chipsalliance.cde.config._
 import org.chipsalliance.diplomacy.lazymodule._
 
 import freechips.rocketchip.diplomacy.TransferSizes
-import freechips.rocketchip.tilelink.{TLClientNode, TLMasterParameters, TLMasterPortParameters, TLMasterToSlaveTransferSizes}
+import freechips.rocketchip.tilelink.{TLClientNode, TLClientParameters, TLClientPortParameters, TLClientToManagerTransferSizes}
 import freechips.rocketchip.util.ParameterizedBundle
 
 /** Constant values used by both Debug Bus Response & Request
@@ -80,9 +80,9 @@ class ClockedDMIIO(implicit val p: Parameters) extends ParameterizedBundle()(p){
   */
 
 class DMIToTL(implicit p: Parameters) extends LazyModule {
-  val node = TLClientNode(Seq(TLMasterPortParameters.v2(Seq(TLMasterParameters.v2(
+  val node = TLClientNode(Seq(TLClientPortParameters.v2(Seq(TLClientParameters.v2(
     name = "debug",
-    emits = TLMasterToSlaveTransferSizes(
+    emits = TLClientToManagerTransferSizes(
       get = TransferSizes(4,4),
       putFull = TransferSizes(4,4)))))))
 

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -96,7 +96,7 @@ object DebugAbstractCommandType extends scala.Enumeration {
   *  @param nDMIAddrSize Size of the Debug Bus Address
   *  @param nAbstractDataWords Number of 32-bit words for Abstract Commands
   *  @param nProgamBufferWords Number of 32-bit words for Program Buffer
-  *  @param hasBusMaster Whether or not a bus master should be included
+  *  @param hasBusDriver Whether or not a bus driver should be included
   *  @param clockGate Whether or not to use dmactive as the clockgate for debug module
   *  @param maxSupportedSBAccess Maximum transaction size supported by System Bus Access logic.
   *  @param supportQuickAccess Whether or not to support the quick access command.
@@ -114,7 +114,7 @@ case class DebugModuleParams (
   nProgramBufferWords: Int = 16,
   nAbstractDataWords : Int = 4,
   nScratch : Int = 1,
-  hasBusMaster : Boolean = false,
+  hasBusDriver : Boolean = false,
   clockGate : Boolean = true,
   maxSupportedSBAccess : Int = 32,
   supportQuickAccess : Boolean = false,
@@ -254,7 +254,7 @@ class DebugCtrlBundle (nComponents: Int)(implicit val p: Parameters) extends Par
 /** Parameterized version of the Debug Module defined in the
   *  RISC-V Debug Specification 
   *  
-  *  DebugModule is a slave to two asynchronous masters:
+  *  DebugModule is a receiver to two asynchronous drivers:
   *    The Debug Bus (DMI) -- This is driven by an external debugger
   *  
   *    The System Bus -- This services requests from the cores. Generally
@@ -779,7 +779,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     executable=true
   )
 
-  val sb2tlOpt = cfg.hasBusMaster.option(LazyModule(new SBToTL()))
+  val sb2tlOpt = cfg.hasBusDriver.option(LazyModule(new SBToTL()))
 
   // If we want to support custom registers read through Abstract Commands,
   // provide a place to bring them into the debug module. What this connects

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.amba.{AMBAProt, AMBAProtField}
 import freechips.rocketchip.devices.debug.{DebugModuleKey, RWNotify, SBCSFields, WNotifyVal}
 import freechips.rocketchip.diplomacy.TransferSizes
 import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup, RegFieldWrType}
-import freechips.rocketchip.tilelink.{TLClientNode, TLMasterParameters, TLMasterPortParameters}
+import freechips.rocketchip.tilelink.{TLClientNode, TLClientParameters, TLClientPortParameters}
 import freechips.rocketchip.util.property
 
 object SystemBusAccessState extends scala.Enumeration {
@@ -265,8 +265,8 @@ class SBToTL(implicit p: Parameters) extends LazyModule {
 
   val cfg = p(DebugModuleKey).get
 
-  val node = TLClientNode(Seq(TLMasterPortParameters.v1(
-    clients = Seq(TLMasterParameters.v1("debug")),
+  val node = TLClientNode(Seq(TLClientPortParameters.v1(
+    clients = Seq(TLClientParameters.v1("debug")),
     requestFields = Seq(AMBAProtField()))))
 
   lazy val module = new Impl

--- a/src/main/scala/devices/debug/dm_registers.scala
+++ b/src/main/scala/devices/debug/dm_registers.scala
@@ -116,7 +116,7 @@ object DMI_RegAddrs {
       of the configuration string pointer. Reading the other {\tt confstrptr}
       registers returns the upper bits of the address.
 
-      When system bus mastering is implemented, this must be an
+      When system bus driving is implemented, this must be an
       address that can be used with the System Bus Access module. Otherwise,
       this must be an address that can be used to access the
       configuration string from the hart with ID 0.
@@ -241,7 +241,7 @@ object DMI_RegAddrs {
 
   /* If \Fsbasize is 0, then this register is not present.
 
-        When the system bus master is busy, writes to this register will set
+        When the system bus driver is busy, writes to this register will set
         \Fsbbusyerror and don't do anything else.
 
         \begin{steps}{If \Fsberror is 0, \Fsbbusyerror is 0, and \Fsbreadonaddr
@@ -257,21 +257,21 @@ object DMI_RegAddrs {
 
   /* If \Fsbasize is less than 33, then this register is not present.
 
-        When the system bus master is busy, writes to this register will set
+        When the system bus driver is busy, writes to this register will set
         \Fsbbusyerror and don't do anything else.
   */
   def DMI_SBADDRESS1 =  0x3a
 
   /* If \Fsbasize is less than 65, then this register is not present.
 
-        When the system bus master is busy, writes to this register will set
+        When the system bus driver is busy, writes to this register will set
         \Fsbbusyerror and don't do anything else.
   */
   def DMI_SBADDRESS2 =  0x3b
 
   /* If \Fsbasize is less than 97, then this register is not present.
 
-        When the system bus master is busy, writes to this register will set
+        When the system bus driver is busy, writes to this register will set
         \Fsbbusyerror and don't do anything else.
   */
   def DMI_SBADDRESS3 =  0x37
@@ -285,7 +285,7 @@ object DMI_RegAddrs {
 
         If \Fsberror or \Fsbbusyerror both aren't 0 then accesses do nothing.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus driver is busy then accesses set \Fsbbusyerror, and don't do
         anything else.
 
         \begin{steps}{Writes to this register start the following:}
@@ -316,21 +316,21 @@ object DMI_RegAddrs {
   /* If \Fsbaccesssixtyfour and \Fsbaccessonetwentyeight are 0, then this
         register is not present.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus driver is busy then accesses set \Fsbbusyerror, and don't do
         anything else.
   */
   def DMI_SBDATA1 =  0x3d
 
   /* This register only exists if \Fsbaccessonetwentyeight is 1.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus driver is busy then accesses set \Fsbbusyerror, and don't do
         anything else.
   */
   def DMI_SBDATA2 =  0x3e
 
   /* This register only exists if \Fsbaccessonetwentyeight is 1.
 
-        If the bus master is busy then accesses set \Fsbbusyerror, and don't do
+        If the bus driver is busy then accesses set \Fsbbusyerror, and don't do
         anything else.
   */
   def DMI_SBDATA3 =  0x3f
@@ -858,7 +858,7 @@ class SBCSFields extends Bundle {
   */
   val sbbusyerror = Bool()
 
-  /* When 1, indicates the system bus master is busy. (Whether the
+  /* When 1, indicates the system bus driver is busy. (Whether the
             system bus itself is busy is related, but not the same thing.) This
             bit goes high immediately when a read or write is requested for any
             reason, and does not go low until the access is fully completed.
@@ -902,7 +902,7 @@ class SBCSFields extends Bundle {
   val sbreadondata = Bool()
 
   /* When the Debug Module's system bus
-            master encounters an error, this field gets set. The bits in this
+            driver encounters an error, this field gets set. The bits in this
             field remain set until they are cleared by writing 1 to them.
             While this field is non-zero, no more system bus accesses can be
             initiated by the Debug Module.

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -12,7 +12,7 @@ import org.chipsalliance.diplomacy.lazymodule._
 import freechips.rocketchip.diplomacy.{AddressSet, RegionType, TransferSizes}
 import freechips.rocketchip.resources.{Resource, SimpleDevice}
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.tilelink.{TLFragmenter, TLManagerNode, TLSlaveParameters, TLSlavePortParameters}
+import freechips.rocketchip.tilelink.{TLFragmenter, TLManagerNode, TLManagerParameters, TLManagerPortParameters}
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
@@ -27,8 +27,8 @@ case class BootROMParams(
 class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], executable: Boolean = true, beatBytes: Int = 4,
   resources: Seq[Resource] = new SimpleDevice("rom", Seq("sifive,rom0")).reg("mem"))(implicit p: Parameters) extends LazyModule
 {
-  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
-    Seq(TLSlaveParameters.v1(
+  val node = TLManagerNode(Seq(TLManagerPortParameters.v1(
+    Seq(TLManagerParameters.v1(
       address     = List(AddressSet(base, size-1)),
       resources   = resources,
       regionType  = RegionType.UNCACHED,

--- a/src/main/scala/devices/tilelink/BusBypass.scala
+++ b/src/main/scala/devices/tilelink/BusBypass.scala
@@ -46,7 +46,7 @@ class TLBusBypass(beatBytes: Int, bufferError: Boolean = false, maxAtomic: Int =
   }
 }
 
-class TLBypassNode(dFn: TLSlavePortParameters => TLSlavePortParameters)(implicit valName: ValName) extends TLCustomNode
+class TLBypassNode(dFn: TLManagerPortParameters => TLManagerPortParameters)(implicit valName: ValName) extends TLCustomNode
 {
   def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
     require (iStars == 0 && oStars == 0, "TLBypass node does not support :=* or :*=")
@@ -54,11 +54,11 @@ class TLBypassNode(dFn: TLSlavePortParameters => TLSlavePortParameters)(implicit
     require (oKnown == 2, "TLBypass node expects exactly two outputs")
     (0, 0)
   }
-  def mapParamsD(n: Int, p: Seq[TLMasterPortParameters]): Seq[TLMasterPortParameters] = { p ++ p }
-  def mapParamsU(n: Int, p: Seq[TLSlavePortParameters]): Seq[TLSlavePortParameters] = { Seq(dFn(p.last).v1copy(minLatency = p.map(_.minLatency).min))}
+  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] = { p ++ p }
+  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] = { Seq(dFn(p.last).v1copy(minLatency = p.map(_.minLatency).min))}
 }
 
-class TLBusBypassBar(dFn: TLSlavePortParameters => TLSlavePortParameters)(implicit p: Parameters) extends LazyModule
+class TLBusBypassBar(dFn: TLManagerPortParameters => TLManagerPortParameters)(implicit p: Parameters) extends LazyModule
 {
   val node = new TLBypassNode(dFn)
 
@@ -73,7 +73,7 @@ class TLBusBypassBar(dFn: TLSlavePortParameters => TLSlavePortParameters)(implic
     val Seq((out0, edgeOut0), (out1, edgeOut1)) = node.out
 
     require (edgeOut0.manager.beatBytes == edgeOut1.manager.beatBytes,
-      s"BusBypass slave device widths mismatch (${edgeOut0.manager.managers.map(_.name)} has ${edgeOut0.manager.beatBytes}B vs ${edgeOut1.manager.managers.map(_.name)} has ${edgeOut1.manager.beatBytes}B)")
+      s"BusBypass manager device widths mismatch (${edgeOut0.manager.managers.map(_.name)} has ${edgeOut0.manager.beatBytes}B vs ${edgeOut1.manager.managers.map(_.name)} has ${edgeOut1.manager.beatBytes}B)")
 
     // We need to be locked to the given bypass direction until all transactions stop
     val in_reset = RegNext(false.B, init = true.B)

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -37,7 +37,7 @@ case class CLINTParams(baseAddress: BigInt = 0x02000000, intStages: Int = 0)
 case object CLINTKey extends Field[Option[CLINTParams]](None)
 
 case class CLINTAttachParams(
-  slaveWhere: TLBusWrapperLocation = CBUS
+  managerWhere: TLBusWrapperLocation = CBUS
 )
 
 case object CLINTAttachKey extends Field(CLINTAttachParams())
@@ -107,7 +107,7 @@ class CLINT(params: CLINTParams, beatBytes: Int)(implicit p: Parameters) extends
 /** Trait that will connect a CLINT to a subsystem */
 trait CanHavePeripheryCLINT { this: BaseSubsystem =>
   val (clintOpt, clintDomainOpt, clintTickOpt) = p(CLINTKey).map { params =>
-    val tlbus = locateTLBusWrapper(p(CLINTAttachKey).slaveWhere)
+    val tlbus = locateTLBusWrapper(p(CLINTAttachKey).managerWhere)
     val clintDomainWrapper = tlbus.generateSynchronousDomain("CLINT").suggestName("clint_domain")
     val clint = clintDomainWrapper { LazyModule(new CLINT(params, tlbus.beatBytes)) }
     clintDomainWrapper { clint.node := tlbus.coupleTo("clint") { TLFragmenter(tlbus, Some("CLINT")) := _ } }

--- a/src/main/scala/devices/tilelink/Deadlock.scala
+++ b/src/main/scala/devices/tilelink/Deadlock.scala
@@ -7,7 +7,7 @@ import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.resources.{SimpleDevice}
 
-/** Adds a /dev/null slave that does not raise ready for any incoming traffic.
+/** Adds a /dev/null manager that does not raise ready for any incoming traffic.
   * !!! WARNING: This device WILL cause your bus to deadlock for as long as you
   *              continue to send traffic to it !!!
   */

--- a/src/main/scala/devices/tilelink/DevNull.scala
+++ b/src/main/scala/devices/tilelink/DevNull.scala
@@ -8,7 +8,7 @@ import org.chipsalliance.diplomacy.lazymodule._
 import freechips.rocketchip.diplomacy.{AddressSet, RegionType, TransferSizes}
 import freechips.rocketchip.resources.{SimpleDevice}
 import freechips.rocketchip.prci.{HasClockDomainCrossing}
-import freechips.rocketchip.tilelink.{TLManagerNode, TLSlaveParameters, TLSlavePortParameters}
+import freechips.rocketchip.tilelink.{TLManagerNode, TLManagerParameters, TLManagerPortParameters}
 
 import freechips.rocketchip.tilelink.TLClockDomainCrossing
 
@@ -38,8 +38,8 @@ abstract class DevNullDevice(params: DevNullParams, minLatency: Int, beatBytes: 
   val atom = if (params.maxAtomic > 0) TransferSizes(1, params.maxAtomic) else TransferSizes.none
   val acq  = if (params.acquire) xfer else TransferSizes.none
   val hint = if (params.hint) xfer else TransferSizes.none
-  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
-    Seq(TLSlaveParameters.v1(
+  val node = TLManagerNode(Seq(TLManagerPortParameters.v1(
+    Seq(TLManagerParameters.v1(
       address            = params.address,
       resources          = device.reg,
       regionType         = params.region,

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -11,7 +11,7 @@ import org.chipsalliance.diplomacy.lazymodule._
 import freechips.rocketchip.resources.SimpleDevice
 import freechips.rocketchip.tilelink.{TLArbiter, TLMessages, TLPermissions}
 
-/** Adds a /dev/null slave that generates TL error response messages */
+/** Adds a /dev/null manager that generates TL error response messages */
 class TLError(params: DevNullParams, buffer: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters)
     extends DevNullDevice(params,
       minLatency = if (buffer) 1 else 0,

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -11,7 +11,7 @@ import org.chipsalliance.diplomacy.lazymodule._
 import freechips.rocketchip.diplomacy.{RegionType, AddressSet, TransferSizes}
 import freechips.rocketchip.resources.{SimpleDevice}
 import freechips.rocketchip.subsystem.{Attachable, HierarchicalLocation, TLBusWrapperLocation}
-import freechips.rocketchip.tilelink.{TLFragmenter, TLManagerNode, TLSlaveParameters, TLSlavePortParameters, TLWidthWidget}
+import freechips.rocketchip.tilelink.{TLFragmenter, TLManagerNode, TLManagerParameters, TLManagerPortParameters, TLWidthWidget}
 import freechips.rocketchip.util.{ROMConfig, ROMGenerator}
 
 import freechips.rocketchip.util.DataToAugmentedData
@@ -20,8 +20,8 @@ case class MaskROMParams(address: BigInt, name: String, depth: Int = 2048, width
 
 class TLMaskROM(c: MaskROMParams)(implicit p: Parameters) extends LazyModule {
   val beatBytes = c.width/8
-  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
-    Seq(TLSlaveParameters.v1(
+  val node = TLManagerNode(Seq(TLManagerPortParameters.v1(
+    Seq(TLManagerParameters.v1(
       address            = AddressSet.misaligned(c.address, c.depth*beatBytes),
       resources          = new SimpleDevice("rom", Seq("sifive,maskrom0")).reg("mem"),
       regionType         = RegionType.UNCACHED,

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -74,7 +74,7 @@ case class PLICParams(baseAddress: BigInt = 0xC000000, maxPriorities: Int = 7, i
 case object PLICKey extends Field[Option[PLICParams]](None)
 
 case class PLICAttachParams(
-  slaveWhere: TLBusWrapperLocation = CBUS
+  managerWhere: TLBusWrapperLocation = CBUS
 )
 
 case object PLICAttachKey extends Field(PLICAttachParams())
@@ -361,7 +361,7 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 /** Trait that will connect a PLIC to a subsystem */
 trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val (plicOpt, plicDomainOpt) = p(PLICKey).map { params =>
-    val tlbus = locateTLBusWrapper(p(PLICAttachKey).slaveWhere)
+    val tlbus = locateTLBusWrapper(p(PLICAttachKey).managerWhere)
     val plicDomainWrapper = tlbus.generateSynchronousDomain("PLIC").suggestName("plic_domain")
 
     val plic = plicDomainWrapper { LazyModule(new TLPLIC(params, tlbus.beatBytes)) }

--- a/src/main/scala/devices/tilelink/TestRAM.scala
+++ b/src/main/scala/devices/tilelink/TestRAM.scala
@@ -10,15 +10,15 @@ import org.chipsalliance.diplomacy.lazymodule._
 
 import freechips.rocketchip.diplomacy.{AddressSet, RegionType, TransferSizes}
 import freechips.rocketchip.resources.{MemoryDevice}
-import freechips.rocketchip.tilelink.{TLDelayer, TLFuzzer, TLManagerNode, TLMessages, TLRAMModel, TLSlaveParameters, TLSlavePortParameters}
+import freechips.rocketchip.tilelink.{TLDelayer, TLFuzzer, TLManagerNode, TLMessages, TLRAMModel, TLManagerParameters, TLManagerPortParameters}
 
 // Do not use this for synthesis! Only for simulation.
 class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4, trackCorruption: Boolean = true)(implicit p: Parameters) extends LazyModule
 {
   val device = new MemoryDevice
 
-  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
-    Seq(TLSlaveParameters.v1(
+  val node = TLManagerNode(Seq(TLManagerPortParameters.v1(
+    Seq(TLManagerParameters.v1(
       address            = List(address),
       resources          = device.reg,
       regionType         = RegionType.UNCACHED,

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -15,7 +15,7 @@ object RegionType {
   }
 
   case object CACHED      extends T // an intermediate agent may have cached a copy of the region for you
-  case object TRACKED     extends T // the region may have been cached by another master, but coherence is being provided
+  case object TRACKED     extends T // the region may have been cached by another client, but coherence is being provided
   case object UNCACHED    extends T // the region has not been cached yet, but should be cached when possible
   case object IDEMPOTENT  extends T // gets return most recently put content, but content should not be cached
   case object VOLATILE    extends T // content may change without a put, but puts and gets have no side effects
@@ -119,7 +119,7 @@ object TransferSizes {
   def mincover(seq: Seq[TransferSizes]) = seq.foldLeft(none)(_ mincover _)
   def intersect(seq: Seq[TransferSizes]) = seq.reduce(_ intersect _)
 
-  implicit def asBool(x: TransferSizes) = !x.none
+  implicit def asBool(x: TransferSizes): Boolean = !x.none
 }
 
 // AddressSets specify the address space managed by the manager

--- a/src/main/scala/formal/FormalUtils.scala
+++ b/src/main/scala/formal/FormalUtils.scala
@@ -12,10 +12,10 @@ sealed abstract class MonitorDirection(name: String) {
   def flip: MonitorDirection
 }
 object MonitorDirection {
-  // Also known as master, effectively contains assumes
+  // Also known as client, effectively contains assumes
   object Driver  extends MonitorDirection("Driver") { override def flip: MonitorDirection = Receiver }
 
-  // Also known as slave, effectively contains asserts
+  // Also known as manager, effectively contains asserts
   object Receiver extends MonitorDirection("Receiver") { override def flip: MonitorDirection = Driver }
 
   object Monitor extends MonitorDirection("Monitor") { override def flip: MonitorDirection = Monitor }

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -6,10 +6,10 @@ package freechips.rocketchip.groundtest
 import org.chipsalliance.cde.config._
 
 import freechips.rocketchip.devices.tilelink.{CLINTKey, PLICKey}
-import freechips.rocketchip.devices.debug.{DebugModuleKey}
+import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.system.BaseConfig
-import freechips.rocketchip.rocket.{DCacheParams}
+import freechips.rocketchip.rocket.DCacheParams
 
 /** Actual testing target Configs */
 
@@ -44,7 +44,7 @@ class WithTraceGen(
   case TilesLocated(InSubsystem) => {
     val prev = up(TilesLocated(InSubsystem), site)
     val idOffset = up(NumTiles)
-    val memOffset: BigInt = overrideMemOffset.orElse(site(ExtMem).map(_.master.base)).getOrElse(0x0L)
+    val memOffset: BigInt = overrideMemOffset.orElse(site(ExtMem).map(_.client.base)).getOrElse(0x0L)
     params.zipWithIndex.map { case (dcp, i) =>
       TraceGenTileAttachParams(
         tileParams = TraceGenParams(

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -23,7 +23,7 @@ class GroundTestSubsystem(implicit p: Parameters)
   with HasHierarchicalElements
   with HasTileNotificationSinks
   with HasTileInputConstants
-  with CanHaveMasterAXI4MemPort
+  with CanHaveManagerAXI4MemPort
 {
   val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), beatBytes=tlBusWrapperLocationMap.get(PBUS).getOrElse(tlBusWrapperLocationMap(p(TLManagerViewpointLocated(location)))).beatBytes))
   tlBusWrapperLocationMap.lift(PBUS).getOrElse(tlBusWrapperLocationMap(p(TLManagerViewpointLocated(location)))).coupleTo("TestRAM") { testram.node := TLFragmenter(tlBusWrapperLocationMap.lift(PBUS).getOrElse(tlBusWrapperLocationMap(p(TLManagerViewpointLocated(location))))) := _ }

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -40,7 +40,7 @@ abstract class GroundTestTile(
 {
   val cpuDevice: SimpleDevice = new SimpleDevice("groundtest", Nil)
   val intOutwardNode = None
-  val slaveNode: TLInwardNode = TLIdentityNode()
+  val managerNode: TLInwardNode = TLIdentityNode()
   val statusNode = BundleBridgeSource(() => new GroundTestStatus)
 
   val dcacheOpt = params.dcache.map { dc => LazyModule(p(BuildHellaCache)(this)(p)) }

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -622,7 +622,7 @@ class TraceGenTile private(
   def this(params: TraceGenParams, crossing: HierarchicalElementCrossingParamsLike, lookup: LookupByHartIdImpl)(implicit p: Parameters) =
     this(params, crossing.crossingType, lookup, p)
 
-  val masterNode: TLOutwardNode = TLIdentityNode() := visibilityNode := dcacheOpt.map(_.node).getOrElse(TLTempNode())
+  val clientNode: TLOutwardNode = TLIdentityNode() := visibilityNode := dcacheOpt.map(_.node).getOrElse(TLTempNode())
 
   override lazy val module = new TraceGenTileModuleImp(this)
 }

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -7,7 +7,7 @@ import scala.collection.SortedMap
 import chisel3._
 import org.chipsalliance.cde.config.Parameters
 
-/** JTAG signals, viewed from the master side
+/** JTAG signals, viewed from the driver side
   */
 class JTAGIO(hasTRSTn: Boolean = false) extends Bundle {
   val TRSTn = if (hasTRSTn) Some(Output(Bool())) else None

--- a/src/main/scala/jtag/JtagUtils.scala
+++ b/src/main/scala/jtag/JtagUtils.scala
@@ -21,7 +21,7 @@ object JtagIdcode {
     BigInt(version) << 28 | BigInt(partNumber) << 12 | BigInt(mfrId) << 1 | 1
   }
 
-  /** A dummy manufacturer ID, not to be used per 12.2.1b since bus masters may shift this out to
+  /** A dummy manufacturer ID, not to be used per 12.2.1b since bus drivers may shift this out to
     * determine the end of a bus.
     */
   def dummyMfrId: Int = 0x7f

--- a/src/main/scala/regmapper/Test.scala
+++ b/src/main/scala/regmapper/Test.scala
@@ -235,22 +235,22 @@ abstract class RRTest1(address: BigInt, concurrency: Int, undefZero: Boolean = t
 
       val readCross = Module(new RegisterReadCrossing(field))
       readCross.io := DontCare
-      readCross.io.master_clock  := clock
-      readCross.io.master_reset  := reset
-      readCross.io.master_bypass := false.B
-      readCross.io.slave_clock   := clocks.io.clock_out
-      readCross.io.slave_reset   := reset
+      readCross.io.client_clock  := clock
+      readCross.io.client_reset  := reset
+      readCross.io.client_bypass := false.B
+      readCross.io.manager_clock   := clocks.io.clock_out
+      readCross.io.manager_reset   := reset
 
       val writeCross = Module(new RegisterWriteCrossing(field))
       writeCross.io := DontCare
-      writeCross.io.master_clock  := clock
-      writeCross.io.master_reset  := reset
-      writeCross.io.master_bypass := false.B
-      writeCross.io.slave_clock   := clocks.io.clock_out
-      writeCross.io.slave_reset   := reset
+      writeCross.io.client_clock  := clock
+      writeCross.io.client_reset  := reset
+      writeCross.io.client_bypass := false.B
+      writeCross.io.manager_clock   := clocks.io.clock_out
+      writeCross.io.manager_reset   := reset
 
-      readCross.io.slave_register := writeCross.io.slave_register
-      RegField(bits, readCross.io.master_port, writeCross.io.master_port)
+      readCross.io.manager_register := writeCross.io.manager_register
+      RegField(bits, readCross.io.client_port, writeCross.io.client_port)
     }
 
     val map = RRTest1Map.map.drop(1) ++ Seq(0 -> Seq(x(8), x(8), x(8), x(8)))

--- a/src/main/scala/rocket/Configs.scala
+++ b/src/main/scala/rocket/Configs.scala
@@ -6,7 +6,7 @@ import org.chipsalliance.cde.config._
 import org.chipsalliance.diplomacy.lazymodule._
 
 import freechips.rocketchip.prci.{SynchronousCrossing, AsynchronousCrossing, RationalCrossing, ClockCrossingType}
-import freechips.rocketchip.subsystem.{TilesLocated, NumTiles, HierarchicalLocation, RocketCrossingParams, SystemBusKey, CacheBlockBytes, RocketTileAttachParams, InSubsystem, InCluster, HierarchicalElementMasterPortParams, HierarchicalElementSlavePortParams, CBUS, CCBUS, ClustersLocated, TileAttachConfig, CloneTileAttachParams}
+import freechips.rocketchip.subsystem.{TilesLocated, NumTiles, HierarchicalLocation, RocketCrossingParams, SystemBusKey, CacheBlockBytes, RocketTileAttachParams, InSubsystem, InCluster, HierarchicalElementClientPortParams, HierarchicalElementManagerPortParams, CBUS, CCBUS, ClustersLocated, TileAttachConfig, CloneTileAttachParams}
 import freechips.rocketchip.tile.{RocketTileParams, RocketTileBoundaryBufferParams, FPUParams}
 import scala.reflect.ClassTag
 
@@ -49,8 +49,8 @@ class WithNHugeCores(
   case NumTiles => up(NumTiles) + n
 }) {
   def this(n: Int, location: HierarchicalLocation = InSubsystem) = this(n, location, RocketCrossingParams(
-    master = HierarchicalElementMasterPortParams.locationDefault(location),
-    slave = HierarchicalElementSlavePortParams.locationDefault(location),
+    client = HierarchicalElementClientPortParams.locationDefault(location),
+    manager = HierarchicalElementManagerPortParams.locationDefault(location),
     mmioBaseAddressPrefixWhere = location match {
       case InSubsystem => CBUS
       case InCluster(clusterId) => CCBUS(clusterId)
@@ -86,8 +86,8 @@ class WithNBigCores(
   case NumTiles => up(NumTiles) + n
 }) {
   def this(n: Int, location: HierarchicalLocation = InSubsystem) = this(n, location, RocketCrossingParams(
-    master = HierarchicalElementMasterPortParams.locationDefault(location),
-    slave = HierarchicalElementSlavePortParams.locationDefault(location),
+    client = HierarchicalElementClientPortParams.locationDefault(location),
+    manager = HierarchicalElementManagerPortParams.locationDefault(location),
     mmioBaseAddressPrefixWhere = location match {
       case InSubsystem => CBUS
       case InCluster(clusterId) => CCBUS(clusterId)
@@ -192,7 +192,7 @@ class With1TinyCore extends Config((site, here, up) => {
       tiny,
       RocketCrossingParams(
         crossingType = SynchronousCrossing(),
-        master = HierarchicalElementMasterPortParams())
+        client = HierarchicalElementClientPortParams())
     ))
   }
   case NumTiles => 1

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -68,9 +68,9 @@ class FrontendIO(implicit p: Parameters) extends CoreBundle()(p) {
 class Frontend(val icacheParams: ICacheParams, tileId: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new FrontendModule(this)
   val icache = LazyModule(new ICache(icacheParams, tileId))
-  val masterNode = icache.masterNode
-  val slaveNode = icache.slaveNode
-  val resetVectorSinkNode = BundleBridgeSink[UInt](Some(() => UInt(masterNode.edges.out.head.bundle.addressBits.W)))
+  val clientNode = icache.clientNode
+  val managerNode = icache.managerNode
+  val resetVectorSinkNode = BundleBridgeSink[UInt](Some(() => UInt(clientNode.edges.out.head.bundle.addressBits.W)))
 }
 
 class FrontendBundle(val outer: Frontend) extends CoreBundle()(outer.p) {
@@ -84,7 +84,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
     with HasL1ICacheParameters {
   val io = IO(new FrontendBundle(outer))
   val io_reset_vector = outer.resetVectorSinkNode.bundle
-  implicit val edge: TLEdgeOut = outer.masterNode.edges.out(0)
+  implicit val edge: TLEdgeOut = outer.clientNode.edges.out(0)
   val icache = outer.icache.module
   require(fetchWidth*coreInstBytes == outer.icacheParams.fetchBytes)
 
@@ -391,8 +391,8 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   val module: HasICacheFrontendModule
   val frontend = LazyModule(new Frontend(tileParams.icache.get, tileId))
-  tlMasterXbar.node := TLWidthWidget(tileParams.icache.get.rowBits/8) := frontend.masterNode
-  connectTLSlave(frontend.slaveNode, tileParams.core.fetchBytes)
+  tlClientXbar.node := TLWidthWidget(tileParams.icache.get.rowBits/8) := frontend.clientNode
+  connectTLManager(frontend.managerNode, tileParams.core.fetchBytes)
   frontend.icache.hartIdSinkNodeOpt.foreach { _ := hartIdNexusNode }
   frontend.icache.mmioAddressPrefixSinkNodeOpt.foreach { _ := mmioAddressPrefixNexusNode }
   frontend.resetVectorSinkNode := resetVectorNexusNode

--- a/src/main/scala/rocket/PMA.scala
+++ b/src/main/scala/rocket/PMA.scala
@@ -13,9 +13,9 @@ import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.diplomacy.RegionType
 import freechips.rocketchip.subsystem.CacheBlockBytes
 import freechips.rocketchip.tile.{CoreModule, CoreBundle}
-import freechips.rocketchip.tilelink.{TLSlavePortParameters, TLManagerParameters}
+import freechips.rocketchip.tilelink.{TLManagerPortParameters, TLManagerParameters}
 
-class PMAChecker(manager: TLSlavePortParameters)(implicit p: Parameters) extends CoreModule()(p) {
+class PMAChecker(manager: TLManagerPortParameters)(implicit p: Parameters) extends CoreModule()(p) {
   val io = IO(new Bundle {
     val paddr = Input(UInt())
 
@@ -32,7 +32,7 @@ class PMAChecker(manager: TLSlavePortParameters)(implicit p: Parameters) extends
   })
 
   // PMA
-  // check exist a slave can consume this address.
+  // check exist a manager can consume this address.
   val legal_address = manager.findSafe(io.paddr).reduce(_||_)
   // check utility to help check SoC property.
   def fastCheck(member: TLManagerParameters => Boolean) =

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -11,21 +11,21 @@ import org.chipsalliance.diplomacy.lazymodule._
 import freechips.rocketchip.diplomacy.{AddressSet, RegionType, TransferSizes}
 import freechips.rocketchip.resources.{SimpleDevice}
 
-import freechips.rocketchip.tilelink.{TLManagerNode, TLSlavePortParameters, TLSlaveParameters, TLBundleA, TLMessages, TLAtomics}
+import freechips.rocketchip.tilelink.{TLManagerNode, TLManagerPortParameters, TLManagerParameters, TLBundleA, TLMessages, TLAtomics}
 
 import freechips.rocketchip.util.UIntIsOneOf
 import freechips.rocketchip.util.DataToAugmentedData
 
 /* This adapter converts between diplomatic TileLink and non-diplomatic HellaCacheIO */
-class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) extends LazyModule {
+class ScratchpadManagerPort(address: Seq[AddressSet], coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) extends LazyModule {
   def this(address: AddressSet, coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) = {
     this(Seq(address), coreDataBytes, usingAtomics)
   }
 
   val device = new SimpleDevice("dtim", Seq("sifive,dtim0"))
 
-  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
-    Seq(TLSlaveParameters.v1(
+  val node = TLManagerNode(Seq(TLManagerPortParameters.v1(
+    Seq(TLManagerParameters.v1(
       address            = address,
       resources          = device.reg("mem"),
       regionType         = RegionType.IDEMPOTENT,
@@ -45,7 +45,7 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
       val dmem = new HellaCacheIO
     })
 
-    require(coreDataBytes * 8 == io.dmem.resp.bits.data.getWidth, "ScratchpadSlavePort is misconfigured: coreDataBytes must match D$ data width")
+    require(coreDataBytes * 8 == io.dmem.resp.bits.data.getWidth, "ScratchpadManagerPort is misconfigured: coreDataBytes must match D$ data width")
 
     val (tl_in, edge) = node.in(0)
 

--- a/src/main/scala/subsystem/BankedCoherenceParams.scala
+++ b/src/main/scala/subsystem/BankedCoherenceParams.scala
@@ -81,10 +81,10 @@ object CoherenceManagerWrapper {
   def broadcastManagerFn(
     name: String,
     location: HierarchicalLocation,
-    controlPortsSlaveWhere: TLBusWrapperLocation
+    controlPortsManagerWhere: TLBusWrapperLocation
   ): CoherenceManagerInstantiationFn = { context =>
     implicit val p = context.p
-    val cbus = context.locateTLBusWrapper(controlPortsSlaveWhere)
+    val cbus = context.locateTLBusWrapper(controlPortsManagerWhere)
 
     val BroadcastParams(nTrackers, bufferless, controlAddress, filterFactory) = p(BroadcastKey)
     val bh = LazyModule(new TLBroadcast(TLBroadcastParams(

--- a/src/main/scala/subsystem/BusTopology.scala
+++ b/src/main/scala/subsystem/BusTopology.scala
@@ -104,10 +104,10 @@ case class CoherentBusTopologyParams(
     (MBUS, mbus),
     (COH, CoherenceManagerWrapperParams(mbus.blockBytes, mbus.beatBytes, coherence.nBanks, COH.name)(coherence.coherenceManager)))),
   connections = if (coherence.nBanks == 0) Nil else List(
-    (SBUS, COH,   TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_STAR)()),
+    (SBUS, COH,   TLBusWrapperConnection(driveClockFromClient = Some(true), nodeBinding = BIND_STAR)()),
     (COH,  MBUS,  TLBusWrapperConnection.crossTo(
       xType = sbusToMbusXType,
-      driveClockFromMaster = if (driveMBusClockFromSBus) Some(true) else None,
+      driveClockFromClient = if (driveMBusClockFromSBus) Some(true) else None,
       nodeBinding = BIND_QUERY))
   )
 )
@@ -124,10 +124,10 @@ case class ClusterBusTopologyParams(
     (CMBUS(clusterId), csbus),
     (CCOH (clusterId), CoherenceManagerWrapperParams(csbus.blockBytes, csbus.beatBytes, coherence.nBanks, CCOH(clusterId).name)(coherence.coherenceManager)))),
   connections = if (coherence.nBanks == 0) Nil else List(
-    (CSBUS(clusterId), CCOH (clusterId), TLBusWrapperConnection(driveClockFromMaster = Some(true), nodeBinding = BIND_STAR)()),
+    (CSBUS(clusterId), CCOH (clusterId), TLBusWrapperConnection(driveClockFromClient = Some(true), nodeBinding = BIND_STAR)()),
     (CCOH (clusterId), CMBUS(clusterId), TLBusWrapperConnection.crossTo(
       xType = NoCrossing,
-      driveClockFromMaster = Some(true),
+      driveClockFromClient = Some(true),
       nodeBinding = BIND_QUERY))
   )
 )

--- a/src/main/scala/subsystem/Cluster.scala
+++ b/src/main/scala/subsystem/Cluster.scala
@@ -52,8 +52,8 @@ class Cluster(
   csbus.clockGroupNode := allClockGroupsNode
   ccbus.clockGroupNode := allClockGroupsNode
 
-  val slaveNode = ccbus.inwardNode
-  val masterNode = cmbus.outwardNode
+  val managerNode = ccbus.inwardNode
+  val clientNode = cmbus.outwardNode
 
 
 
@@ -117,8 +117,8 @@ trait CanAttachCluster {
   }
 
   def connect(domain: ClusterPRCIDomain, context: ClusterContextType): Unit = {
-    connectMasterPorts(domain, context)
-    connectSlavePorts(domain, context)
+    connectClientPorts(domain, context)
+    connectManagerPorts(domain, context)
     connectInterrupts(domain, context)
     connectPRC(domain, context)
     connectOutputNotifications(domain, context)
@@ -126,18 +126,18 @@ trait CanAttachCluster {
     connectTrace(domain, context)
   }
 
-  def connectMasterPorts(domain: ClusterPRCIDomain, context: Attachable): Unit = {
+  def connectClientPorts(domain: ClusterPRCIDomain, context: Attachable): Unit = {
     implicit val p = context.p
-    val dataBus = context.locateTLBusWrapper(crossingParams.master.where)
+    val dataBus = context.locateTLBusWrapper(crossingParams.client.where)
     dataBus.coupleFrom(clusterParams.baseName) { bus =>
-      bus :=* crossingParams.master.injectNode(context) :=* domain.crossMasterPort(crossingParams.crossingType)
+      bus :=* crossingParams.client.injectNode(context) :=* domain.crossClientPort(crossingParams.crossingType)
     }
   }
-  def connectSlavePorts(domain: ClusterPRCIDomain, context: Attachable): Unit = {
+  def connectManagerPorts(domain: ClusterPRCIDomain, context: Attachable): Unit = {
     implicit val p = context.p
-    val controlBus = context.locateTLBusWrapper(crossingParams.slave.where)
+    val controlBus = context.locateTLBusWrapper(crossingParams.manager.where)
     controlBus.coupleTo(clusterParams.baseName) { bus =>
-      domain.crossSlavePort(crossingParams.crossingType) :*= crossingParams.slave.injectNode(context) :*= TLWidthWidget(controlBus.beatBytes) :*= bus
+      domain.crossManagerPort(crossingParams.crossingType) :*= crossingParams.manager.injectNode(context) :*= TLWidthWidget(controlBus.beatBytes) :*= bus
     }
   }
   def connectInterrupts(domain: ClusterPRCIDomain, context: ClusterContextType): Unit = {

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -195,9 +195,9 @@ class WithRoccExample extends Config((site, here, up) => {
 class WithIncoherentTiles extends Config((site, here, up) => {
   case TilesLocated(location) => up(TilesLocated(location), site) map {
     case tp: RocketTileAttachParams => tp.copy(crossingParams = tp.crossingParams.copy(
-      master = tp.crossingParams.master match {
-        case x: HierarchicalElementMasterPortParams => x.copy(cork = Some(true))
-        case _ => throw new Exception("Unrecognized type for RocketCrossingParams.master")
+      client = tp.crossingParams.client match {
+        case x: HierarchicalElementClientPortParams => x.copy(cork = Some(true))
+        case _ => throw new Exception("Unrecognized type for RocketCrossingParams.client")
       }))
     case t => t
   }
@@ -229,7 +229,7 @@ class WithDebugAPB extends Config ((site, here, up) => {
 
 
 class WithDebugSBA extends Config ((site, here, up) => {
-  case DebugModuleKey => up(DebugModuleKey, site).map(_.copy(hasBusMaster = true))
+  case DebugModuleKey => up(DebugModuleKey, site).map(_.copy(hasBusDriver = true))
 })
 
 class WithNBitPeripheryBus(nBits: Int) extends Config ((site, here, up) => {
@@ -249,7 +249,7 @@ class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {
 })
 
 class WithExtMemSize(n: BigInt) extends Config((site, here, up) => {
-  case ExtMem => up(ExtMem, site).map(x => x.copy(master = x.master.copy(size = n)))
+  case ExtMem => up(ExtMem, site).map(x => x.copy(client = x.client.copy(size = n)))
 })
 
 class WithExtMemSbusBypass(base: BigInt = x"10_0000_0000") extends Config((site, here, up) => {
@@ -266,7 +266,7 @@ class WithTimebase(hertz: BigInt) extends Config((site, here, up) => {
 })
 
 class WithDefaultMemPort extends Config((site, here, up) => {
-  case ExtMem => Some(MemoryPortParams(MasterPortParams(
+  case ExtMem => Some(MemoryPortParams(ClientPortParams(
                       base = x"8000_0000",
                       size = x"1000_0000",
                       beatBytes = site(MemoryBusKey).beatBytes,
@@ -274,7 +274,7 @@ class WithDefaultMemPort extends Config((site, here, up) => {
 })
 
 class WithCustomMemPort (base_addr: BigInt, base_size: BigInt, data_width: Int, id_bits: Int, maxXferBytes: Int) extends Config((site, here, up) => {
-  case ExtMem => Some(MemoryPortParams(MasterPortParams(
+  case ExtMem => Some(MemoryPortParams(ClientPortParams(
                       base = base_addr,
                       size = base_size,
                       beatBytes = data_width/8,
@@ -287,7 +287,7 @@ class WithNoMemPort extends Config((site, here, up) => {
 })
 
 class WithDefaultMMIOPort extends Config((site, here, up) => {
-  case ExtBus => Some(MasterPortParams(
+  case ExtBus => Some(ClientPortParams(
                       base = x"6000_0000",
                       size = x"2000_0000",
                       beatBytes = site(MemoryBusKey).beatBytes,
@@ -295,7 +295,7 @@ class WithDefaultMMIOPort extends Config((site, here, up) => {
 })
 
 class WithCustomMMIOPort (base_addr: BigInt, base_size: BigInt, data_width: Int, id_bits: Int, maxXferBytes: Int) extends Config((site, here, up) => {
-  case ExtBus => Some(MasterPortParams(
+  case ExtBus => Some(ClientPortParams(
                       base = base_addr,
                       size = base_size,
                       beatBytes = data_width/8,
@@ -307,15 +307,15 @@ class WithNoMMIOPort extends Config((site, here, up) => {
   case ExtBus => None
 })
 
-class WithDefaultSlavePort extends Config((site, here, up) => {
-  case ExtIn  => Some(SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4))
+class WithDefaultManagerPort extends Config((site, here, up) => {
+  case ExtIn  => Some(ManagerPortParams(beatBytes = 8, idBits = 8, sourceBits = 4))
 })
 
-class WithCustomSlavePort (data_width: Int, id_bits: Int) extends Config((site, here, up) => {
-  case ExtIn  => Some(SlavePortParams(beatBytes = data_width/8, idBits = id_bits, sourceBits = 4))
+class WithCustomManagerPort (data_width: Int, id_bits: Int) extends Config((site, here, up) => {
+  case ExtIn  => Some(ManagerPortParams(beatBytes = data_width/8, idBits = id_bits, sourceBits = 4))
 })
 
-class WithNoSlavePort extends Config((site, here, up) => {
+class WithNoManagerPort extends Config((site, here, up) => {
   case ExtIn => None
 })
 

--- a/src/main/scala/subsystem/HasHierarchicalElements.scala
+++ b/src/main/scala/subsystem/HasHierarchicalElements.scala
@@ -22,10 +22,10 @@ import freechips.rocketchip.util.TraceCoreInterface
 
 import scala.collection.immutable.SortedMap
 
-/** A default implementation of parameterizing the connectivity of the port where the tile is the master.
+/** A default implementation of parameterizing the connectivity of the port where the tile is the client.
   *   Optional timing buffers and/or an optional CacheCork can be inserted in the interconnect's clock domain.
   */
-case class HierarchicalElementMasterPortParams(
+case class HierarchicalElementClientPortParams(
   buffers: Int = 0,
   cork: Option[Boolean] = None,
   where: TLBusWrapperLocation = SBUS
@@ -35,17 +35,17 @@ case class HierarchicalElementMasterPortParams(
   }
 }
 
-object HierarchicalElementMasterPortParams {
+object HierarchicalElementClientPortParams {
   def locationDefault(loc: HierarchicalLocation) = loc match {
-    case InSubsystem => HierarchicalElementMasterPortParams()
-    case InCluster(clusterId) => HierarchicalElementMasterPortParams(where=CSBUS(clusterId))
+    case InSubsystem => HierarchicalElementClientPortParams()
+    case InCluster(clusterId) => HierarchicalElementClientPortParams(where=CSBUS(clusterId))
   }
 }
 
-/** A default implementation of parameterizing the connectivity of the port giving access to slaves inside the tile.
+/** A default implementation of parameterizing the connectivity of the port giving access to managers inside the tile.
   *   Optional timing buffers and/or an optional BusBlocker adapter can be inserted in the interconnect's clock domain.
   */
-case class HierarchicalElementSlavePortParams(
+case class HierarchicalElementManagerPortParams(
   buffers: Int = 0,
   blockerCtrlAddr: Option[BigInt] = None,
   blockerCtrlWhere: TLBusWrapperLocation = CBUS,
@@ -58,16 +58,16 @@ case class HierarchicalElementSlavePortParams(
       .map { BasicBusBlockerParams(_, blockerBus.beatBytes, controlBus.beatBytes) }
       .map { bbbp =>
         val blocker = LazyModule(new BasicBusBlocker(bbbp))
-        blockerBus.coupleTo("tile_slave_port_bus_blocker") { blocker.controlNode := TLFragmenter(blockerBus) := _ }
+        blockerBus.coupleTo("tile_manager_port_bus_blocker") { blocker.controlNode := TLFragmenter(blockerBus) := _ }
         blocker.node :*= TLBuffer.chainNode(buffers)
       } .getOrElse { TLBuffer.chainNode(buffers) }
   }
 }
 
-object HierarchicalElementSlavePortParams {
+object HierarchicalElementManagerPortParams {
   def locationDefault(loc: HierarchicalLocation) = loc match {
-    case InSubsystem => HierarchicalElementSlavePortParams()
-    case InCluster(clusterId) => HierarchicalElementSlavePortParams(where=CCBUS(clusterId), blockerCtrlWhere=CCBUS(clusterId))
+    case InSubsystem => HierarchicalElementManagerPortParams()
+    case InCluster(clusterId) => HierarchicalElementManagerPortParams(where=CCBUS(clusterId), blockerCtrlWhere=CCBUS(clusterId))
   }
 }
 

--- a/src/main/scala/subsystem/HierarchicalElement.scala
+++ b/src/main/scala/subsystem/HierarchicalElement.scala
@@ -25,10 +25,10 @@ abstract class InstantiableHierarchicalElementParams[ElementType <: BaseHierarch
 trait HierarchicalElementCrossingParamsLike {
   /** The type of clock crossing that should be inserted at the element boundary. */
   def crossingType: ClockCrossingType
-  /** Parameters describing the contents and behavior of the point where the element is attached as an interconnect master. */
-  def master: HierarchicalElementPortParamsLike
-  /** Parameters describing the contents and behavior of the point where the element is attached as an interconnect slave. */
-  def slave: HierarchicalElementPortParamsLike
+  /** Parameters describing the contents and behavior of the point where the element is attached as an interconnect client. */
+  def client: HierarchicalElementPortParamsLike
+  /** Parameters describing the contents and behavior of the point where the element is attached as an interconnect manager. */
+  def manager: HierarchicalElementPortParamsLike
   /** The subnetwork location of the device selecting the apparent base address of MMIO devices inside the element */
   def mmioBaseAddressPrefixWhere: TLBusWrapperLocation
   /** Inject a reset management subgraph that effects the element child reset only */
@@ -51,29 +51,29 @@ abstract class BaseHierarchicalElement (val crossing: ClockCrossingType)(implici
 {
   def module: BaseHierarchicalElementModuleImp[BaseHierarchicalElement]
 
-  protected val tlOtherMastersNode = TLIdentityNode()
-  protected val tlMasterXbar = LazyModule(new TLXbar(nameSuffix = Some(s"MasterXbar_$desiredName")))
-  protected val tlSlaveXbar = LazyModule(new TLXbar(nameSuffix = Some(s"SlaveXbar_$desiredName")))
+  protected val tlOtherClientsNode = TLIdentityNode()
+  protected val tlClientXbar = LazyModule(new TLXbar(nameSuffix = Some(s"ClientXbar_$desiredName")))
+  protected val tlManagerXbar = LazyModule(new TLXbar(nameSuffix = Some(s"ManagerXbar_$desiredName")))
   protected val intXbar = LazyModule(new IntXbar)
 
-  def masterNode: TLOutwardNode
-  def slaveNode: TLInwardNode
+  def clientNode: TLOutwardNode
+  def managerNode: TLInwardNode
 
-  /** Helper function to insert additional buffers on master ports at the boundary of the tile.
+  /** Helper function to insert additional buffers on client ports at the boundary of the tile.
     *
     * The boundary buffering needed to cut feed-through paths is
     * microarchitecture specific, so this may need to be overridden
     * in subclasses of this class.
     */
-  def makeMasterBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = TLBuffer(BufferParams.none)
+  def makeClientBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = TLBuffer(BufferParams.none)
 
-  /** Helper function to insert additional buffers on slave ports at the boundary of the tile.
+  /** Helper function to insert additional buffers on manager ports at the boundary of the tile.
     *
     * The boundary buffering needed to cut feed-through paths is
     * microarchitecture specific, so this may need to be overridden
     * in subclasses of this class.
     */
-  def makeSlaveBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = TLBuffer(BufferParams.none)
+  def makeManagerBoundaryBuffers(crossing: ClockCrossingType)(implicit p: Parameters) = TLBuffer(BufferParams.none)
 
 
 }

--- a/src/main/scala/subsystem/HierarchicalElementPRCIDomain.scala
+++ b/src/main/scala/subsystem/HierarchicalElementPRCIDomain.scala
@@ -74,27 +74,27 @@ abstract class HierarchicalElementPRCIDomain[T <: BaseHierarchicalElement](
     intOutClockXing(crossingType)
   }
 
-  /** External code looking to connect the ports where this tile is slaved to an interconnect
+  /** External code looking to connect the ports where this tile is managerd to an interconnect
     * (while also crossing clock domains) can call this.
     */
-  def crossSlavePort(crossingType: ClockCrossingType): TLInwardNode = { DisableMonitors { implicit p => FlipRendering { implicit p =>
-    val tlSlaveResetXing = this {
-      element_reset_domain.crossTLIn(element.slaveNode) :*=
-        element { element.makeSlaveBoundaryBuffers(crossingType) }
+  def crossManagerPort(crossingType: ClockCrossingType): TLInwardNode = { DisableMonitors { implicit p => FlipRendering { implicit p =>
+    val tlManagerResetXing = this {
+      element_reset_domain.crossTLIn(element.managerNode) :*=
+        element { element.makeManagerBoundaryBuffers(crossingType) }
     }
-    val tlSlaveClockXing = this.crossIn(tlSlaveResetXing)
-    tlSlaveClockXing(crossingType)
+    val tlManagerClockXing = this.crossIn(tlManagerResetXing)
+    tlManagerClockXing(crossingType)
   } } }
 
-  /** External code looking to connect the ports where this tile masters an interconnect
+  /** External code looking to connect the ports where this tile clients an interconnect
     * (while also crossing clock domains) can call this.
     */
-  def crossMasterPort(crossingType: ClockCrossingType): TLOutwardNode = {
-    val tlMasterResetXing = this { DisableMonitors { implicit p =>
-      element { element.makeMasterBoundaryBuffers(crossingType) } :=*
-        element_reset_domain.crossTLOut(element.masterNode)
+  def crossClientPort(crossingType: ClockCrossingType): TLOutwardNode = {
+    val tlClientResetXing = this { DisableMonitors { implicit p =>
+      element { element.makeClientBoundaryBuffers(crossingType) } :=*
+        element_reset_domain.crossTLOut(element.clientNode)
     } }
-    val tlMasterClockXing = this.crossOut(tlMasterResetXing)
-    tlMasterClockXing(crossingType)
+    val tlClientClockXing = this.crossOut(tlClientResetXing)
+    tlClientClockXing(crossingType)
   }
 }

--- a/src/main/scala/subsystem/RTC.scala
+++ b/src/main/scala/subsystem/RTC.scala
@@ -15,7 +15,7 @@ trait HasRTCModuleImp extends LazyRawModuleImp {
 
   // Use the static period to toggle the RTC
   outer.clintDomainOpt.map { domain => {
-    val bus = outer.locateTLBusWrapper(p(CLINTAttachKey).slaveWhere)
+    val bus = outer.locateTLBusWrapper(p(CLINTAttachKey).managerWhere)
     val busFreq = bus.dtsFrequency.get
     val rtcFreq = outer.p(DTSTimebase)
     val internalPeriod: BigInt = busFreq / rtcFreq

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -12,8 +12,8 @@ import freechips.rocketchip.util.HasCoreMonitorBundles
 
 case class RocketCrossingParams(
   crossingType: ClockCrossingType = SynchronousCrossing(),
-  master: HierarchicalElementPortParamsLike = HierarchicalElementMasterPortParams(),
-  slave: HierarchicalElementSlavePortParams = HierarchicalElementSlavePortParams(),
+  client: HierarchicalElementPortParamsLike = HierarchicalElementClientPortParams(),
+  manager: HierarchicalElementManagerPortParams = HierarchicalElementManagerPortParams(),
   mmioBaseAddressPrefixWhere: TLBusWrapperLocation = CBUS,
   resetCrossingType: ResetCrossingType = NoResetCrossing(),
   forceSeparateClockReset: Boolean = false

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -14,7 +14,7 @@ class WithDebugAPB extends freechips.rocketchip.subsystem.WithDebugAPB
 class BaseConfig extends Config(
   new WithDefaultMemPort ++
   new WithDefaultMMIOPort ++
-  new WithDefaultSlavePort ++
+  new WithDefaultManagerPort ++
   new WithTimebase(BigInt(1000000)) ++ // 1 MHz
   new WithDTS("freechips,rocketchip-unknown", Nil) ++
   new WithNExtTopInterrupts(2) ++
@@ -86,12 +86,12 @@ class TinyConfig extends Config(
 
 class MemPortOnlyConfig extends Config(
   new WithNoMMIOPort ++
-  new WithNoSlavePort ++
+  new WithNoManagerPort ++
   new DefaultConfig
 )
 
 class MMIOPortOnlyConfig extends Config(
-  new WithNoSlavePort ++
+  new WithNoManagerPort ++
   new WithNoMemPort ++
   new WithNMemoryChannels(0) ++
   new WithNBanks(0) ++

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -10,9 +10,9 @@ import freechips.rocketchip.util.DontTouch
 /** Example Top with periphery devices and ports, and a Rocket subsystem */
 class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
     with HasAsyncExtInterrupts
-    with CanHaveMasterAXI4MemPort
-    with CanHaveMasterAXI4MMIOPort
-    with CanHaveSlaveAXI4Port
+    with CanHaveManagerAXI4MemPort
+    with CanHaveManagerAXI4MMIOPort
+    with CanHaveSubordinateAXI4Port
 {
   // optionally add ROM devices
   // Note that setting BootROMLocated will override the reset_vector for all tiles

--- a/src/main/scala/system/SimAXIMem.scala
+++ b/src/main/scala/system/SimAXIMem.scala
@@ -8,21 +8,21 @@ import org.chipsalliance.cde.config._
 import org.chipsalliance.diplomacy.lazymodule._
 
 import freechips.rocketchip.amba.AMBACorrupt
-import freechips.rocketchip.amba.axi4.{AXI4RAM, AXI4MasterNode, AXI4EdgeParameters, AXI4Xbar, AXI4Buffer, AXI4Fragmenter}
+import freechips.rocketchip.amba.axi4.{AXI4RAM, AXI4ManagerNode, AXI4EdgeParameters, AXI4Xbar, AXI4Buffer, AXI4Fragmenter}
 import freechips.rocketchip.diplomacy.AddressSet
-import freechips.rocketchip.subsystem.{CanHaveMasterAXI4MMIOPort, CanHaveMasterAXI4MemPort, ExtBus, ExtMem}
+import freechips.rocketchip.subsystem.{CanHaveManagerAXI4MMIOPort, CanHaveManagerAXI4MemPort, ExtBus, ExtMem}
 
 /** Memory with AXI port for use in elaboratable test harnesses.
  * 
- * Topology: AXIRAM <-< AXI4Buffer <-< AXI4Fragmenter <-< AXI4Xbar <-< AXI4MasterNode
+ * Topology: AXIRAM <-< AXI4Buffer <-< AXI4Fragmenter <-< AXI4Xbar <-< AXI4ManagerNode
 */
 class SimAXIMem(edge: AXI4EdgeParameters, size: BigInt, base: BigInt = 0)(implicit p: Parameters) extends SimpleLazyModule {
-  val node = AXI4MasterNode(List(edge.master))
+  val node = AXI4ManagerNode(List(edge.manager))
   val srams = AddressSet.misaligned(base, size).map { aSet =>
     LazyModule(new AXI4RAM(
       address = aSet,
       beatBytes = edge.bundle.dataBits/8,
-      wcorrupt=edge.slave.requestKeys.contains(AMBACorrupt)))
+      wcorrupt=edge.subordinate.requestKeys.contains(AMBACorrupt)))
   }
   val xbar = AXI4Xbar()
   srams.foreach{ s => s.node := AXI4Buffer() := AXI4Fragmenter() := xbar }
@@ -31,12 +31,12 @@ class SimAXIMem(edge: AXI4EdgeParameters, size: BigInt, base: BigInt = 0)(implic
 }
 
 /**
-  * Connect Master AXI4 Mem/MMIO Port to SimAXIMem.
+  * Connect Manager AXI4 Mem/MMIO Port to SimAXIMem.
   */
 object SimAXIMem {
-  def connectMMIO(dut: CanHaveMasterAXI4MMIOPort)(implicit p: Parameters): Seq[SimAXIMem] = {
+  def connectMMIO(dut: CanHaveManagerAXI4MMIOPort)(implicit p: Parameters): Seq[SimAXIMem] = {
     dut.mmio_axi4.zip(dut.mmioAXI4Node.in).map { case (io, (_, edge)) =>
-      // test harness size capped to 4KB (ignoring p(ExtMem).get.master.size)
+      // test harness size capped to 4KB (ignoring p(ExtMem).get.manager.size)
       val mmio_mem = LazyModule(new SimAXIMem(edge, base = p(ExtBus).get.base, size = 4096))
       Module(mmio_mem.module).suggestName("mmio_mem")
       mmio_mem.io_axi4.head <> io
@@ -44,9 +44,9 @@ object SimAXIMem {
     }.toSeq
   }
 
-  def connectMem(dut: CanHaveMasterAXI4MemPort)(implicit p: Parameters): Seq[SimAXIMem] = {
+  def connectMem(dut: CanHaveManagerAXI4MemPort)(implicit p: Parameters): Seq[SimAXIMem] = {
     dut.mem_axi4.zip(dut.memAXI4Node.in).map { case (io, (_, edge)) =>
-      val mem = LazyModule(new SimAXIMem(edge, base = p(ExtMem).get.master.base, size = p(ExtMem).get.master.size))
+      val mem = LazyModule(new SimAXIMem(edge, base = p(ExtMem).get.client.base, size = p(ExtMem).get.client.size))
       Module(mem.module).suggestName("mem")
       mem.io_axi4.head <> io
       mem

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -15,7 +15,7 @@ import freechips.rocketchip.rocket.{
   SimpleHellaCacheIF, M_XRD, PTE, PRV, M_SZ
 }
 import freechips.rocketchip.tilelink.{
-  TLNode, TLIdentityNode, TLClientNode, TLMasterParameters, TLMasterPortParameters
+  TLNode, TLIdentityNode, TLClientNode, TLClientParameters, TLClientPortParameters
 }
 import freechips.rocketchip.util.InOrderArbiter
 
@@ -86,9 +86,9 @@ trait HasLazyRoCC extends CanHavePTW { this: BaseTile =>
   val roccCSRs = roccs.map(_.roccCSRs) // the set of custom CSRs requested by all roccs
   require(roccCSRs.flatten.map(_.id).toSet.size == roccCSRs.flatten.size,
     "LazyRoCC instantiations require overlapping CSRs")
-  roccs.map(_.atlNode).foreach { atl => tlMasterXbar.node :=* atl }
-  roccs.map(_.tlNode).foreach { tl => tlOtherMastersNode :=* tl }
-  roccs.map(_.stlNode).foreach { stl => stl :*= tlSlaveXbar.node }
+  roccs.map(_.atlNode).foreach { atl => tlClientXbar.node :=* atl }
+  roccs.map(_.tlNode).foreach { tl => tlOtherClientsNode :=* tl }
+  roccs.map(_.stlNode).foreach { stl => stl :*= tlManagerXbar.node }
 
   nPTWPorts += roccs.map(_.nPTWPorts).sum
   nDCachePorts += roccs.size
@@ -236,7 +236,7 @@ class TranslatorExampleModuleImp(outer: TranslatorExample)(implicit p: Parameter
 
 class  CharacterCountExample(opcodes: OpcodeSet)(implicit p: Parameters) extends LazyRoCC(opcodes) {
   override lazy val module = new CharacterCountExampleModuleImp(this)
-  override val atlNode = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1("CharacterCountRoCC")))))
+  override val atlNode = TLClientNode(Seq(TLClientPortParameters.v1(Seq(TLClientParameters.v1("CharacterCountRoCC")))))
 }
 
 class CharacterCountExampleModuleImp(outer: CharacterCountExample)(implicit p: Parameters) extends LazyRoCCModuleImp(outer)

--- a/src/main/scala/tilelink/AtomicAutomata.scala
+++ b/src/main/scala/tilelink/AtomicAutomata.scala
@@ -66,7 +66,7 @@ class TLAtomicAutomata(logical: Boolean = true, arithmetic: Boolean = true, conc
       // Don't overprovision the CAM
       val camSize = min(domainsNeedingHelp.size, concurrency)
       // Compact the fifoIds to only those we care about
-      def camFifoId(m: TLSlaveParameters) = m.fifoId.map(id => max(0, domainsNeedingHelp.indexOf(id))).getOrElse(0)
+      def camFifoId(m: TLManagerParameters) = m.fifoId.map(id => max(0, domainsNeedingHelp.indexOf(id))).getOrElse(0)
 
       // CAM entry state machine
       val FREE = 0.U // unused                   waiting on Atomic from A

--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -23,7 +23,7 @@ case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCus
     (iStar, oStar)
   }
 
-  def mapParamsD(n: Int, p: Seq[TLMasterPortParameters]): Seq[TLMasterPortParameters] =
+  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] =
     (p zip ids) map { case (cp, id) => cp.v1copy(clients = cp.clients.map { c => c.v1copy(
       visibility         = c.visibility.flatMap { a => a.intersect(AddressSet(id, ~mask))},
       supportsProbe      = c.supports.probe      intersect maxXfer,
@@ -34,7 +34,7 @@ case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCus
       supportsPutPartial = c.supports.putPartial intersect maxXfer,
       supportsHint       = c.supports.hint       intersect maxXfer)})}
 
-  def mapParamsU(n: Int, p: Seq[TLSlavePortParameters]): Seq[TLSlavePortParameters] =
+  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] =
     (p zip ids) map { case (mp, id) => mp.v1copy(managers = mp.managers.flatMap { m =>
       val addresses = m.address.flatMap(a => a.intersect(AddressSet(id, ~mask)))
       if (addresses.nonEmpty)

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -42,7 +42,7 @@ class TLBroadcast(params: TLBroadcastParams)(implicit p: Parameters) extends Laz
 
   val node = TLAdapterNode(
     clientFn  = { cp =>
-      cp.v1copy(clients = Seq(TLMasterParameters.v1(
+      cp.v1copy(clients = Seq(TLClientParameters.v1(
         name     = "TLBroadcast",
         sourceId = IdRange(0, 1 << log2Ceil(cp.endSourceId*4)))))
     },
@@ -304,7 +304,7 @@ class TLBroadcast(params: TLBroadcastParams)(implicit p: Parameters) extends Laz
 // addressMask is set for those bits which can actually toggle in an address; ie:
 //   - offset bits are 0
 //   - bank bits are 0
-//   - bits unused by any actual slave are 0
+//   - bits unused by any actual manager are 0
 case class ProbeFilterParams(mshrs: Int, caches: Int, maxAddress: BigInt, addressMask: BigInt)
 {
   require (mshrs >= 0)

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -68,7 +68,7 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
         // The CacheCork can potentially send the same source twice if a client sends
         // simultaneous Release and AMO/Get with the same source. It will still correctly
         // decode the messages based on the D.opcode, but the double use violates the spec.
-        // Fortunately, no masters we know of behave this way!
+        // Fortunately, no clients we know of behave this way!
 
         // Take requests from A to A or D (if BtoT Acquire)
         val a_a = Wire(chiselTypeOf(out.a))

--- a/src/main/scala/tilelink/FIFOFixer.scala
+++ b/src/main/scala/tilelink/FIFOFixer.scala
@@ -14,7 +14,7 @@ import freechips.rocketchip.util.property
 
 class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Parameters) extends LazyModule
 {
-  private def fifoMap(seq: Seq[TLSlaveParameters]) = {
+  private def fifoMap(seq: Seq[TLManagerParameters]) = {
     val (flatManagers, keepManagers) = seq.partition(policy)
     // We need to be careful if one flatManager and one keepManager share an existing domain
     // Erring on the side of caution, we will also flatten the keepManager in this case
@@ -138,9 +138,9 @@ class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Para
 
 object TLFIFOFixer
 {
-  // Which slaves should have their FIFOness combined?
-  // NOTE: this transformation is still only applied for masters with requestFifo
-  type Policy = TLSlaveParameters => Boolean
+  // Which managers should have their FIFOness combined?
+  // NOTE: this transformation is still only applied for clients with requestFifo
+  type Policy = TLManagerParameters => Boolean
   import RegionType._
 
   val all:            Policy = m => true

--- a/src/main/scala/tilelink/Filter.scala
+++ b/src/main/scala/tilelink/Filter.scala
@@ -76,8 +76,8 @@ class TLFilter(
 
 object TLFilter
 {
-  type ManagerFilter = TLSlaveParameters => Option[TLSlaveParameters]
-  type ClientFilter = TLMasterParameters => Option[TLMasterParameters]
+  type ManagerFilter = TLManagerParameters => Option[TLManagerParameters]
+  type ClientFilter = TLClientParameters => Option[TLClientParameters]
 
   // preserve manager visibility
   def mIdentity: ManagerFilter = { m => Some(m) }
@@ -103,7 +103,7 @@ object TLFilter
   }
 
   // adjust supported transfer sizes based on filtered intersection
-  private def transferSizeHelper(m: TLSlaveParameters, filtered: Seq[AddressSet], alignment: BigInt): Option[TLSlaveParameters] = {
+  private def transferSizeHelper(m: TLManagerParameters, filtered: Seq[AddressSet], alignment: BigInt): Option[TLManagerParameters] = {
     val maxTransfer = 1 << 30
     val capTransfer = if (alignment == 0 || alignment > maxTransfer) maxTransfer else alignment.toInt
     val cap = TransferSizes(1, capTransfer)

--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -101,18 +101,18 @@ class TLFuzzer(
     require(n > 0, s"nOrdered must be > 0, not $n")
     require((inFlight % n) == 0, s"inFlight (${inFlight}) must be evenly divisible by nOrdered (${nOrdered}).")
     Seq.tabulate(n) {i =>
-      TLMasterParameters.v1(name =s"OrderedFuzzer$i",
+      TLClientParameters.v1(name =s"OrderedFuzzer$i",
         sourceId = IdRange(i * (inFlight/n),  (i + 1)*(inFlight/n)),
         requestFifo = true)
     }
   } else {
-    Seq(TLMasterParameters.v1(
+    Seq(TLClientParameters.v1(
       name = "Fuzzer",
       sourceId = IdRange(0,inFlight)
     ))
   }
 
-  val node = TLClientNode(Seq(TLMasterPortParameters.v1(clientParams)))
+  val node = TLClientNode(Seq(TLClientPortParameters.v1(clientParams)))
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {

--- a/src/main/scala/tilelink/HintHandler.scala
+++ b/src/main/scala/tilelink/HintHandler.scala
@@ -37,8 +37,8 @@ class TLHintHandler(passthrough: Boolean = true)(implicit p: Parameters) extends
       }
 
       val isHint = in.a.bits.opcode === TLMessages.Hint
-      def usePP (m: TLSlaveParameters) = !(passthrough && m.supportsHint) && m.supportsPutPartial
-      def useGet(m: TLSlaveParameters) = !(passthrough && m.supportsHint) && !m.supportsPutPartial
+      def usePP (m: TLManagerParameters) = !(passthrough && m.supportsHint) && m.supportsPutPartial
+      def useGet(m: TLManagerParameters) = !(passthrough && m.supportsHint) && !m.supportsPutPartial
 
       // Does the HintHandler help using PutPartial with this message?
       val helpPP = isHint && edgeOut.manager.fastProperty(in.a.bits.address, usePP, (b:Boolean) => b.B)

--- a/src/main/scala/tilelink/Map.scala
+++ b/src/main/scala/tilelink/Map.scala
@@ -9,8 +9,8 @@ import org.chipsalliance.diplomacy.lazymodule._
 
 import freechips.rocketchip.diplomacy.AddressSet
 
-// Moves the AddressSets of slave devices around
-// Combine with TLFilter to remove slaves or reduce their size
+// Moves the AddressSets of manager devices around
+// Combine with TLFilter to remove managers or reduce their size
 class TLMap(fn: AddressSet => BigInt)(implicit p: Parameters) extends LazyModule
 {
   val node = TLAdapterNode(

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -82,8 +82,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     //The monitor doesn’t check for acquire T vs acquire B, it assumes that acquire B implies acquire T and only checks for acquire B
     //TODO: check for acquireT?
     when (bundle.opcode === TLMessages.AcquireBlock) {
-      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.client.emitsAcquireB(bundle.source, bundle.size) && edge.manager.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.client.supportsProbe(edge.source(bundle), bundle.size) && edge.manager.emitsProbeSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquireBlock carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquireBlock smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquireBlock address not aligned to size" + extra)
@@ -93,8 +93,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.AcquirePerm) {
-      monAssert (edge.master.emitsAcquireB(bundle.source, bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
+      monAssert (edge.client.emitsAcquireB(bundle.source, bundle.size) && edge.manager.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.client.supportsProbe(edge.source(bundle), bundle.size) && edge.manager.emitsProbeSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel AcquirePerm carries invalid source ID" + diplomacyInfo + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'A' channel AcquirePerm smaller than a beat" + extra)
       monAssert (is_aligned, "'A' channel AcquirePerm address not aligned to size" + extra)
@@ -105,8 +105,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      monAssert (edge.master.emitsGet(bundle.source, bundle.size), "'A' channel carries Get type which master claims it can't emit" + diplomacyInfo + extra)
-      monAssert (edge.slave.supportsGetSafe(edge.address(bundle), bundle.size, None), "'A' channel carries Get type which slave claims it can't support" + diplomacyInfo + extra)
+      monAssert (edge.client.emitsGet(bundle.source, bundle.size), "'A' channel carries Get type which client claims it can't emit" + diplomacyInfo + extra)
+      monAssert (edge.manager.supportsGetSafe(edge.address(bundle), bundle.size, None), "'A' channel carries Get type which manager claims it can't support" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel Get carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Get address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel Get carries invalid param" + extra)
@@ -115,7 +115,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.emitsPutFull(bundle.source, bundle.size) && edge.slave.supportsPutFullSafe(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
+      monAssert (edge.client.emitsPutFull(bundle.source, bundle.size) && edge.manager.supportsPutFullSafe(edge.address(bundle), bundle.size), "'A' channel carries PutFull type which is unexpected using diplomatic parameters" + diplomacyInfo + extra)
       monAssert (source_ok, "'A' channel PutFull carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutFull address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutFull carries invalid param" + extra)
@@ -123,7 +123,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.emitsPutPartial(bundle.source, bundle.size) && edge.slave.supportsPutPartialSafe(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.client.emitsPutPartial(bundle.source, bundle.size) && edge.manager.supportsPutPartialSafe(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel PutPartial carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel PutPartial address not aligned to size" + extra)
       monAssert (bundle.param === 0.U, "'A' channel PutPartial carries invalid param" + extra)
@@ -131,7 +131,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.emitsArithmetic(bundle.source, bundle.size) && edge.slave.supportsArithmeticSafe(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.client.emitsArithmetic(bundle.source, bundle.size) && edge.manager.supportsArithmeticSafe(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Arithmetic carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Arithmetic address not aligned to size" + extra)
       monAssert (TLAtomics.isArithmetic(bundle.param), "'A' channel Arithmetic carries invalid opcode param" + extra)
@@ -139,7 +139,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.emitsLogical(bundle.source, bundle.size) && edge.slave.supportsLogicalSafe(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.client.emitsLogical(bundle.source, bundle.size) && edge.manager.supportsLogicalSafe(edge.address(bundle), bundle.size), "'A' channel carries Logical type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Logical carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Logical address not aligned to size" + extra)
       monAssert (TLAtomics.isLogical(bundle.param), "'A' channel Logical carries invalid opcode param" + extra)
@@ -147,7 +147,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.emitsHint(bundle.source, bundle.size) && edge.slave.supportsHintSafe(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.client.emitsHint(bundle.source, bundle.size) && edge.manager.supportsHintSafe(edge.address(bundle), bundle.size), "'A' channel carries Hint type which is unexpected using diplomatic parameters" + extra)
       monAssert (source_ok, "'A' channel Hint carries invalid source ID" + diplomacyInfo + extra)
       monAssert (is_aligned, "'A' channel Hint address not aligned to size" + extra)
       monAssert (TLHints.isHints(bundle.param), "'A' channel Hint carries invalid opcode param" + extra)
@@ -168,7 +168,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     val legal_source = Mux1H(edge.client.find(bundle.source), edge.client.clients.map(c => c.sourceId.start.U)) === bundle.source
 
     when (bundle.opcode === TLMessages.Probe) {
-      assume (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
+      assume (edge.client.supportsProbe(edge.source(bundle), bundle.size) && edge.manager.emitsProbeSafe(edge.address(bundle), bundle.size), "'B' channel carries Probe type which is unexpected using diplomatic parameters" + extra)
       assume (address_ok, "'B' channel Probe carries unmanaged address" + extra)
       assume (legal_source, "'B' channel Probe carries source that is not first source" + extra)
       assume (is_aligned, "'B' channel Probe address not aligned to size" + extra)
@@ -178,7 +178,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      monAssert (edge.master.supportsGet(edge.source(bundle), bundle.size) && edge.slave.emitsGetSafe(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.client.supportsGet(edge.source(bundle), bundle.size) && edge.manager.emitsGetSafe(edge.address(bundle), bundle.size), "'B' channel carries Get type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel Get carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Get carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Get address not aligned to size" + extra)
@@ -188,7 +188,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      monAssert (edge.master.supportsPutFull(edge.source(bundle), bundle.size) && edge.slave.emitsPutFullSafe(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.client.supportsPutFull(edge.source(bundle), bundle.size) && edge.manager.emitsPutFullSafe(edge.address(bundle), bundle.size), "'B' channel carries PutFull type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutFull carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutFull carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutFull address not aligned to size" + extra)
@@ -197,7 +197,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      monAssert (edge.master.supportsPutPartial(edge.source(bundle), bundle.size) && edge.slave.emitsPutPartialSafe(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
+      monAssert (edge.client.supportsPutPartial(edge.source(bundle), bundle.size) && edge.manager.emitsPutPartialSafe(edge.address(bundle), bundle.size), "'B' channel carries PutPartial type which is unexpected using diplomatic parameters" + extra)
       monAssert (address_ok, "'B' channel PutPartial carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel PutPartial carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel PutPartial address not aligned to size" + extra)
@@ -206,7 +206,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      monAssert (edge.master.supportsArithmetic(edge.source(bundle), bundle.size) && edge.slave.emitsArithmeticSafe(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by master" + extra)
+      monAssert (edge.client.supportsArithmetic(edge.source(bundle), bundle.size) && edge.manager.emitsArithmeticSafe(edge.address(bundle), bundle.size), "'B' channel carries Arithmetic type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Arithmetic carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Arithmetic carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Arithmetic address not aligned to size" + extra)
@@ -215,7 +215,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      monAssert (edge.master.supportsLogical(edge.source(bundle), bundle.size) && edge.slave.emitsLogicalSafe(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
+      monAssert (edge.client.supportsLogical(edge.source(bundle), bundle.size) && edge.manager.emitsLogicalSafe(edge.address(bundle), bundle.size), "'B' channel carries Logical type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Logical carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Logical carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Logical address not aligned to size" + extra)
@@ -224,7 +224,7 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      monAssert (edge.master.supportsHint(edge.source(bundle), bundle.size) && edge.slave.emitsHintSafe(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
+      monAssert (edge.client.supportsHint(edge.source(bundle), bundle.size) && edge.manager.emitsHintSafe(edge.address(bundle), bundle.size), "'B' channel carries Hint type unsupported by client" + extra)
       monAssert (address_ok, "'B' channel Hint carries unmanaged address" + extra)
       monAssert (legal_source, "'B' channel Hint carries source that is not first source" + extra)
       monAssert (is_aligned, "'B' channel Hint address not aligned to size" + extra)
@@ -260,8 +260,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.Release) {
-      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.client.emitsAcquireB(edge.source(bundle), bundle.size) && edge.manager.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
+      monAssert (edge.client.supportsProbe(edge.source(bundle), bundle.size) && edge.manager.emitsProbeSafe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel Release carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel Release smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel Release address not aligned to size" + extra)
@@ -270,8 +270,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     }
 
     when (bundle.opcode === TLMessages.ReleaseData) {
-      monAssert (edge.master.emitsAcquireB(edge.source(bundle), bundle.size) && edge.slave.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
-      monAssert (edge.master.supportsProbe(edge.source(bundle), bundle.size) && edge.slave.emitsProbeSafe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
+      monAssert (edge.client.emitsAcquireB(edge.source(bundle), bundle.size) && edge.manager.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
+      monAssert (edge.client.supportsProbe(edge.source(bundle), bundle.size) && edge.manager.emitsProbeSafe(edge.address(bundle), bundle.size), "'C' channel carries Release from a client which does not support Probe" + extra)
       monAssert (source_ok, "'C' channel ReleaseData carries invalid source ID" + extra)
       monAssert (bundle.size >= log2Ceil(edge.manager.beatBytes).U, "'C' channel ReleaseData smaller than a beat" + extra)
       monAssert (is_aligned, "'C' channel ReleaseData address not aligned to size" + extra)

--- a/src/main/scala/tilelink/PatternPusher.scala
+++ b/src/main/scala/tilelink/PatternPusher.scala
@@ -37,7 +37,7 @@ case class ReadExpectPattern(address: BigInt, size: Int, data: BigInt) extends P
 
 class TLPatternPusher(name: String, pattern: Seq[Pattern])(implicit p: Parameters) extends LazyModule
 {
-  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1(name = name)))))
+  val node = TLClientNode(Seq(TLClientPortParameters.v1(Seq(TLClientParameters.v1(name = name)))))
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {

--- a/src/main/scala/tilelink/ProbePicker.scala
+++ b/src/main/scala/tilelink/ProbePicker.scala
@@ -17,12 +17,12 @@ class ProbePicker(implicit p: Parameters) extends LazyModule
     clientFn = { p =>
       // The ProbePicker assembles multiple clients based on the assumption they are contiguous in the clients list
       // This should be true for custers of xbar :=* BankBinder connections
-      def combine(next: TLMasterParameters, pair: (TLMasterParameters, Seq[TLMasterParameters])) = {
+      def combine(next: TLClientParameters, pair: (TLClientParameters, Seq[TLClientParameters])) = {
         val (head, output) = pair
         if (head.visibility.exists(x => next.visibility.exists(_.overlaps(x)))) {
           (next, head +: output) // pair is not banked, push head without merging
         } else {
-          def redact(x: TLMasterParameters) = x.v1copy(sourceId = IdRange(0,1), nodePath = Nil, visibility = Seq(AddressSet(0, ~0)))
+          def redact(x: TLClientParameters) = x.v1copy(sourceId = IdRange(0,1), nodePath = Nil, visibility = Seq(AddressSet(0, ~0)))
           require (redact(next) == redact(head), s"${redact(next)} != ${redact(head)}")
           val merge = head.v1copy(
             sourceId = IdRange(
@@ -32,7 +32,7 @@ class ProbePicker(implicit p: Parameters) extends LazyModule
           (merge, output)
         }
       }
-      val myNil: Seq[TLMasterParameters] = Nil
+      val myNil: Seq[TLClientParameters] = Nil
       val (head, output) = p.clients.init.foldRight((p.clients.last, myNil))(combine)
       p.v1copy(clients = head +: output)
     },

--- a/src/main/scala/tilelink/RegionReplication.scala
+++ b/src/main/scala/tilelink/RegionReplication.scala
@@ -46,8 +46,8 @@ class RegionReplicator(val params: ReplicatedRegion)(implicit p: Parameters) ext
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
       out <> in
 
-      // Is every slave contained by the replication region?
-      val totalContainment = edgeIn.slave.slaves.forall(_.address.forall(params.region contains _))
+      // Is every manager contained by the replication region?
+      val totalContainment = edgeIn.manager.managers.forall(_.address.forall(params.region contains _))
 
       // Which address within the mask routes to local devices?
       val local_prefix = RegNext(prefix.bundle)

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -42,8 +42,8 @@ case class TLRegisterNode(
     undefZero:   Boolean = true,
     executable:  Boolean = false)(
     implicit valName: ValName)
-  extends SinkNode(TLImp)(Seq(TLSlavePortParameters.v1(
-    Seq(TLSlaveParameters.v1(
+  extends SinkNode(TLImp)(Seq(TLManagerPortParameters.v1(
+    Seq(TLManagerParameters.v1(
       address            = address,
       resources          = Seq(Resource(device, deviceKey)),
       executable         = executable,

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -40,8 +40,8 @@ class TLRAM(
   require (beatBytes >= 1 && isPow2(beatBytes))
   require (eccBytes <= beatBytes, s"TLRAM eccBytes (${eccBytes}) > beatBytes (${beatBytes}). Use a WidthWidget=>Fragmenter=>SRAM if you need high density and narrow ECC; it will do bursts efficiently")
 
-  val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
-    Seq(TLSlaveParameters.v1(
+  val node = TLManagerNode(Seq(TLManagerPortParameters.v1(
+    Seq(TLManagerParameters.v1(
       address            = List(address),
       resources          = resources,
       regionType         = if (cacheable) RegionType.UNCACHED else RegionType.IDEMPOTENT,

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -19,13 +19,13 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
   private def noShrinkRequired(client: TLClientPortParameters) = maxInFlight >= client.endSourceId
 
   // The SourceShrinker completely destroys all FIFO property guarantees
-  private val client = TLMasterParameters.v1(
+  private val client = TLClientParameters.v1(
     name     = "TLSourceShrinker",
     sourceId = IdRange(0, maxInFlight))
   val node = (new TLAdapterNode(
     clientFn  = { cp => if (noShrinkRequired(cp)) { cp } else {
       // We erase all client information since we crush the source Ids
-      TLMasterPortParameters.v1(
+      TLClientPortParameters.v1(
         clients = Seq(client.v1copy(requestFifo = cp.clients.exists(_.requestFifo))),
         echoFields = cp.echoFields,
         requestFields = cp.requestFields,

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -172,12 +172,12 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
 
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
 
-      // If the master is narrower than the slave, the D channel must be narrowed.
+      // If the client is narrower than the manager, the D channel must be narrowed.
       // This is tricky, because the D channel has no address data.
       // Thus, you don't know which part of a sub-beat transfer to extract.
       // To fix this, we record the relevant address bits for all sources.
       // The assumption is that this sort of situation happens only where
-      // you connect a narrow master to the system bus, so there are few sources.
+      // you connect a narrow client to the system bus, so there are few sources.
 
       def sourceMap(source_bits: UInt) = {
         val source = if (edgeIn.client.endSourceId == 1) 0.U(0.W) else source_bits

--- a/src/main/scala/tilelink/package.scala
+++ b/src/main/scala/tilelink/package.scala
@@ -9,13 +9,9 @@ import freechips.rocketchip.prci.{HasResetDomainCrossing, HasClockDomainCrossing
 
 package object tilelink
 {
-  type TLInwardNode = InwardNodeHandle[TLMasterPortParameters, TLSlavePortParameters, TLEdgeIn, TLBundle]
-  type TLOutwardNode = OutwardNodeHandle[TLMasterPortParameters, TLSlavePortParameters, TLEdgeOut, TLBundle]
-  type TLNode = NodeHandle[TLMasterPortParameters, TLSlavePortParameters, TLEdgeIn, TLBundle, TLMasterPortParameters, TLSlavePortParameters, TLEdgeOut, TLBundle]
-  type TLManagerParameters = TLSlaveParameters
-  type TLManagerPortParameters = TLSlavePortParameters
-  type TLClientParameters = TLMasterParameters
-  type TLClientPortParameters = TLMasterPortParameters
+  type TLInwardNode = InwardNodeHandle[TLClientPortParameters, TLManagerPortParameters, TLEdgeIn, TLBundle]
+  type TLOutwardNode = OutwardNodeHandle[TLClientPortParameters, TLManagerPortParameters, TLEdgeOut, TLBundle]
+  type TLNode = NodeHandle[TLClientPortParameters, TLManagerPortParameters, TLEdgeIn, TLBundle, TLClientPortParameters, TLManagerPortParameters, TLEdgeOut, TLBundle]
 
   implicit class TLClockDomainCrossing(private val x: HasClockDomainCrossing) extends AnyVal {
     def crossIn (n: TLInwardNode) (implicit valName: ValName) = TLInwardClockCrossingHelper (valName.name, x, n)

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -92,7 +92,7 @@ class WithTLXbarUnitTests extends Config((site, here, up) => {
       Module(new TLRAMXbarTest(2,           txns=5*txns, timeout=timeout)),
       Module(new TLRAMXbarTest(8,           txns=5*txns, timeout=timeout)),
       Module(new TLMulticlientXbarTest(4,4, txns=2*txns, timeout=timeout)),
-      Module(new TLMasterMuxTest(           txns=5*txns, timeout=timeout)) ) }
+      Module(new TLClientMuxTest(           txns=5*txns, timeout=timeout)) ) }
 })
 
 class WithECCTests extends Config((site, here, up) => {

--- a/src/main/scala/util/Annotations.scala
+++ b/src/main/scala/util/Annotations.scala
@@ -70,8 +70,8 @@ case class RetimeModuleAnnotation(target: ModuleName) extends SingleTargetAnnota
   def duplicate(n: ModuleName) = this.copy(n)
 }
 
-/** Annotation capturing information about port slave devices. */
-case class SlaveAddressMapChiselAnnotation(
+/** Annotation capturing information about port manager devices. */
+case class ManagerAddressMapChiselAnnotation(
     target: InstanceId,
     addresses: Seq[AddressSet],
     perms: ResourcePermissions) extends ChiselAnnotation {
@@ -79,7 +79,7 @@ case class SlaveAddressMapChiselAnnotation(
   def toFirrtl = AddressMapAnnotation(
     target = target.toNamed,
     mapping = range.map { r => AddressMapEntry(r, perms, Nil) },
-    label = "slaves")
+    label = "managers")
 }
 
 /** Record information about a top-level port of the design */

--- a/src/main/scala/util/BundleMap.scala
+++ b/src/main/scala/util/BundleMap.scala
@@ -88,9 +88,9 @@ abstract class ControlKey[T <: Data](name: String) extends BundleKey[T](name) wi
 abstract class DataKey   [T <: Data](name: String) extends BundleKey[T](name) with IsDataKey
 
 /* Signals can be further categorized in a request-response protocol:
- *  - request fields flow from master to slave
- *  - response fields flow from slave to master
- *  - echo fields flow from master to slave to master; a master must receive the same value in the response as he sent in the request
+ *  - request fields flow from client to manager
+ *  - response fields flow from manager to client
+ *  - echo fields flow from client to manager to client; a client must receive the same value in the response as he sent in the request
  * Generally, this categorization belongs in different BundleMaps
  */
 


### PR DESCRIPTION
**Related issue**:  https://github.com/chipsalliance/rocket-chip/issues/3684
**Type of change**: other enhancement
**Impact**:  API modification
**Development Phase**: implementation

**Release Notes**
Remove master/slave terminology in favor of Client/Manager for tilelink and Manager/Subordinate for amba interfaces.
