### PR TITLE
Move `desiredName` override to top of `LazyModuleImp`

### DIFF
--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -72,13 +72,13 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin, nameSuffix: Option
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
+    val wide_bundle = TLBundleParameters.union((node.in ++ node.out).map(_._2.bundle))
+    override def desiredName = (Seq("TLXbar") ++ nameSuffix ++ Seq(s"i${node.in.size}_o${node.out.size}_${wide_bundle.shortName}")).mkString("_")
     if ((node.in.size * node.out.size) > (8*32)) {
       println (s"!!! WARNING !!!")
       println (s" Your TLXbar ($name with parent $parent) is very large, with ${node.in.size} Masters and ${node.out.size} Slaves.")
       println (s"!!! WARNING !!!")
     }
-    val wide_bundle = TLBundleParameters.union((node.in ++ node.out).map(_._2.bundle))
-    override def desiredName = (Seq("TLXbar") ++ nameSuffix ++ Seq(s"i${node.in.size}_o${node.out.size}_${wide_bundle.shortName}")).mkString("_")
     TLXbar.circuit(policy, node.in, node.out)
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
If a TLXbar is very large, it will print a warning using `$name`. However, `$name` can only be accessed after `desiredName` is set otherwise it will throw an error like `chisel3.package$ChiselException: Error: desiredName of freechips.rocketchip.tilelink.TLXbar$Impl is null. Did you evaluate 'name' before all values needed by desiredName were available?`. This re-orders the `desiredName` override to the top of the `LazyModuleImp`.
