### PR TITLE
Fix: c.addi4spn with imm=0 and rd'!=0 should be reserved

### DIFF
--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -155,12 +155,12 @@ class RVCDecoder(x: UInt, xLen: Int, fLen: Int, useAddiForMv: Boolean = false) {
   }
 
   def q0_ill = {
-    def allz = !(x(12, 2).orR)
+    def immz = !(x(12, 5).orR)
     def fld = if (fLen >= 64) false.B else true.B
     def flw32 = if (xLen == 64 || fLen >= 32) false.B else true.B
     def fsd = if (fLen >= 64) false.B else true.B
     def fsw32 = if (xLen == 64 || fLen >= 32) false.B else true.B
-    Seq(allz, fld, false.B, flw32, true.B, fsd, false.B, fsw32)
+    Seq(immz, fld, false.B, flw32, true.B, fsd, false.B, fsw32)
   }
 
   def q1_ill = {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: not applicable

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
According to unprivileged specification section 26.5.2:
>  C.ADDI4SPN is a CIW-format instruction that adds a zero-extended non-zero immediate, scaled by
> 4, to the stack pointer, x2, and writes the result to rd′. This instruction is used to generate pointers to
> stack-allocated variables, and expands to addi rd′, x2, nzuimm[9:2]. C.ADDI4SPN is only valid
> when nzuimm≠0; the code points with nzuimm=0 are reserved.

`C.ADDI4SPN` with `imm=0` (i.e. `x(12,5) === 0.U`) should be reserved (illegal for now), whether or not `rd'=0` (i.e. `x(4,2) === 0.U`)
