### PR TITLE
Rocket Core Clock Gate Bug Fix

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -1174,6 +1174,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
       !div.io.req.ready || // mul/div in flight
       usingFPU.B && !io.fpu.fcsr_rdy || // long-latency FPU in flight
       io.dmem.replay_next || // long-latency load replaying
+      id_rocc_busy || // RoCC command in flight
       (!long_latency_stall && (ibuf.io.inst(0).valid || io.imem.resp.valid)) // instruction pending
 
     assert(!(ex_pc_valid || mem_pc_valid || wb_pc_valid) || clock_en)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable --> This PR contains a fix for the core clock gating bug described in the following issue: https://github.com/chipsalliance/rocket-chip/issues/3695.

<!-- choose one -->
**Type of change**: bug fix

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The core clock will no longer be gated when there is a RoCC instruction active or busy.