### PR TITLE
fixed TL refill request when TL request is not accepted

### DIFF
--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -377,7 +377,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   /** [[io]] access L1 I$ miss. */
   val s2_miss = s2_valid && !s2_hit && !io.s2_kill
   /** forward signal to stage 1, permit stage 1 refill. */
-  val s1_can_request_refill = !(s2_miss || refill_valid)
+  val s1_can_request_refill = !((s2_miss && refill_fire) || refill_valid)
   /** real refill signal, stage 2 miss, and was permit to refill in stage 1.
     * Since a miss will trigger burst.
     * miss under miss won't trigger another burst.


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->


There is a peculiarity in the rocket chip I$ that seems to be a bug. Namely, it seems that the I$ is coded such that when a miss takes place, the I$ only requests a refill from the TL bus once, and achieves this by checking if the previous cycle has a miss and the I$ is currently missing. This works okay most of the time but doesnt account for the TL.A channel not accepting the request. 

ex: 
![I$_Bug](https://github.com/user-attachments/assets/cecdca00-81b9-4d9f-a101-f83a96b35563)

What I suspect the offending line of code is (line 380 in icache.scala):

![image](https://github.com/user-attachments/assets/4f922033-38e0-413f-8328-7096d5d12581)

Waveform after the change: 

![image](https://github.com/user-attachments/assets/c08844da-9f99-4a4b-8f74-04fdc5184b52)



