### PR TITLE
fix `hartReset` in DM

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -660,7 +660,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
       val hartResetReg = RegNext(next=hartResetNxt, init=0.U.asTypeOf(hartResetNxt))
 
       for (component <- 0 until nComponents) {
-        hartResetNxt(component) := DMCONTROLReg.hartreset & hartSelected(component)
+        hartResetNxt(component) := DMCONTROLNext.hartreset & hartSelected(component)
         io.hartResetReq.get(component) := hartResetReg(component)
       }
     }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change
<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**

This pr is for debug multiCore. Hart0 should not be reset when reset hartX(X>0) by writing dmcontrol(hasel=0, hartsello=X, hartreset=1, dmactive=1).
<!--
-->
