### PR TITLE
Fix filtering tiles with supervisor for seipNodes

### DIFF
--- a/src/main/scala/subsystem/Cluster.scala
+++ b/src/main/scala/subsystem/Cluster.scala
@@ -72,9 +72,10 @@ class Cluster(
   def meipDomain = this
   def seipDomain = this
   def toPlicDomain = this
+  def hasSupervisorTileIdList: Seq[Int] = totalTiles.filter(_._2.tileParams.core.hasSupervisorMode).keys.toSeq.sorted
   lazy val msipNodes = totalTileIdList.map { i => (i, IntIdentityNode()) }.to(SortedMap)
   lazy val meipNodes = totalTileIdList.map { i => (i, IntIdentityNode()) }.to(SortedMap)
-  lazy val seipNodes = totalTiles.filter(_._2.tileParams.core.useSupervisor).keys.map { i => (i, IntIdentityNode()) }.to(SortedMap)
+  lazy val seipNodes = hasSupervisorTileIdList.map { i => (i, IntIdentityNode()) }.to(SortedMap)
   lazy val tileToPlicNodes = totalTileIdList.map { i => (i, IntIdentityNode()) }.to(SortedMap)
   lazy val debugNodes = totalTileIdList.map { i => (i, IntSyncIdentityNode()) }.to(SortedMap)
   lazy val nmiNodes = totalTiles.filter { case (i,t) => t.tileParams.core.useNMI }


### PR DESCRIPTION
Fixes tile filtering logic for seipNodes by using `hasSupervisorMode` instead of `useSupervisor`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/ucb-bar/chipyard/pull/2190

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
