### PR TITLE
Fix circuitIdentity in Xbars

### DIFF
--- a/src/main/scala/amba/ahb/Xbar.scala
+++ b/src/main/scala/amba/ahb/Xbar.scala
@@ -21,7 +21,7 @@ class AHBFanout()(implicit p: Parameters) extends LazyModule {
         requestKeys    = seq.flatMap(_.requestKeys).distinct,
         responseFields = BundleField.union(seq.flatMap(_.responseFields))) }
   ){
-    override def circuitIdentity = outputs == 1 && inputs == 1
+    override def circuitIdentity = outputs.size == 1 && inputs.size == 1
   }
 
   lazy val module = new Impl

--- a/src/main/scala/amba/apb/Xbar.scala
+++ b/src/main/scala/amba/apb/Xbar.scala
@@ -21,7 +21,7 @@ class APBFanout()(implicit p: Parameters) extends LazyModule {
         requestKeys    = seq.flatMap(_.requestKeys).distinct,
         responseFields = BundleField.union(seq.flatMap(_.responseFields))) }
   ){
-    override def circuitIdentity = outputs == 1 && inputs == 1
+    override def circuitIdentity = outputs.size == 1 && inputs.size == 1
   }
 
   lazy val module = new Impl

--- a/src/main/scala/amba/axi4/Xbar.scala
+++ b/src/main/scala/amba/axi4/Xbar.scala
@@ -53,7 +53,7 @@ class AXI4Xbar(
       )
     }
   ){
-    override def circuitIdentity = outputs == 1 && inputs == 1
+    override def circuitIdentity = outputs.size == 1 && inputs.size == 1
   }
 
   lazy val module = new Impl

--- a/src/main/scala/interrupts/Xbar.scala
+++ b/src/main/scala/interrupts/Xbar.scala
@@ -15,7 +15,7 @@ class IntXbar()(implicit p: Parameters) extends LazyModule
       }.flatten)
     })
   {
-    override def circuitIdentity = outputs == 1 && inputs == 1
+    override def circuitIdentity = outputs.size == 1 && inputs.size == 1
   }
 
   lazy val module = new Impl
@@ -36,7 +36,7 @@ class IntSyncXbar()(implicit p: Parameters) extends LazyModule
       }.flatten)
     })
   {
-    override def circuitIdentity = outputs == 1 && inputs == 1
+    override def circuitIdentity = outputs.size == 1 && inputs.size == 1
   }
 
   lazy val module = new Impl


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/chipsalliance/rocket-chip/pull/2639

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix type mismatch that makes it always false.

``` scala
  def inputs: Seq[(OutwardNode[DI, UI, BI], RenderedEdge)] = (iPorts zip edgesIn) map { case ((_, n, p, _), e) =>
    val re = inner.render(e)
    (n, re.copy(flipped = re.flipped != p(RenderFlipped)))
  }
  /** Metadata for printing the node graph */
  def outputs: Seq[(InwardNode[DO, UO, BO], RenderedEdge)] = oPorts map { case (i, n, _, _) => (n, n.inputs(i)._2) }
```