### PR TITLE
Resolve no-implicit-clock error with AXI4 monitors

### DIFF
--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -105,8 +105,9 @@ trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
     })
 
     mbus.coupleTo(s"memory_controller_port_named_$portName") {
-      (memAXI4Node
-        := AXI4UserYanker()
+      // Disable monitors on this connection since the class with this trait (i.e. DigitalTop) doesn't provide an
+      // implicit clock for the monitor.
+      (DisableMonitors { implicit p => memAXI4Node := AXI4UserYanker() }
         := AXI4IdIndexer(idBits)
         := TLToAXI4()
         := TLWidthWidget(mbus.beatBytes)


### PR DESCRIPTION
If a user enables AXI4 Monitors (using `AXI4MonitorBuilder`), they'll get a no-implicit-clock error at this point, which isn't easy to track down. Chipyard worked around a similar problem with TileLink Monitors here: https://github.com/ucb-bar/chipyard/pull/1868

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Resolve build error when using AXI4 monitors.