### PR TITLE
Use Connectable coercion operator to drive diplomatic monitors

### DIFF
--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -22,7 +22,7 @@ object AHBImpSlave extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortPa
   override def monitor(bundle: AHBSlaveBundle, edge: AHBEdgeParameters): Unit = {
     edge.params.lift(AHBSlaveMonitorBuilder).foreach { builder =>
       val monitor = Module(builder(AHBSlaveMonitorArgs(edge)))
-      monitor.io.in := bundle
+      monitor.io.in :#= bundle
     }
   }
 
@@ -44,7 +44,7 @@ object AHBImpMaster extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortP
   override def monitor(bundle: AHBMasterBundle, edge: AHBEdgeParameters): Unit = {
     edge.params.lift(AHBMasterMonitorBuilder).foreach { builder =>
       val monitor = Module(builder(AHBMasterMonitorArgs(edge)))
-      monitor.io.in := bundle
+      monitor.io.in :#= bundle
     }
   }
 

--- a/src/main/scala/amba/apb/Nodes.scala
+++ b/src/main/scala/amba/apb/Nodes.scala
@@ -21,7 +21,7 @@ object APBImp extends SimpleNodeImp[APBMasterPortParameters, APBSlavePortParamet
   override def monitor(bundle: APBBundle, edge: APBEdgeParameters): Unit = {
     edge.params.lift(APBMonitorBuilder).foreach { builder =>
       val monitor = Module(builder(APBMonitorArgs(edge)))
-      monitor.io.in := bundle
+      monitor.io.in :#= bundle
     }
   }
 

--- a/src/main/scala/amba/axi4/Nodes.scala
+++ b/src/main/scala/amba/axi4/Nodes.scala
@@ -23,7 +23,7 @@ object AXI4Imp extends SimpleNodeImp[AXI4MasterPortParameters, AXI4SlavePortPara
   override def monitor(bundle: AXI4Bundle, edge: AXI4EdgeParameters): Unit = {
     edge.params.lift(AXI4MonitorBuilder).foreach { builder =>
       val monitor = Module(builder(AXI4MonitorArgs(edge)))
-      monitor.io.in := bundle
+      monitor.io.in :#= bundle
     }
   }
 

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -25,7 +25,7 @@ object TLImp extends NodeImp[TLMasterPortParameters, TLSlavePortParameters, TLEd
 
   override def monitor(bundle: TLBundle, edge: TLEdgeIn): Unit = {
     val monitor = Module(edge.params(TLMonitorBuilder)(TLMonitorArgs(edge)))
-    monitor.io.in := bundle
+    monitor.io.in :#= bundle
   }
 
   override def mixO(pd: TLMasterPortParameters, node: OutwardNode[TLMasterPortParameters, TLSlavePortParameters, TLBundle]): TLMasterPortParameters  =


### PR DESCRIPTION
This operator coerces every right-hand-size element to drive a left-hand-size element, which is exactly the use-case for a monitor.

See here for more information:

- https://www.chisel-lang.org/docs/explanations/connectable#coercing-mono-direction-connection-operator-
- https://www.chisel-lang.org/api/latest/chisel3/connectable/Connectable.html

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
