### PR TITLE
ControlBus diplomacy breaks when CBus atomics is disabled

### DIFF
--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -63,7 +63,11 @@ class PeripheryBus(params: PeripheryBusParams, name: String)(implicit p: Paramet
           TLWidthWidget(w) :*= TLAtomicAutomata(arithmetic = pa.arithmetic, nameSuffix = Some(name))
         } .getOrElse { TLAtomicAutomata(arithmetic = pa.arithmetic, nameSuffix = Some(name)) })
       :*= in_xbar.node)
-  } .getOrElse { TLXbar() :*= fixer.node }
+  } .getOrElse {
+    val in_xbar = LazyModule(new TLXbar(nameSuffix = Some(s"${name}_in")))
+    val out_xbar = LazyModule(new TLXbar(nameSuffix = Some(s"${name}_out")))
+    (out_xbar.node :*= fixer.node :*= in_xbar.node)
+  }
 
   def inwardNode: TLInwardNode = node
   def outwardNode: TLOutwardNode = node


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->


To reproduce:

```scala
class WithNoAtomicsCBus extends Config ((site, here, up) => {
  case ControlBusKey => up(ControlBusKey).copy(
    atomics = None,
  )
})

class RocketWithNoAtomicsCBusConfig extends Config(
  new WithNoAtomicsCBus ++
  new RocketConfig)
```

This will cause this:
```
Caused by: java.lang.IllegalArgumentException: requirement failed: Diplomacy has detected a problem with your graph:
The following node appears left of a :*= 2 times and right of a :=* 0 times, at most once is allowed.
adapter cbus_fixer.$anon node:
parents: cbus_fixer/cbus/system/chiptop0
locator:  (generators/rocket-chip/src/main/scala/subsystem/PeripheryBus.scala:54:33)

2 inward nodes bound: [flex-buffer.node,flex-coupler_from_port_named_custom_boot_pin.tl]
1 outward nodes bound: [query-xbar.$anon]


        at scala.Predef$.require(Predef.scala:337)
        at org.chipsalliance.diplomacy.nodes.MixedAdapterNode.resolveStar(AdapterNode.scala:37)
        at org.chipsalliance.diplomacy.nodes.MixedNode.liftedTree1$1(MixedNode.scala:381)
        at org.chipsalliance.diplomacy.nodes.MixedNode.x$19$lzycompute(MixedNode.scala:342)
        at org.chipsalliance.diplomacy.nodes.MixedNode.x$19(MixedNode.scala:336)
        at org.chipsalliance.diplomacy.nodes.MixedNode.iStar$lzycompute(MixedNode.scala:340)
        at org.chipsalliance.diplomacy.nodes.MixedNode.iStar(MixedNode.scala:340)
        at org.chipsalliance.diplomacy.nodes.MixedNode.$anonfun$x$19$5(MixedNode.scala:363)
        at org.chipsalliance.diplomacy.nodes.MixedNode.edgeAritySelect(MixedNode.scala:319)
        at org.chipsalliance.diplomacy.nodes.MixedNode.$anonfun$x$19$3(MixedNode.scala:363)
        at org.chipsalliance.diplomacy.nodes.MixedNode.$anonfun$x$19$3$adapted(MixedNode.scala:360)
        at scala.collection.immutable.List.map(List.scala:247)
        at scala.collection.immutable.List.map(List.scala:79)
        at org.chipsalliance.diplomacy.nodes.MixedNode.liftedTree1$1(MixedNode.scala:360)
(and so on)
```

Fix is the commit