### PR TITLE
Add configurable BHT history parameters via CSR

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -218,6 +218,8 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
     val force_taken = io.ptw.customCSRs.bpmStatic
     when (io.ptw.customCSRs.flushBTB) { btb.io.flush := true.B }
     when (force_taken) { btb.io.bht_update.valid := false.B }
+    btb.io.historyLengthConfig := io.ptw.customCSRs.historyLengthConfig
+    btb.io.historyBitsConfig := io.ptw.customCSRs.historyBitsConfig
 
     val s2_base_pc = ~(~s2_pc | (fetchBytes-1).U)
     val taken_idx = Wire(UInt())

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -97,7 +97,7 @@ trait HasRocketCoreParameters extends HasCoreParameters {
 
 class RocketCustomCSRs(implicit p: Parameters) extends CustomCSRs with HasRocketCoreParameters {
   override def bpmCSR = {
-    rocketParams.branchPredictionModeCSR.option(CustomCSR(bpmCSRId, BigInt(1), Some(BigInt(0))))
+    rocketParams.branchPredictionModeCSR.option(CustomCSR(bpmCSRId, BigInt(0x1FF), Some(BigInt(0))))
   }
 
   private def haveDCache = tileParams.dcache.get.scratch.isEmpty

--- a/src/main/scala/tile/CustomCSRs.scala
+++ b/src/main/scala/tile/CustomCSRs.scala
@@ -40,6 +40,8 @@ class CustomCSRs(implicit p: Parameters) extends CoreBundle {
 
   def flushBTB = getOrElse(bpmCSR, _.wen, false.B)
   def bpmStatic = getOrElse(bpmCSR, _.value(0), false.B)
+  def historyLengthConfig = getOrElse(bpmCSR, _.value(4,1), 0.U)
+  def historyBitsConfig = getOrElse(bpmCSR, _.value(8,5), 0.U)
   def disableDCacheClockGate = getOrElse(chickenCSR, _.value(0), false.B)
   def disableICacheClockGate = getOrElse(chickenCSR, _.value(1), false.B)
   def disableCoreClockGate = getOrElse(chickenCSR, _.value(2), false.B)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Add runtime configurable BHT (Branch History Table) parameters to the Rocket core branch predictor. The branch predictor's history length and history bits can now be configured at runtime through CSR 0x7c0 instead of being fixed at compile time.

**Changes**
  - Extended CSR 0x7c0 with new bit fields: bits[4:1] for history length config, bits[8:5] for history bits
  config
  - Updated BHT indexing logic to use configurable parameters instead of compile-time constants
  - Added new input ports to BTB for runtime configuration
  - Maintains backward compatibility with existing configurations (defaults to 0)

**Limitations:**
  - History length and history bits are limited to 4-bit fields (0-15 range)
  - Configurations with history length > 15 are no longer supported
  - Runtime configuration values must not exceed the compile-time BHTParams limits
  - Shuttle BHT instantiation needs to be updated afterwards to ensure compilation at top level. Separate PR will be submitted for shuttle if this is approved.