### PR TITLE
Fix AHBToTL elaboration error due to missing user fields

### DIFF
--- a/src/main/scala/amba/ahb/Test.scala
+++ b/src/main/scala/amba/ahb/Test.scala
@@ -6,12 +6,12 @@ import chisel3._
 
 import org.chipsalliance.cde.config.Parameters
 
-import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp, SimpleLazyModule}
+import org.chipsalliance.diplomacy.lazymodule.{InModuleBody, LazyModule, LazyModuleImp, SimpleLazyModule}
 
 import freechips.rocketchip.devices.tilelink.TLTestRAM
 import freechips.rocketchip.diplomacy.{AddressSet, BufferParams}
 import freechips.rocketchip.regmapper.{RRTest0, RRTest1}
-import freechips.rocketchip.tilelink.{TLFuzzer, TLRAMModel, TLToAHB, TLDelayer, TLBuffer, TLErrorEvaluator, TLFragmenter}
+import freechips.rocketchip.tilelink.{TLFuzzer, TLRAMModel, TLRAM, TLToAHB, TLDelayer, TLBuffer, TLErrorEvaluator, TLFragmenter}
 import freechips.rocketchip.unittest.{UnitTestModule, UnitTest}
 
 class AHBRRTest0(address: BigInt)(implicit p: Parameters)
@@ -112,4 +112,36 @@ class AHBBridgeTest(aFlow: Boolean, txns: Int = 5000, timeout: Int = 500000)(imp
   val dut = Module(LazyModule(new AHBFuzzBridge(aFlow, txns)).module)
   io.finished := dut.io.finished
   dut.io.start := io.start
+}
+
+/** Test that AHBToTL elaborates when driven by an AHBSlaveSourceNode. */
+class AHBSourceToTLSlave()(implicit p: Parameters) extends SimpleLazyModule {
+  val ram = LazyModule(new TLRAM(AddressSet(0x0, 0xfff)))
+
+  val ahbMaster = AHBSlaveSourceNode(
+    Seq(AHBMasterPortParameters(masters = Seq(AHBMasterParameters(name = "test_ahb_master"))))
+  )
+
+  (ram.node
+    := AHBToTL()
+    := ahbMaster)
+
+  val idle = InModuleBody {
+    val (bundle, _) = ahbMaster.out.head
+    bundle.htrans    := 0.U // idle
+    bundle.hsize     := 0.U
+    bundle.hburst    := 0.U
+    bundle.hwrite    := false.B
+    bundle.hprot     := 0.U
+    bundle.haddr     := 0.U
+    bundle.hwdata    := 0.U
+    bundle.hmastlock := false.B
+    bundle.hsel      := false.B
+    bundle.hready    := true.B
+  }
+}
+
+class AHBSourceToTLSlaveTest(timeout: Int = 500000)(implicit p: Parameters) extends UnitTest(timeout) {
+  val dut = Module(LazyModule(new AHBSourceToTLSlave()).module)
+  io.finished := true.B
 }

--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -118,7 +118,11 @@ class AHBToTL()(implicit p: Parameters) extends LazyModule
           d_write := in.hwrite
           d_addr  := in.haddr
           d_size  := Mux(a_burst_ok, a_burst_size, in.hsize)
-          d_user  :<= in.hauser
+
+          Connectable.waiveUnmatched(d_user, in.hauser) match {
+            case (lhs, rhs) => lhs.squeezeAll :<= rhs.squeezeAll
+          }
+
           d_user.lift(AMBAProt).foreach { x =>
             x.fetch      := !in.hprot(0)
             x.privileged :=  in.hprot(1)

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -27,6 +27,7 @@ class WithAMBAUnitTests extends Config((site, here, up) => {
       Module(new AHBBridgeTest(true,         txns=8*txns, timeout=timeout)),
       Module(new AHBNativeTest(true,         txns=6*txns, timeout=timeout)),
       Module(new AHBNativeTest(false,        txns=6*txns, timeout=timeout)),
+      Module(new AHBSourceToTLSlaveTest(                  timeout=timeout)),
       Module(new APBBridgeTest(true,         txns=6*txns, timeout=timeout)),
       Module(new APBBridgeTest(false,        txns=6*txns, timeout=timeout)),
       Module(new AXI4LiteFuzzRAMTest(        txns=6*txns, timeout=timeout)),


### PR DESCRIPTION
Without this change, the following error shows up when connecting an AHBSlaveSourceNode (which can model an external AHB master port) through AHBToTL:

    [error] generators/rocket-chip/src/main/scala/amba/ahb/ToTL.scala 121:19: unconnected consumer field AHBToTL.d_user.amba_prot: Reg[AMBAProtBundle]
    [error]           d_user  :<= in.hauser
    [error]                   ^
    [error] There were 1 error(s) during hardware elaboration.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: N/A

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Fix AHBToTL elaboration error due to missing user fields