### PR TITLE
fix rocc write back

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -796,7 +796,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
 
   if (usingRoCC) {
     io.rocc.resp.ready := ll_arb.io.in(1).ready
-    ll_arb.io.in(1).valid := io.rocc.resp.valid
+    ll_arb.io.in(1).valid := io.rocc.resp.valid && rocc_write_waiting
     ll_arb.io.in(1).bits.data := io.rocc.resp.bits.data
     ll_arb.io.in(1).bits.tag := io.rocc.resp.bits.rd
   } else {
@@ -1056,7 +1056,9 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     blocked && !io.dmem.perf.grant
   }
   val rocc_blocked = Reg(Bool())
+  val rocc_write_waiting = RegInit(false.B)
   rocc_blocked := !wb_xcpt && !io.rocc.cmd.ready && (io.rocc.cmd.valid || rocc_blocked)
+  rocc_write_waiting := Mux(io.rocc.cmd.fire, !wb_xcpt && wb_ctrl.rocc && wb_ctrl.wxd, Mux(io.rocc.resp.fire, false.B, rocc_write_waiting))
 
   val ctrl_stalld =
     id_ex_hazard || id_mem_hazard || id_wb_hazard || id_sboard_hazard ||


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
The RoCC Coprocessor will write back the value unconditionally without having `xd` rocc instructions, which might cause data pollution if the Coprocessor intentionally raise `io.rocc.resp.valid`

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
