### PR TITLE
PTW: traverse check GPA bits higher than HGATP mode also if table

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -563,7 +563,18 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     io.requestor(i).resp.bits.fragmented_superpage := resp_fragmented_superpage && pageGranularityPMPs.B
     io.requestor(i).resp.bits.gpa.valid := r_req.need_gpa
     io.requestor(i).resp.bits.gpa.bits :=
-      Cat(Mux(!stage2_final || !r_req.vstage1 || aux_count === (pgLevels - 1).U, aux_pte.ppn, makeFragmentedSuperpagePPN(aux_pte.ppn)(aux_count)), gpa_pgoff)
+      Mux(
+        r_req.vstage1,
+        Cat(
+          Mux(
+            stage2,
+            Mux(!stage2_final || aux_count === (pgLevels - 1).U, aux_pte.ppn, makeFragmentedSuperpagePPN(aux_pte.ppn)(aux_count)),
+            r_pte.ppn,
+          ),
+          gpa_pgoff,
+        ),
+        r_req.addr,
+      )
     io.requestor(i).resp.bits.gpa_is_pte := !stage2_final
     io.requestor(i).ptbr := io.dpath.ptbr
     io.requestor(i).hgatp := io.dpath.hgatp
@@ -691,12 +702,21 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   when (mem_resp_valid) {
     assert(state === s_wait3)
     next_state := s_req
+    when (do_both_stages && !stage2) {
+      gpa_pgoff := {
+        val vpn_idxs = (0 until pgLevels).map(i => vpn >> ((pgLevels - i - 1) * pgLevelBits))
+        val vpn_idx  = vpn_idxs(count + 1.U)
+        vpn_idx << log2Ceil(xLen / 8)
+      }
+    }
+
     when (traverse) {
       when (do_both_stages && !stage2) { do_switch := true.B }
       count := count + 1.U
     }.otherwise {
-      val gf = (stage2 && !stage2_final && !pte.ur()) || (pte.leaf() && pte.reserved_for_future === 0.U && invalid_gpa)
-      val ae = pte.v && invalid_paddr
+      val gf = (stage2 && !stage2_final && !pte.ur()) ||
+        (Mux(count === (pgLevels - 1).U, pte.leaf(), pte.v) && pte.reserved_for_future === 0.U && invalid_gpa)
+      val ae = pte.v && invalid_paddr && !(invalid_gpa && ((count =/= (pgLevels - 1).U) || pte.leaf()))
       val pf = pte.v && pte.reserved_for_future =/= 0.U
       val success = pte.v && !ae && !pf && !gf
 
@@ -715,7 +735,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
            do_both_stages && aux_count === (pgLevels-1).U && pte.isFullPerm())
         count := max_count
 
-        when (pageGranularityPMPs.B && !(count === (pgLevels-1).U && (!do_both_stages || aux_count === (pgLevels-1).U))) {
+        when (success && pageGranularityPMPs.B && !(count === (pgLevels-1).U && (!do_both_stages || aux_count === (pgLevels-1).U))) {
           next_state := s_fragment_superpage
         }.otherwise {
           next_state := s_ready


### PR DESCRIPTION
**Related issue**: Introduced by previous fix https://github.com/chipsalliance/rocket-chip/pull/3651.

**Type of change**: bug report

**Impact**: functional fix

**Development Phase**: implementation

**Release Notes**
In the failing scenario, a Stage-1 (VS-mode) table (non-leaf) PTE PPN is larger than the Stage-2 (G-stage) input GPA maximum size. The previous fix only validated GPA bits higher than the HGATP mode for leaf PTEs, but the specification requires this check for all PTEs during page table traversal, including non-leaf (table) PTEs, which this fix does.

Changes in `PTW.scala`:
1. In equation `gf`: qualify the previous fix https://github.com/chipsalliance/rocket-chip/pull/3651 to check for just `pte.leaf()` at the last level only.  At non-last levels, this allows both leaf (superpage) and non-leaf entries.
2. In equation `ae`: suppress access exceptions when a guest page fault `gf` should be taken instead.
3. Capture the upper bits of the Stage-1 (VS-mode) PTE PPN in `gpa_pgoff`, even if they are higher than the `r_pte` can hold, to use in reporting the faulting GPA in the equation `resp.bits.gpa.bits`.
4. Do not advance the PTW FSM `state` or `count` to the `s_fragment_superpage` state when reporting a fault from the PTW, so that the `r_pte` captured does not change in the equation `resp.bits.gpa.bits`.