### PR TITLE
PTW: access vs guest page fault exception prioritization for Stage-1 PTEs with unsupported GPA sizes

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -310,7 +310,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
         when (count <= i.U && tmp.ppn((pgLevels-1-i)*pgLevelBits-1, (pgLevels-2-i)*pgLevelBits) =/= 0.U) { res.v := false.B }
     }
     (res,
-     Mux(do_both_stages && !stage2, (tmp.ppn >> vpnBits) =/= 0.U, (tmp.ppn >> ppnBits) =/= 0.U),
+     !(do_both_stages && !stage2) && ((tmp.ppn >> ppnBits) =/= 0.U),
      do_both_stages && !stage2 && checkInvalidHypervisorGPA(r_hgatp, tmp.ppn))
   }
   // find non-leaf PTE, need traverse
@@ -722,8 +722,8 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
           resp_valid(r_req_dest) := true.B
         }
 
-        resp_ae_ptw := ae && count < (pgLevels-1).U && pte.table()
-        resp_ae_final := ae && pte.leaf()
+        resp_ae_ptw := ae && ((count < (pgLevels-1).U && pte.table()) || (do_both_stages && !stage2_final))
+        resp_ae_final := ae && pte.leaf() && !(do_both_stages && !stage2_final)
         resp_pf := pf && !stage2
         resp_gf := gf || (pf && stage2)
         resp_hr := !stage2 || (!pf && !gf && pte.ur())

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -597,9 +597,9 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   val pf_ld_array = Mux(cmd_read, ((~Mux(cmd_readx, x_array, r_array) & ~ptw_ae_array) | ptw_pf_array) & ~ptw_gf_array, 0.U)
   val pf_st_array = Mux(cmd_write_perms, ((~w_array & ~ptw_ae_array) | ptw_pf_array) & ~ptw_gf_array, 0.U)
   val pf_inst_array = ((~x_array & ~ptw_ae_array) | ptw_pf_array) & ~ptw_gf_array
-  val gf_ld_array = Mux(priv_v && cmd_read, (~Mux(cmd_readx, hx_array, hr_array) | ptw_gf_array) & ~ptw_ae_array, 0.U)
-  val gf_st_array = Mux(priv_v && cmd_write_perms, (~hw_array | ptw_gf_array) & ~ptw_ae_array, 0.U)
-  val gf_inst_array = Mux(priv_v, (~hx_array | ptw_gf_array) & ~ptw_ae_array, 0.U)
+  val gf_ld_array = Mux(priv_v && cmd_read, (~Mux(cmd_readx, hx_array, hr_array) & ~ptw_ae_array) | ptw_gf_array, 0.U)
+  val gf_st_array = Mux(priv_v && cmd_write_perms, (~hw_array & ~ptw_ae_array) | ptw_gf_array, 0.U)
+  val gf_inst_array = Mux(priv_v, (~hx_array & ~ptw_ae_array) | ptw_gf_array, 0.U)
 
   val gpa_hits = {
     val need_gpa_mask = if (instruction) gf_inst_array else gf_ld_array | gf_st_array


### PR DESCRIPTION
**Related issue**: follows https://github.com/chipsalliance/rocket-chip/pull/3788

**Type of change**: bug report

**Impact**: functional fix

**Development Phase**: implementation

**Release Notes**
An access exception was raised instead of guest page fault exception for Stage-1 PTEs with unsupported GPA sizes.

PTW:
1. Do not report `invalid_paddr` from Stage-1 (VS-mode) underneath Stage-2.  Instead, rely on the `invalid_gpa` check from https://github.com/chipsalliance/rocket-chip/pull/3591.
2. Remove the extra unnecessary logic from `ae`, because `gf` (guest fault) is higher priority in the fault prioritization checkExceptions list.
3. An access exception from a Stage-2 (G-Stage) PTW for a Stage-1 (VS-stage) table (non-final) entry should be treated as a non-final access exception.

TLB:
1. Swap the priority in `gf_*_array` so that a PTW guest fault is higher priority than access exception, following the same example as `pf_*_array`.