### PR TITLE
Resolve implicit-width-truncation warnings

### DIFF
--- a/src/main/scala/amba/axi4/Fragmenter.scala
+++ b/src/main/scala/amba/axi4/Fragmenter.scala
@@ -132,7 +132,7 @@ class AXI4Fragmenter()(implicit p: Parameters) extends LazyModule
         when (out.fire) {
           busy := !last
           r_addr := mux_addr
-          r_len  := len - beats
+          r_len  :<= (len - beats).squeeze
         }
 
         (out, last, beats)

--- a/src/main/scala/amba/axi4/Fragmenter.scala
+++ b/src/main/scala/amba/axi4/Fragmenter.scala
@@ -11,6 +11,7 @@ import org.chipsalliance.diplomacy.lazymodule.{LazyModule, LazyModuleImp}
 
 import freechips.rocketchip.diplomacy.{AddressDecoder, AddressSet, TransferSizes}
 import freechips.rocketchip.util.{ControlKey, SimpleBundleField, rightOR, leftOR, OH1ToOH, UIntToOH1}
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 case object AXI4FragLast extends ControlKey[Bool]("real_last")
 case class AXI4FragLastField() extends SimpleBundleField(AXI4FragLast)(Output(Bool()), false.B)
@@ -132,7 +133,7 @@ class AXI4Fragmenter()(implicit p: Parameters) extends LazyModule
         when (out.fire) {
           busy := !last
           r_addr := mux_addr
-          r_len  :<= (len - beats).squeeze
+          r_len  :%= (len - beats)
         }
 
         (out, last, beats)

--- a/src/main/scala/devices/debug/Custom.scala
+++ b/src/main/scala/devices/debug/Custom.scala
@@ -84,7 +84,7 @@ class DebugCustomXbar(
     }
     // mux correct 'ready' and 'data' based on address
     sink.ready := (decoded zip sources).foldLeft(false.B){case (result, (d, i)) => result || (d & i.ready)}
-    sink.data := (decoded zip sources).foldLeft(0.U){ case (result, (d, i)) => result | Mux(i.ready, i.data, 0.U)}
+    sink.data :<= (decoded zip sources).foldLeft(0.U(0.W)){ case (result, (d, i)) => result | Mux(i.ready, i.data, 0.U)}
 
   }
 }

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -24,6 +24,7 @@ import freechips.rocketchip.util.{AsyncBundle, AsyncQueueParams, AsyncResetSynch
 import freechips.rocketchip.util.SeqBoolBitwiseOps
 import freechips.rocketchip.util.SeqToAugmentedSeq
 import freechips.rocketchip.util.BooleanToAugmentedBoolean
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 object DsbBusConsts {
   def sbAddrWidth = 12
@@ -905,7 +906,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       when (~io.dmactive) {
         selectedHartReg := 0.U
       }.elsewhen (io.innerCtrl.fire){
-        selectedHartReg :<= io.innerCtrl.bits.hartsel.squeeze
+        selectedHartReg :%= io.innerCtrl.bits.hartsel
       }
     }
 
@@ -1042,7 +1043,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         }.otherwise {
           when (haltgroupWrEn & DMCS2WrData.hgwrite & ~DMCS2WrData.hgselect &
               hamaskFull(component) & (DMCS2WrData.haltgroup <= nHaltGroups.U)) {
-            hgParticipateHart(component) :<= DMCS2WrData.haltgroup.squeeze
+            hgParticipateHart(component) :%= DMCS2WrData.haltgroup
           }
         }
       }
@@ -1323,10 +1324,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         val hartselIndex        = UIntToOH(io.innerCtrl.bits.hartsel)
         when (hartHaltedWrEn) {
           // add those harts halting and remove those in reset
-          haltedBitRegs :<= ((haltedBitRegs | hartHaltedIdIndex) & ~(hartIsInResetSync.asUInt)).squeeze
+          haltedBitRegs :%= ((haltedBitRegs | hartHaltedIdIndex) & ~(hartIsInResetSync.asUInt))
         }.elsewhen (hartResumingWrEn) {
           // remove those harts in reset and those in resume
-          haltedBitRegs :<= ((haltedBitRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt)).squeeze
+          haltedBitRegs :%= ((haltedBitRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt))
         }.otherwise {
           // remove those harts in reset
           haltedBitRegs := haltedBitRegs & ~(hartIsInResetSync.asUInt)
@@ -1334,7 +1335,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
         when (hartResumingWrEn) {
           // remove those harts in resume and those in reset
-          resumeReqRegs :<= ((resumeReqRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt)).squeeze
+          resumeReqRegs :%= ((resumeReqRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt))
         }
         when (resumereq) {
           // set all sleceted harts to resumeReq, remove those in reset
@@ -1574,7 +1575,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         val immBits = WireInit(VecInit(immWire.asBools))
 
         imm0 := immBits.slice(1,  1  + 10).asUInt
-        imm1 :<= immBits.slice(11, 11 + 11).asUInt.squeeze
+        imm1 :%= immBits.slice(11, 11 + 11).asUInt
         imm2 := immBits.slice(12, 12 + 8).asUInt
         imm3 := immBits.slice(20, 20 + 1).asUInt
       }
@@ -1589,7 +1590,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       val offset = if (cfg.atzero) DATA else (DATA-0x800) & 0xFFF
       val base = if (cfg.atzero) 0.U else Mux(accessRegisterCommandReg.regno(0), 8.U, 9.U)
       inst.opcode := (Instructions.LW.value.U.asTypeOf(new GeneratedI())).opcode
-      inst.rd     :<= (accessRegisterCommandReg.regno & 0x1F.U).squeeze
+      inst.rd     :%= (accessRegisterCommandReg.regno & 0x1F.U)
       inst.funct3 := accessRegisterCommandReg.size
       inst.rs1    := base
       inst.imm    := offset.U
@@ -1604,7 +1605,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       inst.immlo  := (offset & 0x1F).U
       inst.funct3 := accessRegisterCommandReg.size
       inst.rs1    := base
-      inst.rs2    :<= (accessRegisterCommandReg.regno & 0x1F.U).squeeze
+      inst.rs2    :%= (accessRegisterCommandReg.regno & 0x1F.U)
       inst.immhi  := (offset >> 5).U
       inst.asUInt
     }

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -905,7 +905,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       when (~io.dmactive) {
         selectedHartReg := 0.U
       }.elsewhen (io.innerCtrl.fire){
-        selectedHartReg := io.innerCtrl.bits.hartsel
+        selectedHartReg :<= io.innerCtrl.bits.hartsel.squeeze
       }
     }
 
@@ -1042,7 +1042,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         }.otherwise {
           when (haltgroupWrEn & DMCS2WrData.hgwrite & ~DMCS2WrData.hgselect &
               hamaskFull(component) & (DMCS2WrData.haltgroup <= nHaltGroups.U)) {
-            hgParticipateHart(component) := DMCS2WrData.haltgroup
+            hgParticipateHart(component) :<= DMCS2WrData.haltgroup.squeeze
           }
         }
       }
@@ -1323,10 +1323,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         val hartselIndex        = UIntToOH(io.innerCtrl.bits.hartsel)
         when (hartHaltedWrEn) {
           // add those harts halting and remove those in reset
-          haltedBitRegs := (haltedBitRegs | hartHaltedIdIndex) & ~(hartIsInResetSync.asUInt)
+          haltedBitRegs :<= ((haltedBitRegs | hartHaltedIdIndex) & ~(hartIsInResetSync.asUInt)).squeeze
         }.elsewhen (hartResumingWrEn) {
           // remove those harts in reset and those in resume
-          haltedBitRegs := (haltedBitRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt)
+          haltedBitRegs :<= ((haltedBitRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt)).squeeze
         }.otherwise {
           // remove those harts in reset
           haltedBitRegs := haltedBitRegs & ~(hartIsInResetSync.asUInt)
@@ -1334,7 +1334,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
         when (hartResumingWrEn) {
           // remove those harts in resume and those in reset
-          resumeReqRegs := (resumeReqRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt)
+          resumeReqRegs :<= ((resumeReqRegs & ~(hartResumingIdIndex)) & ~(hartIsInResetSync.asUInt)).squeeze
         }
         when (resumereq) {
           // set all sleceted harts to resumeReq, remove those in reset
@@ -1574,7 +1574,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         val immBits = WireInit(VecInit(immWire.asBools))
 
         imm0 := immBits.slice(1,  1  + 10).asUInt
-        imm1 := immBits.slice(11, 11 + 11).asUInt
+        imm1 :<= immBits.slice(11, 11 + 11).asUInt.squeeze
         imm2 := immBits.slice(12, 12 + 8).asUInt
         imm3 := immBits.slice(20, 20 + 1).asUInt
       }
@@ -1589,7 +1589,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       val offset = if (cfg.atzero) DATA else (DATA-0x800) & 0xFFF
       val base = if (cfg.atzero) 0.U else Mux(accessRegisterCommandReg.regno(0), 8.U, 9.U)
       inst.opcode := (Instructions.LW.value.U.asTypeOf(new GeneratedI())).opcode
-      inst.rd     := (accessRegisterCommandReg.regno & 0x1F.U)
+      inst.rd     :<= (accessRegisterCommandReg.regno & 0x1F.U).squeeze
       inst.funct3 := accessRegisterCommandReg.size
       inst.rs1    := base
       inst.imm    := offset.U
@@ -1604,7 +1604,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       inst.immlo  := (offset & 0x1F).U
       inst.funct3 := accessRegisterCommandReg.size
       inst.rs1    := base
-      inst.rs2    := (accessRegisterCommandReg.regno & 0x1F.U)
+      inst.rs2    :<= (accessRegisterCommandReg.regno & 0x1F.U).squeeze
       inst.immhi  := (offset >> 5).U
       inst.asUInt
     }

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -237,7 +237,7 @@ object SystemBusAccessModule
     SBCSRdData.sbaccess16  := (cfg.maxSupportedSBAccess >=  16).B
     SBCSRdData.sbaccess8   := (cfg.maxSupportedSBAccess >=   8).B
     SBCSRdData.sbbusy      := sbBusy
-    SBCSRdData.sberror     := sbErrorReg.asUInt
+    SBCSRdData.sberror     :<= sbErrorReg.asUInt.squeeze
     
     when (~dmAuthenticated) {    // Read value must be 0 if not authenticated
       SBCSRdData := 0.U.asTypeOf(new SBCSFields())

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -14,6 +14,7 @@ import freechips.rocketchip.diplomacy.TransferSizes
 import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup, RegFieldWrType}
 import freechips.rocketchip.tilelink.{TLClientNode, TLMasterParameters, TLMasterPortParameters}
 import freechips.rocketchip.util.property
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 object SystemBusAccessState extends scala.Enumeration {
    type SystemBusAccessState = Value
@@ -237,7 +238,7 @@ object SystemBusAccessModule
     SBCSRdData.sbaccess16  := (cfg.maxSupportedSBAccess >=  16).B
     SBCSRdData.sbaccess8   := (cfg.maxSupportedSBAccess >=   8).B
     SBCSRdData.sbbusy      := sbBusy
-    SBCSRdData.sberror     :<= sbErrorReg.asUInt.squeeze
+    SBCSRdData.sberror     :%= sbErrorReg.asUInt
     
     when (~dmAuthenticated) {    // Read value must be 0 if not authenticated
       SBCSRdData := 0.U.asTypeOf(new SBCSFields())

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -21,6 +21,7 @@ import scala.math.min
 
 import freechips.rocketchip.util.UIntToAugmentedUInt
 import freechips.rocketchip.util.SeqToAugmentedSeq
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 class GatewayPLICIO extends Bundle {
   val valid = Output(Bool())
@@ -352,7 +353,7 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 
   val effectivePriority = (1.U << prioBits) +: (io.ip.asBools zip io.prio).map { case (p, x) => Cat(p, x) }
   val (maxPri, maxDev) = findMax(effectivePriority)
-  io.max :<= maxPri.squeeze // strips the always-constant high '1' bit
+  io.max :%= maxPri // strips the always-constant high '1' bit
   io.dev := maxDev
 }
 

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -352,7 +352,7 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 
   val effectivePriority = (1.U << prioBits) +: (io.ip.asBools zip io.prio).map { case (p, x) => Cat(p, x) }
   val (maxPri, maxDev) = findMax(effectivePriority)
-  io.max := maxPri // strips the always-constant high '1' bit
+  io.max :<= maxPri.squeeze // strips the always-constant high '1' bit
   io.dev := maxDev
 }
 

--- a/src/main/scala/regmapper/RegField.scala
+++ b/src/main/scala/regmapper/RegField.scala
@@ -153,7 +153,7 @@ object RegField
     val oldBytes = VecInit.tabulate(numBytes) { i => pad(8*(i+1)-1, 8*i) }
     val newBytes = WireDefault(oldBytes)
     val valids = WireDefault(VecInit.fill(numBytes) { false.B })
-    when (valids.reduce(_ || _)) { reg := newBytes.asUInt }
+    when (valids.reduce(_ || _)) { reg :<= newBytes.asUInt.squeeze }
 
     def wrFn(i: Int): RegWriteFn = RegWriteFn((valid, data) => {
       valids(i) := valid

--- a/src/main/scala/regmapper/RegField.scala
+++ b/src/main/scala/regmapper/RegField.scala
@@ -11,6 +11,7 @@ import org.json4s.JsonDSL._
 import org.json4s.JsonAST.JValue
 
 import freechips.rocketchip.util.{SimpleRegIO}
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 case class RegReadFn private(combinational: Boolean, fn: (Bool, Bool) => (Bool, Bool, UInt))
 object RegReadFn
@@ -153,7 +154,7 @@ object RegField
     val oldBytes = VecInit.tabulate(numBytes) { i => pad(8*(i+1)-1, 8*i) }
     val newBytes = WireDefault(oldBytes)
     val valids = WireDefault(VecInit.fill(numBytes) { false.B })
-    when (valids.reduce(_ || _)) { reg :<= newBytes.asUInt.squeeze }
+    when (valids.reduce(_ || _)) { reg :%= newBytes.asUInt }
 
     def wrFn(i: Int): RegWriteFn = RegWriteFn((valid, data) => {
       valids(i) := valid

--- a/src/main/scala/rocket/BTB.scala
+++ b/src/main/scala/rocket/BTB.scala
@@ -233,7 +233,7 @@ class BTB(implicit p: Parameters) extends BtbModule {
   val usePageHit = pageHit.orR
   val doIdxPageRepl = !useUpdatePageHit
   val nextPageRepl = RegInit(0.U(log2Ceil(nPages).W))
-  val idxPageRepl = Cat(pageHit(nPages-2,0), pageHit(nPages-1)) | Mux(usePageHit, 0.U, UIntToOH(nextPageRepl))
+  val idxPageRepl = Cat(pageHit(nPages-2,0), pageHit(nPages-1)) | Mux(usePageHit, 0.U, UIntToOH(nextPageRepl, nPages))
   val idxPageUpdateOH = Mux(useUpdatePageHit, updatePageHit, idxPageRepl)
   val idxPageUpdate = OHToUInt(idxPageUpdateOH)
   val idxPageReplEn = Mux(doIdxPageRepl, idxPageRepl, 0.U)
@@ -258,13 +258,13 @@ class BTB(implicit p: Parameters) extends BtbModule {
   }
 
   when (r_btb_update.valid) {
-    val mask = UIntToOH(waddr)
+    val mask = UIntToOH(waddr, entries)
     idxs(waddr) := r_btb_update.bits.pc(matchBits-1, log2Up(coreInstBytes))
     tgts(waddr) := update_target(matchBits-1, log2Up(coreInstBytes))
     idxPages(waddr) :<= (idxPageUpdate +& 1.U).squeeze // the +1 corresponds to the <<1 on io.resp.valid
     tgtPages(waddr) := tgtPageUpdate
     cfiType(waddr) := r_btb_update.bits.cfiType
-    isValid := Mux(r_btb_update.bits.isValid, isValid | mask, isValid & ~mask)
+    isValid :<= Mux(r_btb_update.bits.isValid, isValid | mask, isValid & ~mask)
     if (fetchWidth > 1)
       brIdx(waddr) :<= (r_btb_update.bits.br_pc >> log2Up(coreInstBytes)).squeeze
 
@@ -279,7 +279,7 @@ class BTB(implicit p: Parameters) extends BtbModule {
       Mux(idxWritesEven, page(r_btb_update.bits.pc), page(update_target)))
     writeBank(1, 2, Mux(idxWritesEven, tgtPageReplEn, idxPageReplEn),
       Mux(idxWritesEven, page(update_target), page(r_btb_update.bits.pc)))
-    pageValid := pageValid | tgtPageReplEn | idxPageReplEn
+    pageValid :<= pageValid | tgtPageReplEn | idxPageReplEn
   }
 
   io.resp.valid := (pageHit << 1)(Mux1H(idxHit, idxPages))

--- a/src/main/scala/rocket/BTB.scala
+++ b/src/main/scala/rocket/BTB.scala
@@ -261,12 +261,12 @@ class BTB(implicit p: Parameters) extends BtbModule {
     val mask = UIntToOH(waddr, entries)
     idxs(waddr) := r_btb_update.bits.pc(matchBits-1, log2Up(coreInstBytes))
     tgts(waddr) := update_target(matchBits-1, log2Up(coreInstBytes))
-    idxPages(waddr) :<= (idxPageUpdate +& 1.U).squeeze // the +1 corresponds to the <<1 on io.resp.valid
+    idxPages(waddr) :%= (idxPageUpdate +& 1.U) // the +1 corresponds to the <<1 on io.resp.valid
     tgtPages(waddr) := tgtPageUpdate
     cfiType(waddr) := r_btb_update.bits.cfiType
     isValid :<= Mux(r_btb_update.bits.isValid, isValid | mask, isValid & ~mask)
     if (fetchWidth > 1)
-      brIdx(waddr) :<= (r_btb_update.bits.br_pc >> log2Up(coreInstBytes)).squeeze
+      brIdx(waddr) :%= (r_btb_update.bits.br_pc >> log2Up(coreInstBytes))
 
     require(nPages % 2 == 0)
     val idxWritesEven = !idxPageUpdate(0)
@@ -287,7 +287,7 @@ class BTB(implicit p: Parameters) extends BtbModule {
   io.resp.bits.target := Cat(pagesMasked(Mux1H(idxHit, tgtPages)), Mux1H(idxHit, tgts) << log2Up(coreInstBytes))
   io.resp.bits.entry := OHToUInt(idxHit)
   io.resp.bits.bridx := (if (fetchWidth > 1) Mux1H(idxHit, brIdx) else 0.U)
-  io.resp.bits.mask :<= Cat((1.U << ~Mux(io.resp.bits.taken, ~io.resp.bits.bridx, 0.U))-1.U, 1.U).squeeze
+  io.resp.bits.mask :%= Cat((1.U << ~Mux(io.resp.bits.taken, ~io.resp.bits.bridx, 0.U))-1.U, 1.U)
   io.resp.bits.cfiType := Mux1H(idxHit, cfiType)
 
   // if multiple entries for same PC land in BTB, zap them

--- a/src/main/scala/rocket/BTB.scala
+++ b/src/main/scala/rocket/BTB.scala
@@ -261,12 +261,12 @@ class BTB(implicit p: Parameters) extends BtbModule {
     val mask = UIntToOH(waddr)
     idxs(waddr) := r_btb_update.bits.pc(matchBits-1, log2Up(coreInstBytes))
     tgts(waddr) := update_target(matchBits-1, log2Up(coreInstBytes))
-    idxPages(waddr) := idxPageUpdate +& 1.U // the +1 corresponds to the <<1 on io.resp.valid
+    idxPages(waddr) :<= (idxPageUpdate +& 1.U).squeeze // the +1 corresponds to the <<1 on io.resp.valid
     tgtPages(waddr) := tgtPageUpdate
     cfiType(waddr) := r_btb_update.bits.cfiType
     isValid := Mux(r_btb_update.bits.isValid, isValid | mask, isValid & ~mask)
     if (fetchWidth > 1)
-      brIdx(waddr) := r_btb_update.bits.br_pc >> log2Up(coreInstBytes)
+      brIdx(waddr) :<= (r_btb_update.bits.br_pc >> log2Up(coreInstBytes)).squeeze
 
     require(nPages % 2 == 0)
     val idxWritesEven = !idxPageUpdate(0)
@@ -287,7 +287,7 @@ class BTB(implicit p: Parameters) extends BtbModule {
   io.resp.bits.target := Cat(pagesMasked(Mux1H(idxHit, tgtPages)), Mux1H(idxHit, tgts) << log2Up(coreInstBytes))
   io.resp.bits.entry := OHToUInt(idxHit)
   io.resp.bits.bridx := (if (fetchWidth > 1) Mux1H(idxHit, brIdx) else 0.U)
-  io.resp.bits.mask := Cat((1.U << ~Mux(io.resp.bits.taken, ~io.resp.bits.bridx, 0.U))-1.U, 1.U)
+  io.resp.bits.mask :<= Cat((1.U << ~Mux(io.resp.bits.taken, ~io.resp.bits.bridx, 0.U))-1.U, 1.U).squeeze
   io.resp.bits.cfiType := Mux1H(idxHit, cfiType)
 
   // if multiple entries for same PC land in BTB, zap them

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -627,8 +627,8 @@ class CSRFile(
   io.interrupt := (anyInterrupt && !io.singleStep || reg_singleStepped) && !(reg_debug || io.status.cease)
   io.interrupt_cause := interruptCause
   io.bp := reg_bp take nBreakpoints
-  io.mcontext := reg_mcontext.getOrElse(0.U)
-  io.scontext := reg_scontext.getOrElse(0.U)
+  io.mcontext :<= reg_mcontext.getOrElse(0.U(0.W))
+  io.scontext :<= reg_scontext.getOrElse(0.U(0.W))
   io.fiom := (reg_mstatus.prv < PRV.M.U && reg_menvcfg.fiom) || (reg_mstatus.prv < PRV.S.U && reg_senvcfg.fiom) || (reg_mstatus.v && reg_henvcfg.fiom)
   io.pmp := reg_pmp.map(PMP(_))
 

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -994,7 +994,7 @@ class CSRFile(
   val nmiTVec = (Mux(causeIsNmi, nmiTVecInt, nmiTVecXcpt)>>1)<<1
 
   val tvec = Mux(trapToDebug, debugTVec, Mux(trapToNmi, nmiTVec, notDebugTVec))
-  io.evec :<= tvec.squeeze
+  io.evec :%= tvec
   io.ptbr := reg_satp
   io.hgatp := reg_hgatp
   io.vsatp := reg_vsatp
@@ -1004,7 +1004,7 @@ class CSRFile(
   io.status := reg_mstatus
   io.status.sd := io.status.fs.andR || io.status.xs.andR || io.status.vs.andR
   io.status.debug := reg_debug
-  io.status.isa :<= reg_misa.squeeze
+  io.status.isa :%= reg_misa
   io.status.uxl := (if (usingUser) log2Ceil(xLen) - 4 else 0).U
   io.status.sxl := (if (usingSupervisor) log2Ceil(xLen) - 4 else 0).U
   io.status.dprv := Mux(reg_mstatus.mprv && !reg_debug, reg_mstatus.mpp, reg_mstatus.prv)
@@ -1057,7 +1057,7 @@ class CSRFile(
       }
     }.elsewhen (delegateVS && nmie) {
       reg_mstatus.v := true.B
-      reg_vsstatus.spp :<= reg_mstatus.prv.squeeze
+      reg_vsstatus.spp :%= reg_mstatus.prv
       reg_vsepc := epc
       reg_vscause := Mux(cause(xLen-1), Cat(cause(xLen-1, 2), 1.U(2.W)), cause)
       reg_vstval := tval
@@ -1075,7 +1075,7 @@ class CSRFile(
       reg_htval := io.htval
       reg_htinst_read_pseudo := io.mhtinst_read_pseudo
       reg_mstatus.spie := reg_mstatus.sie
-      reg_mstatus.spp :<= reg_mstatus.prv.squeeze
+      reg_mstatus.spp :%= reg_mstatus.prv
       reg_mstatus.sie := false.B
       new_prv := PRV.S.U
     }.otherwise {
@@ -1159,7 +1159,7 @@ class CSRFile(
     }
   }
 
-  io.time :<= reg_cycle.value.squeeze
+  io.time :%= reg_cycle.value
   io.csr_stall := reg_wfi || io.status.cease
   io.status.cease := RegEnable(true.B, false.B, insn_cease)
   io.status.wfi := reg_wfi
@@ -1176,7 +1176,7 @@ class CSRFile(
     io.value := reg
   }
 
-  io.rw.rdata :<= Mux1H(for ((k, v) <- read_mapping) yield decoded_addr(k) -> v).asUInt.squeeze
+  io.rw.rdata :%= Mux1H(for ((k, v) <- read_mapping) yield decoded_addr(k) -> v).asUInt
 
   // cover access to register
   val coverable_counters = read_mapping.filterNot { case (k, _) =>
@@ -1222,7 +1222,7 @@ class CSRFile(
   }
 
   val csr_wen = io.rw.cmd.isOneOf(CSR.S, CSR.C, CSR.W) && !io.rw_stall
-  io.csrw_counter :<= Mux(coreParams.haveBasicCounters.B && csr_wen && (io.rw.addr.inRange(CSRs.mcycle.U, (CSRs.mcycle + CSR.nCtr).U) || io.rw.addr.inRange(CSRs.mcycleh.U, (CSRs.mcycleh + CSR.nCtr).U)), UIntToOH(io.rw.addr(log2Ceil(CSR.nCtr+nPerfCounters)-1, 0)), 0.U).squeeze
+  io.csrw_counter :%= Mux(coreParams.haveBasicCounters.B && csr_wen && (io.rw.addr.inRange(CSRs.mcycle.U, (CSRs.mcycle + CSR.nCtr).U) || io.rw.addr.inRange(CSRs.mcycleh.U, (CSRs.mcycleh + CSR.nCtr).U)), UIntToOH(io.rw.addr(log2Ceil(CSR.nCtr+nPerfCounters)-1, 0)), 0.U)
   when (csr_wen) {
     val scause_mask = ((BigInt(1) << (xLen-1)) + 31).U /* only implement 5 LSBs and MSB */
     val satp_valid_modes = 0 +: (minPgLevels to pgLevels).map(new PTBR().pgLevelsToMode(_))
@@ -1280,13 +1280,13 @@ class CSRFile(
         reg_mip.vssip := new_mip.vssip
       }
     }
-    when (decoded_addr(CSRs.mie))      { reg_mie :<= (wdata & supported_interrupts).squeeze }
-    when (decoded_addr(CSRs.mepc))     { reg_mepc :<= formEPC(wdata).squeeze }
+    when (decoded_addr(CSRs.mie))      { reg_mie :%= (wdata & supported_interrupts) }
+    when (decoded_addr(CSRs.mepc))     { reg_mepc :%= formEPC(wdata) }
     when (decoded_addr(CSRs.mscratch)) { reg_mscratch := wdata }
     if (mtvecWritable)
-      when (decoded_addr(CSRs.mtvec))  { reg_mtvec :<= wdata.squeeze }
+      when (decoded_addr(CSRs.mtvec))  { reg_mtvec :%= wdata }
     when (decoded_addr(CSRs.mcause))   { reg_mcause := wdata & ((BigInt(1) << (xLen-1)) + (BigInt(1) << whichInterrupt.getWidth) - 1).U }
-    when (decoded_addr(CSRs.mtval))    { reg_mtval :<= wdata.squeeze }
+    when (decoded_addr(CSRs.mtval))    { reg_mtval :%= wdata }
 
     if (usingNMI) {
       val new_mnstatus = wdata.asTypeOf(new MNStatus())
@@ -1305,18 +1305,18 @@ class CSRFile(
       when (decoded_addr(i + CSR.firstHPE)) { e := perfEventSets.maskEventSelector(wdata) }
     }
     if (coreParams.haveBasicCounters) {
-      when (decoded_addr(CSRs.mcountinhibit)) { reg_mcountinhibit :<= (wdata & ~2.U(xLen.W)).squeeze }  // mcountinhibit bit [1] is tied zero
+      when (decoded_addr(CSRs.mcountinhibit)) { reg_mcountinhibit :%= (wdata & ~2.U(xLen.W)) }  // mcountinhibit bit [1] is tied zero
       writeCounter(CSRs.mcycle, reg_cycle, wdata)
       writeCounter(CSRs.minstret, reg_instret, wdata)
     }
 
     if (usingFPU) {
-      when (decoded_addr(CSRs.fflags)) { set_fs_dirty := true.B; reg_fflags :<= wdata.squeeze }
-      when (decoded_addr(CSRs.frm))    { set_fs_dirty := true.B; reg_frm :<= wdata.squeeze }
+      when (decoded_addr(CSRs.fflags)) { set_fs_dirty := true.B; reg_fflags :%= wdata }
+      when (decoded_addr(CSRs.frm))    { set_fs_dirty := true.B; reg_frm :%= wdata }
       when (decoded_addr(CSRs.fcsr)) {
         set_fs_dirty := true.B
-        reg_fflags :<= wdata.squeeze
-        reg_frm :<= (wdata >> reg_fflags.getWidth).squeeze
+        reg_fflags :%= wdata
+        reg_frm :%= (wdata >> reg_fflags.getWidth)
       }
     }
     if (usingDebug) {
@@ -1329,7 +1329,7 @@ class CSRFile(
         if (usingUser) reg_dcsr.prv := legalizePrivilege(new_dcsr.prv)
         if (usingHypervisor) reg_dcsr.v := new_dcsr.v
       }
-      when (decoded_addr(CSRs.dpc))      { reg_dpc :<= formEPC(wdata).squeeze }
+      when (decoded_addr(CSRs.dpc))      { reg_dpc :%= formEPC(wdata) }
       when (decoded_addr(CSRs.dscratch0)) { reg_dscratch0 := wdata }
       reg_dscratch1.foreach { r =>
         when (decoded_addr(CSRs.dscratch1)) { r := wdata }
@@ -1364,13 +1364,13 @@ class CSRFile(
       }
       when (decoded_addr(CSRs.sie))      { reg_mie := (reg_mie & ~sie_mask) | (wdata & sie_mask) }
       when (decoded_addr(CSRs.sscratch)) { reg_sscratch := wdata }
-      when (decoded_addr(CSRs.sepc))     { reg_sepc :<= formEPC(wdata).squeeze }
-      when (decoded_addr(CSRs.stvec))    { reg_stvec :<= wdata.squeeze }
+      when (decoded_addr(CSRs.sepc))     { reg_sepc :%= formEPC(wdata) }
+      when (decoded_addr(CSRs.stvec))    { reg_stvec :%= wdata }
       when (decoded_addr(CSRs.scause))   { reg_scause := wdata & scause_mask }
-      when (decoded_addr(CSRs.stval))    { reg_stval :<= wdata.squeeze }
+      when (decoded_addr(CSRs.stval))    { reg_stval :%= wdata }
       when (decoded_addr(CSRs.mideleg))  { reg_mideleg := wdata }
       when (decoded_addr(CSRs.medeleg))  { reg_medeleg := wdata }
-      when (decoded_addr(CSRs.scounteren)) { reg_scounteren :<= wdata.squeeze }
+      when (decoded_addr(CSRs.scounteren)) { reg_scounteren :%= wdata }
       when (decoded_addr(CSRs.senvcfg))    { reg_senvcfg.write(wdata) }
     }
 
@@ -1408,9 +1408,9 @@ class CSRFile(
         reg_mip.vstip := new_sip.vstip
         reg_mip.vseip := new_sip.vseip
       }
-      when (decoded_addr(CSRs.hcounteren)) { reg_hcounteren :<= wdata.squeeze }
-      when (decoded_addr(CSRs.htval))      { reg_htval :<= wdata.squeeze }
-      when (decoded_addr(CSRs.mtval2))     { reg_mtval2 :<= wdata.squeeze }
+      when (decoded_addr(CSRs.hcounteren)) { reg_hcounteren :%= wdata }
+      when (decoded_addr(CSRs.htval))      { reg_htval :%= wdata }
+      when (decoded_addr(CSRs.mtval2))     { reg_mtval2 :%= wdata }
 
       val write_mhtinst_read_pseudo = wdata(13) && (xLen == 32).option(true.B).getOrElse(wdata(12))
       when(decoded_addr(CSRs.mtinst)) { reg_mtinst_read_pseudo := write_mhtinst_read_pseudo }
@@ -1441,24 +1441,24 @@ class CSRFile(
           if (asIdBits > 0) reg_vsatp.asid := new_vsatp.asid(asIdBits-1,0)
         }
       }
-      when (decoded_addr(CSRs.vsie))      { reg_mie :<= ((reg_mie & ~read_hideleg) | ((wdata << 1) & read_hideleg)).squeeze }
+      when (decoded_addr(CSRs.vsie))      { reg_mie :%= ((reg_mie & ~read_hideleg) | ((wdata << 1) & read_hideleg)) }
       when (decoded_addr(CSRs.vsscratch)) { reg_vsscratch := wdata }
-      when (decoded_addr(CSRs.vsepc))     { reg_vsepc :<= formEPC(wdata).squeeze }
-      when (decoded_addr(CSRs.vstvec))    { reg_vstvec :<= wdata.squeeze }
+      when (decoded_addr(CSRs.vsepc))     { reg_vsepc :%= formEPC(wdata) }
+      when (decoded_addr(CSRs.vstvec))    { reg_vstvec :%= wdata }
       when (decoded_addr(CSRs.vscause))   { reg_vscause := wdata & scause_mask }
-      when (decoded_addr(CSRs.vstval))    { reg_vstval :<= wdata.squeeze }
+      when (decoded_addr(CSRs.vstval))    { reg_vstval :%= wdata }
       when (decoded_addr(CSRs.henvcfg))   { reg_henvcfg.write(wdata) }
     }
     if (usingUser) {
-      when (decoded_addr(CSRs.mcounteren)) { reg_mcounteren :<= wdata.squeeze }
+      when (decoded_addr(CSRs.mcounteren)) { reg_mcounteren :%= wdata }
       when (decoded_addr(CSRs.menvcfg))    { reg_menvcfg.write(wdata) }
     }
     if (nBreakpoints > 0) {
-      when (decoded_addr(CSRs.tselect)) { reg_tselect :<= wdata.squeeze }
+      when (decoded_addr(CSRs.tselect)) { reg_tselect :%= wdata }
 
       for ((bp, i) <- reg_bp.zipWithIndex) {
         when (i.U === reg_tselect && (!bp.control.dmode || reg_debug)) {
-          when (decoded_addr(CSRs.tdata2)) { bp.address :<= wdata.squeeze }
+          when (decoded_addr(CSRs.tdata2)) { bp.address :%= wdata }
           when (decoded_addr(CSRs.tdata3)) {
             if (coreParams.mcontextWidth > 0) {
               bp.textra.mselect := wdata(bp.textra.mselectPos)
@@ -1499,7 +1499,7 @@ class CSRFile(
           pmp.cfg.a := Cat(newCfg.a(1), newCfg.a.orR)
       }
       when (decoded_addr(CSRs.pmpaddr0 + i) && !pmp.addrLocked(next)) {
-        pmp.addr :<= wdata.squeeze
+        pmp.addr :%= wdata
       }
     }
     def writeCustomCSR(io: CustomCSRIO, csr: CustomCSR, reg: UInt) = {

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -849,7 +849,7 @@ class CSRFile(
   Seq(CSRs.mimpid, CSRs.marchid, CSRs.mvendorid, CSRs.mconfigptr).foreach(id => read_mapping.getOrElseUpdate(id, 0.U))
 
   val decoded_addr = {
-    val addr = Cat(io.status.v, io.rw.addr)
+    val addr = io.rw.addr
     val pats = for (((k, _), i) <- read_mapping.zipWithIndex)
       yield (BitPat(k.U), (0 until read_mapping.size).map(j => BitPat((i == j).B)))
     val decoded = DecodeLogic(addr, Seq.fill(read_mapping.size)(X), pats)

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -994,7 +994,7 @@ class CSRFile(
   val nmiTVec = (Mux(causeIsNmi, nmiTVecInt, nmiTVecXcpt)>>1)<<1
 
   val tvec = Mux(trapToDebug, debugTVec, Mux(trapToNmi, nmiTVec, notDebugTVec))
-  io.evec := tvec
+  io.evec :<= tvec.squeeze
   io.ptbr := reg_satp
   io.hgatp := reg_hgatp
   io.vsatp := reg_vsatp
@@ -1004,7 +1004,7 @@ class CSRFile(
   io.status := reg_mstatus
   io.status.sd := io.status.fs.andR || io.status.xs.andR || io.status.vs.andR
   io.status.debug := reg_debug
-  io.status.isa := reg_misa
+  io.status.isa :<= reg_misa.squeeze
   io.status.uxl := (if (usingUser) log2Ceil(xLen) - 4 else 0).U
   io.status.sxl := (if (usingSupervisor) log2Ceil(xLen) - 4 else 0).U
   io.status.dprv := Mux(reg_mstatus.mprv && !reg_debug, reg_mstatus.mpp, reg_mstatus.prv)
@@ -1057,7 +1057,7 @@ class CSRFile(
       }
     }.elsewhen (delegateVS && nmie) {
       reg_mstatus.v := true.B
-      reg_vsstatus.spp := reg_mstatus.prv
+      reg_vsstatus.spp :<= reg_mstatus.prv.squeeze
       reg_vsepc := epc
       reg_vscause := Mux(cause(xLen-1), Cat(cause(xLen-1, 2), 1.U(2.W)), cause)
       reg_vstval := tval
@@ -1075,7 +1075,7 @@ class CSRFile(
       reg_htval := io.htval
       reg_htinst_read_pseudo := io.mhtinst_read_pseudo
       reg_mstatus.spie := reg_mstatus.sie
-      reg_mstatus.spp := reg_mstatus.prv
+      reg_mstatus.spp :<= reg_mstatus.prv.squeeze
       reg_mstatus.sie := false.B
       new_prv := PRV.S.U
     }.otherwise {
@@ -1159,7 +1159,7 @@ class CSRFile(
     }
   }
 
-  io.time := reg_cycle
+  io.time :<= reg_cycle.value.squeeze
   io.csr_stall := reg_wfi || io.status.cease
   io.status.cease := RegEnable(true.B, false.B, insn_cease)
   io.status.wfi := reg_wfi
@@ -1176,7 +1176,7 @@ class CSRFile(
     io.value := reg
   }
 
-  io.rw.rdata := Mux1H(for ((k, v) <- read_mapping) yield decoded_addr(k) -> v)
+  io.rw.rdata :<= Mux1H(for ((k, v) <- read_mapping) yield decoded_addr(k) -> v).asUInt.squeeze
 
   // cover access to register
   val coverable_counters = read_mapping.filterNot { case (k, _) =>
@@ -1222,7 +1222,7 @@ class CSRFile(
   }
 
   val csr_wen = io.rw.cmd.isOneOf(CSR.S, CSR.C, CSR.W) && !io.rw_stall
-  io.csrw_counter := Mux(coreParams.haveBasicCounters.B && csr_wen && (io.rw.addr.inRange(CSRs.mcycle.U, (CSRs.mcycle + CSR.nCtr).U) || io.rw.addr.inRange(CSRs.mcycleh.U, (CSRs.mcycleh + CSR.nCtr).U)), UIntToOH(io.rw.addr(log2Ceil(CSR.nCtr+nPerfCounters)-1, 0)), 0.U)
+  io.csrw_counter :<= Mux(coreParams.haveBasicCounters.B && csr_wen && (io.rw.addr.inRange(CSRs.mcycle.U, (CSRs.mcycle + CSR.nCtr).U) || io.rw.addr.inRange(CSRs.mcycleh.U, (CSRs.mcycleh + CSR.nCtr).U)), UIntToOH(io.rw.addr(log2Ceil(CSR.nCtr+nPerfCounters)-1, 0)), 0.U).squeeze
   when (csr_wen) {
     val scause_mask = ((BigInt(1) << (xLen-1)) + 31).U /* only implement 5 LSBs and MSB */
     val satp_valid_modes = 0 +: (minPgLevels to pgLevels).map(new PTBR().pgLevelsToMode(_))
@@ -1280,13 +1280,13 @@ class CSRFile(
         reg_mip.vssip := new_mip.vssip
       }
     }
-    when (decoded_addr(CSRs.mie))      { reg_mie := wdata & supported_interrupts }
-    when (decoded_addr(CSRs.mepc))     { reg_mepc := formEPC(wdata) }
+    when (decoded_addr(CSRs.mie))      { reg_mie :<= (wdata & supported_interrupts).squeeze }
+    when (decoded_addr(CSRs.mepc))     { reg_mepc :<= formEPC(wdata).squeeze }
     when (decoded_addr(CSRs.mscratch)) { reg_mscratch := wdata }
     if (mtvecWritable)
-      when (decoded_addr(CSRs.mtvec))  { reg_mtvec := wdata }
+      when (decoded_addr(CSRs.mtvec))  { reg_mtvec :<= wdata.squeeze }
     when (decoded_addr(CSRs.mcause))   { reg_mcause := wdata & ((BigInt(1) << (xLen-1)) + (BigInt(1) << whichInterrupt.getWidth) - 1).U }
-    when (decoded_addr(CSRs.mtval))    { reg_mtval := wdata }
+    when (decoded_addr(CSRs.mtval))    { reg_mtval :<= wdata.squeeze }
 
     if (usingNMI) {
       val new_mnstatus = wdata.asTypeOf(new MNStatus())
@@ -1305,18 +1305,18 @@ class CSRFile(
       when (decoded_addr(i + CSR.firstHPE)) { e := perfEventSets.maskEventSelector(wdata) }
     }
     if (coreParams.haveBasicCounters) {
-      when (decoded_addr(CSRs.mcountinhibit)) { reg_mcountinhibit := wdata & ~2.U(xLen.W) }  // mcountinhibit bit [1] is tied zero
+      when (decoded_addr(CSRs.mcountinhibit)) { reg_mcountinhibit :<= (wdata & ~2.U(xLen.W)).squeeze }  // mcountinhibit bit [1] is tied zero
       writeCounter(CSRs.mcycle, reg_cycle, wdata)
       writeCounter(CSRs.minstret, reg_instret, wdata)
     }
 
     if (usingFPU) {
-      when (decoded_addr(CSRs.fflags)) { set_fs_dirty := true.B; reg_fflags := wdata }
-      when (decoded_addr(CSRs.frm))    { set_fs_dirty := true.B; reg_frm := wdata }
+      when (decoded_addr(CSRs.fflags)) { set_fs_dirty := true.B; reg_fflags :<= wdata.squeeze }
+      when (decoded_addr(CSRs.frm))    { set_fs_dirty := true.B; reg_frm :<= wdata.squeeze }
       when (decoded_addr(CSRs.fcsr)) {
         set_fs_dirty := true.B
-        reg_fflags := wdata
-        reg_frm := wdata >> reg_fflags.getWidth
+        reg_fflags :<= wdata.squeeze
+        reg_frm :<= (wdata >> reg_fflags.getWidth).squeeze
       }
     }
     if (usingDebug) {
@@ -1329,7 +1329,7 @@ class CSRFile(
         if (usingUser) reg_dcsr.prv := legalizePrivilege(new_dcsr.prv)
         if (usingHypervisor) reg_dcsr.v := new_dcsr.v
       }
-      when (decoded_addr(CSRs.dpc))      { reg_dpc := formEPC(wdata) }
+      when (decoded_addr(CSRs.dpc))      { reg_dpc :<= formEPC(wdata).squeeze }
       when (decoded_addr(CSRs.dscratch0)) { reg_dscratch0 := wdata }
       reg_dscratch1.foreach { r =>
         when (decoded_addr(CSRs.dscratch1)) { r := wdata }
@@ -1364,13 +1364,13 @@ class CSRFile(
       }
       when (decoded_addr(CSRs.sie))      { reg_mie := (reg_mie & ~sie_mask) | (wdata & sie_mask) }
       when (decoded_addr(CSRs.sscratch)) { reg_sscratch := wdata }
-      when (decoded_addr(CSRs.sepc))     { reg_sepc := formEPC(wdata) }
-      when (decoded_addr(CSRs.stvec))    { reg_stvec := wdata }
+      when (decoded_addr(CSRs.sepc))     { reg_sepc :<= formEPC(wdata).squeeze }
+      when (decoded_addr(CSRs.stvec))    { reg_stvec :<= wdata.squeeze }
       when (decoded_addr(CSRs.scause))   { reg_scause := wdata & scause_mask }
-      when (decoded_addr(CSRs.stval))    { reg_stval := wdata }
+      when (decoded_addr(CSRs.stval))    { reg_stval :<= wdata.squeeze }
       when (decoded_addr(CSRs.mideleg))  { reg_mideleg := wdata }
       when (decoded_addr(CSRs.medeleg))  { reg_medeleg := wdata }
-      when (decoded_addr(CSRs.scounteren)) { reg_scounteren := wdata }
+      when (decoded_addr(CSRs.scounteren)) { reg_scounteren :<= wdata.squeeze }
       when (decoded_addr(CSRs.senvcfg))    { reg_senvcfg.write(wdata) }
     }
 
@@ -1408,9 +1408,9 @@ class CSRFile(
         reg_mip.vstip := new_sip.vstip
         reg_mip.vseip := new_sip.vseip
       }
-      when (decoded_addr(CSRs.hcounteren)) { reg_hcounteren := wdata }
-      when (decoded_addr(CSRs.htval))      { reg_htval := wdata }
-      when (decoded_addr(CSRs.mtval2))     { reg_mtval2 := wdata }
+      when (decoded_addr(CSRs.hcounteren)) { reg_hcounteren :<= wdata.squeeze }
+      when (decoded_addr(CSRs.htval))      { reg_htval :<= wdata.squeeze }
+      when (decoded_addr(CSRs.mtval2))     { reg_mtval2 :<= wdata.squeeze }
 
       val write_mhtinst_read_pseudo = wdata(13) && (xLen == 32).option(true.B).getOrElse(wdata(12))
       when(decoded_addr(CSRs.mtinst)) { reg_mtinst_read_pseudo := write_mhtinst_read_pseudo }
@@ -1441,24 +1441,24 @@ class CSRFile(
           if (asIdBits > 0) reg_vsatp.asid := new_vsatp.asid(asIdBits-1,0)
         }
       }
-      when (decoded_addr(CSRs.vsie))      { reg_mie := (reg_mie & ~read_hideleg) | ((wdata << 1) & read_hideleg) }
+      when (decoded_addr(CSRs.vsie))      { reg_mie :<= ((reg_mie & ~read_hideleg) | ((wdata << 1) & read_hideleg)).squeeze }
       when (decoded_addr(CSRs.vsscratch)) { reg_vsscratch := wdata }
-      when (decoded_addr(CSRs.vsepc))     { reg_vsepc := formEPC(wdata) }
-      when (decoded_addr(CSRs.vstvec))    { reg_vstvec := wdata }
+      when (decoded_addr(CSRs.vsepc))     { reg_vsepc :<= formEPC(wdata).squeeze }
+      when (decoded_addr(CSRs.vstvec))    { reg_vstvec :<= wdata.squeeze }
       when (decoded_addr(CSRs.vscause))   { reg_vscause := wdata & scause_mask }
-      when (decoded_addr(CSRs.vstval))    { reg_vstval := wdata }
+      when (decoded_addr(CSRs.vstval))    { reg_vstval :<= wdata.squeeze }
       when (decoded_addr(CSRs.henvcfg))   { reg_henvcfg.write(wdata) }
     }
     if (usingUser) {
-      when (decoded_addr(CSRs.mcounteren)) { reg_mcounteren := wdata }
+      when (decoded_addr(CSRs.mcounteren)) { reg_mcounteren :<= wdata.squeeze }
       when (decoded_addr(CSRs.menvcfg))    { reg_menvcfg.write(wdata) }
     }
     if (nBreakpoints > 0) {
-      when (decoded_addr(CSRs.tselect)) { reg_tselect := wdata }
+      when (decoded_addr(CSRs.tselect)) { reg_tselect :<= wdata.squeeze }
 
       for ((bp, i) <- reg_bp.zipWithIndex) {
         when (i.U === reg_tselect && (!bp.control.dmode || reg_debug)) {
-          when (decoded_addr(CSRs.tdata2)) { bp.address := wdata }
+          when (decoded_addr(CSRs.tdata2)) { bp.address :<= wdata.squeeze }
           when (decoded_addr(CSRs.tdata3)) {
             if (coreParams.mcontextWidth > 0) {
               bp.textra.mselect := wdata(bp.textra.mselectPos)
@@ -1499,7 +1499,7 @@ class CSRFile(
           pmp.cfg.a := Cat(newCfg.a(1), newCfg.a.orR)
       }
       when (decoded_addr(CSRs.pmpaddr0 + i) && !pmp.addrLocked(next)) {
-        pmp.addr := wdata
+        pmp.addr :<= wdata.squeeze
       }
     }
     def writeCustomCSR(io: CustomCSRIO, csr: CustomCSR, reg: UInt) = {

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -240,8 +240,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   dataArb.io.in(3).valid := io.cpu.req.valid && likelyNeedsRead(io.cpu.req.bits)
   dataArb.io.in(3).bits := dataArb.io.in(1).bits
   dataArb.io.in(3).bits.write := false.B
-  dataArb.io.in(3).bits.addr := Cat(io.cpu.req.bits.idx.getOrElse(io.cpu.req.bits.addr) >> tagLSB, io.cpu.req.bits.addr(tagLSB-1, 0))
-  dataArb.io.in(3).bits.wordMask := {
+  dataArb.io.in(3).bits.addr :<= Cat(io.cpu.req.bits.idx.getOrElse(io.cpu.req.bits.addr) >> tagLSB, io.cpu.req.bits.addr(tagLSB-1, 0)).squeeze
+  dataArb.io.in(3).bits.wordMask :<= {
     val mask = (subWordBytes.log2 until rowOffBits).foldLeft(1.U) { case (in, i) =>
       val upper_mask = Mux((i >= wordBytes.log2).B || io.cpu.req.bits.size <= i.U, 0.U,
         ((BigInt(1) << (1 << (i - subWordBytes.log2)))-1).U)
@@ -250,7 +250,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
       upper ## lower
     }
     Fill(subWordBytes / eccBytes, mask)
-  }
+  }.squeeze
   dataArb.io.in(3).bits.eccMask := ~0.U((wordBytes / eccBytes).W)
   dataArb.io.in(3).bits.way_en := ~0.U(nWays.W)
   when (!dataArb.io.in(3).ready && s0_read) { io.cpu.req.ready := false.B }
@@ -276,8 +276,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   tlb.io.sfence.valid := s1_valid && !io.cpu.s1_kill && s1_sfence
   tlb.io.sfence.bits.rs1 := s1_req.size(0)
   tlb.io.sfence.bits.rs2 := s1_req.size(1)
-  tlb.io.sfence.bits.asid := io.cpu.s1_data.data
-  tlb.io.sfence.bits.addr := s1_req.addr
+  tlb.io.sfence.bits.asid :<= io.cpu.s1_data.data.squeeze
+  tlb.io.sfence.bits.addr :<= s1_req.addr.squeeze
   tlb.io.sfence.bits.hv := s1_req.cmd === M_HFENCEV
   tlb.io.sfence.bits.hg := s1_req.cmd === M_HFENCEG
 
@@ -544,14 +544,14 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   })
   dataArb.io.in(0).valid := should_pstore_drain(false.B)
   dataArb.io.in(0).bits.write := pstore_drain
-  dataArb.io.in(0).bits.addr := Mux(pstore2_valid, pstore2_addr, pstore1_addr)
+  dataArb.io.in(0).bits.addr :<= Mux(pstore2_valid, pstore2_addr, pstore1_addr).squeeze
   dataArb.io.in(0).bits.way_en := Mux(pstore2_valid, pstore2_way, pstore1_way)
   dataArb.io.in(0).bits.wdata := encodeData(Fill(rowWords, Mux(pstore2_valid, pstore2_storegen_data, pstore1_data)), false.B)
-  dataArb.io.in(0).bits.wordMask := {
+  dataArb.io.in(0).bits.wordMask :<= {
     val eccMask = dataArb.io.in(0).bits.eccMask.asBools.grouped(subWordBytes/eccBytes).map(_.orR).toSeq.asUInt
     val wordMask = UIntToOH(Mux(pstore2_valid, pstore2_addr, pstore1_addr).extract(rowOffBits-1, wordBytes.log2))
     FillInterleaved(wordBytes/subWordBytes, wordMask) & Fill(rowBytes/wordBytes, eccMask)
-  }
+  }.squeeze
   dataArb.io.in(0).bits.eccMask := eccMask(Mux(pstore2_valid, pstore2_storegen_mask, pstore1_mask))
 
   // store->load RAW hazard detection
@@ -723,7 +723,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   }
   if (!usingDataScratchpad) {
     dataArb.io.in(1).bits.write := true.B
-    dataArb.io.in(1).bits.addr :=  (s2_vaddr >> idxLSB) << idxLSB | d_address_inc
+    dataArb.io.in(1).bits.addr :<= ((s2_vaddr >> idxLSB) << idxLSB | d_address_inc).squeeze
     dataArb.io.in(1).bits.way_en := refill_way
     dataArb.io.in(1).bits.wdata := tl_d_data_encoded
     dataArb.io.in(1).bits.wordMask := ~0.U((rowBytes / subWordBytes).W)
@@ -916,7 +916,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   io.cpu.resp.bits.has_data := s2_read
   io.cpu.resp.bits.replay := false.B
   io.cpu.s2_uncached := s2_uncached && !s2_hit
-  io.cpu.s2_paddr := s2_req.addr
+  io.cpu.s2_paddr :<= s2_req.addr.squeeze
   io.cpu.s2_gpa := s2_tlb_xcpt.gpa
   io.cpu.s2_gpa_is_pte := s2_tlb_xcpt.gpa_is_pte
 
@@ -1047,7 +1047,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   metaArb.io.in(0).bits.way_en := ~0.U(nWays.W)
   metaArb.io.in(0).bits.data := tECC.encode(L1Metadata(0.U, ClientMetadata.onReset).asUInt)
   when (resetting) {
-    flushCounter := flushCounterNext
+    flushCounter :<= flushCounterNext.squeeze
     when (flushDone) {
       resetting := false.B
       if (!isPow2(nWays)) flushCounter := flushCounterWrap
@@ -1125,7 +1125,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
       io.errors.uncorrectable.foreach { u => when (u.valid) { c.valid := false.B } }
     }
     io.errors.bus.valid := tl_out.d.fire && (tl_out.d.bits.denied || tl_out.d.bits.corrupt)
-    io.errors.bus.bits := Mux(grantIsCached, s2_req.addr >> idxLSB << idxLSB, 0.U)
+    io.errors.bus.bits :<= Mux(grantIsCached, s2_req.addr >> idxLSB << idxLSB, 0.U).squeeze
 
     ccoverNotScratchpad(io.errors.bus.valid && grantIsCached, "D_ERROR_CACHED", "D$ D-channel error, cached")
     ccover(io.errors.bus.valid && !grantIsCached, "D_ERROR_UNCACHED", "D$ D-channel error, uncached")

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -22,6 +22,7 @@ import freechips.rocketchip.util.UIntIsOneOf
 import freechips.rocketchip.util.IntToAugmentedInt
 import freechips.rocketchip.util.SeqToAugmentedSeq
 import freechips.rocketchip.util.SeqBoolBitwiseOps
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 // TODO: delete this trait once deduplication is smart enough to avoid globally inlining matching circuits
 trait InlineInstance { self: chisel3.experimental.BaseModule =>
@@ -240,8 +241,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   dataArb.io.in(3).valid := io.cpu.req.valid && likelyNeedsRead(io.cpu.req.bits)
   dataArb.io.in(3).bits := dataArb.io.in(1).bits
   dataArb.io.in(3).bits.write := false.B
-  dataArb.io.in(3).bits.addr :<= Cat(io.cpu.req.bits.idx.getOrElse(io.cpu.req.bits.addr) >> tagLSB, io.cpu.req.bits.addr(tagLSB-1, 0)).squeeze
-  dataArb.io.in(3).bits.wordMask :<= {
+  dataArb.io.in(3).bits.addr :%= Cat(io.cpu.req.bits.idx.getOrElse(io.cpu.req.bits.addr) >> tagLSB, io.cpu.req.bits.addr(tagLSB-1, 0))
+  dataArb.io.in(3).bits.wordMask :%= {
     val mask = (subWordBytes.log2 until rowOffBits).foldLeft(1.U) { case (in, i) =>
       val upper_mask = Mux((i >= wordBytes.log2).B || io.cpu.req.bits.size <= i.U, 0.U,
         ((BigInt(1) << (1 << (i - subWordBytes.log2)))-1).U)
@@ -250,7 +251,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
       upper ## lower
     }
     Fill(subWordBytes / eccBytes, mask)
-  }.squeeze
+  }
   dataArb.io.in(3).bits.eccMask := ~0.U((wordBytes / eccBytes).W)
   dataArb.io.in(3).bits.way_en := ~0.U(nWays.W)
   when (!dataArb.io.in(3).ready && s0_read) { io.cpu.req.ready := false.B }
@@ -276,8 +277,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   tlb.io.sfence.valid := s1_valid && !io.cpu.s1_kill && s1_sfence
   tlb.io.sfence.bits.rs1 := s1_req.size(0)
   tlb.io.sfence.bits.rs2 := s1_req.size(1)
-  tlb.io.sfence.bits.asid :<= io.cpu.s1_data.data.squeeze
-  tlb.io.sfence.bits.addr :<= s1_req.addr.squeeze
+  tlb.io.sfence.bits.asid :%= io.cpu.s1_data.data
+  tlb.io.sfence.bits.addr :%= s1_req.addr
   tlb.io.sfence.bits.hv := s1_req.cmd === M_HFENCEV
   tlb.io.sfence.bits.hg := s1_req.cmd === M_HFENCEG
 
@@ -544,14 +545,14 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   })
   dataArb.io.in(0).valid := should_pstore_drain(false.B)
   dataArb.io.in(0).bits.write := pstore_drain
-  dataArb.io.in(0).bits.addr :<= Mux(pstore2_valid, pstore2_addr, pstore1_addr).squeeze
+  dataArb.io.in(0).bits.addr :%= Mux(pstore2_valid, pstore2_addr, pstore1_addr)
   dataArb.io.in(0).bits.way_en := Mux(pstore2_valid, pstore2_way, pstore1_way)
   dataArb.io.in(0).bits.wdata := encodeData(Fill(rowWords, Mux(pstore2_valid, pstore2_storegen_data, pstore1_data)), false.B)
-  dataArb.io.in(0).bits.wordMask :<= {
+  dataArb.io.in(0).bits.wordMask :%= {
     val eccMask = dataArb.io.in(0).bits.eccMask.asBools.grouped(subWordBytes/eccBytes).map(_.orR).toSeq.asUInt
     val wordMask = UIntToOH(Mux(pstore2_valid, pstore2_addr, pstore1_addr).extract(rowOffBits-1, wordBytes.log2))
     FillInterleaved(wordBytes/subWordBytes, wordMask) & Fill(rowBytes/wordBytes, eccMask)
-  }.squeeze
+  }
   dataArb.io.in(0).bits.eccMask := eccMask(Mux(pstore2_valid, pstore2_storegen_mask, pstore1_mask))
 
   // store->load RAW hazard detection
@@ -723,7 +724,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   }
   if (!usingDataScratchpad) {
     dataArb.io.in(1).bits.write := true.B
-    dataArb.io.in(1).bits.addr :<= ((s2_vaddr >> idxLSB) << idxLSB | d_address_inc).squeeze
+    dataArb.io.in(1).bits.addr :%= ((s2_vaddr >> idxLSB) << idxLSB | d_address_inc)
     dataArb.io.in(1).bits.way_en := refill_way
     dataArb.io.in(1).bits.wdata := tl_d_data_encoded
     dataArb.io.in(1).bits.wordMask := ~0.U((rowBytes / subWordBytes).W)
@@ -916,7 +917,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   io.cpu.resp.bits.has_data := s2_read
   io.cpu.resp.bits.replay := false.B
   io.cpu.s2_uncached := s2_uncached && !s2_hit
-  io.cpu.s2_paddr :<= s2_req.addr.squeeze
+  io.cpu.s2_paddr :%= s2_req.addr
   io.cpu.s2_gpa := s2_tlb_xcpt.gpa
   io.cpu.s2_gpa_is_pte := s2_tlb_xcpt.gpa_is_pte
 
@@ -1047,7 +1048,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   metaArb.io.in(0).bits.way_en := ~0.U(nWays.W)
   metaArb.io.in(0).bits.data := tECC.encode(L1Metadata(0.U, ClientMetadata.onReset).asUInt)
   when (resetting) {
-    flushCounter :<= flushCounterNext.squeeze
+    flushCounter :%= flushCounterNext
     when (flushDone) {
       resetting := false.B
       if (!isPow2(nWays)) flushCounter := flushCounterWrap
@@ -1125,7 +1126,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
       io.errors.uncorrectable.foreach { u => when (u.valid) { c.valid := false.B } }
     }
     io.errors.bus.valid := tl_out.d.fire && (tl_out.d.bits.denied || tl_out.d.bits.corrupt)
-    io.errors.bus.bits :<= Mux(grantIsCached, s2_req.addr >> idxLSB << idxLSB, 0.U).squeeze
+    io.errors.bus.bits :%= Mux(grantIsCached, s2_req.addr >> idxLSB << idxLSB, 0.U)
 
     ccoverNotScratchpad(io.errors.bus.valid && grantIsCached, "D_ERROR_CACHED", "D$ D-channel error, cached")
     ccover(io.errors.bus.valid && !grantIsCached, "D_ERROR_UNCACHED", "D$ D-channel error, uncached")

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -171,10 +171,10 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   tlb.io.kill := !s2_valid || s2_kill_speculative_tlb_refill
 
   icache.io.req.valid := s0_valid
-  icache.io.req.bits.addr := io.cpu.npc
+  icache.io.req.bits.addr :<= io.cpu.npc.squeeze
   icache.io.invalidate := io.cpu.flush_icache
   icache.io.s1_paddr := tlb.io.resp.paddr
-  icache.io.s2_vaddr := s2_pc
+  icache.io.s2_vaddr :<= s2_pc.squeeze
   icache.io.s1_kill := s2_redirect || tlb.io.resp.miss || s2_replay
   val s2_can_speculatively_refill = s2_tlb_resp.cacheable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableSpeculativeICacheRefill
   icache.io.s2_kill := s2_speculative && !s2_can_speculatively_refill || s2_xcpt
@@ -183,10 +183,10 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 
   fq.io.enq.valid := RegNext(s1_valid) && s2_valid && (icache.io.resp.valid || (s2_kill_speculative_tlb_refill && s2_tlb_resp.miss) || (!s2_tlb_resp.miss && icache.io.s2_kill))
   fq.io.enq.bits.pc := s2_pc
-  io.cpu.npc := alignPC(Mux(io.cpu.req.valid, io.cpu.req.bits.pc, npc))
+  io.cpu.npc :<= alignPC(Mux(io.cpu.req.valid, io.cpu.req.bits.pc, npc)).squeeze
 
   fq.io.enq.bits.data := icache.io.resp.bits.data
-  fq.io.enq.bits.mask := ((1 << fetchWidth)-1).U << s2_pc.extract(log2Ceil(fetchWidth)+log2Ceil(coreInstBytes)-1, log2Ceil(coreInstBytes))
+  fq.io.enq.bits.mask :<= (((1 << fetchWidth)-1).U << s2_pc.extract(log2Ceil(fetchWidth)+log2Ceil(coreInstBytes)-1, log2Ceil(coreInstBytes))).squeeze
   fq.io.enq.bits.replay := (icache.io.resp.bits.replay || icache.io.s2_kill && !icache.io.resp.valid && !s2_xcpt) || (s2_kill_speculative_tlb_refill && s2_tlb_resp.miss)
   fq.io.enq.bits.btb := s2_btb_resp_bits
   fq.io.enq.bits.btb.taken := s2_btb_taken
@@ -198,7 +198,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
     val btb = Module(new BTB)
     btb.io.flush := false.B
     btb.io.req.valid := false.B
-    btb.io.req.bits.addr := s1_pc
+    btb.io.req.bits.addr :<= s1_pc.squeeze
     btb.io.btb_update := io.cpu.btb_update
     btb.io.bht_update := io.cpu.bht_update
     btb.io.ras_update.valid := false.B
@@ -320,11 +320,11 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
       btb.io.btb_update.bits.prediction.entry := tileParams.btb.get.nEntries.U
       btb.io.btb_update.bits.isValid := true.B
       btb.io.btb_update.bits.cfiType := btb.io.ras_update.bits.cfiType
-      btb.io.btb_update.bits.br_pc := s2_base_pc | (taken_idx << log2Ceil(coreInstBytes))
-      btb.io.btb_update.bits.pc := s2_base_pc
+      btb.io.btb_update.bits.br_pc :<= (s2_base_pc | (taken_idx << log2Ceil(coreInstBytes))).squeeze
+      btb.io.btb_update.bits.pc :<= s2_base_pc.squeeze
     }
 
-    btb.io.ras_update.bits.returnAddr := s2_base_pc + (after_idx << log2Ceil(coreInstBytes))
+    btb.io.ras_update.bits.returnAddr :<= (s2_base_pc + (after_idx << log2Ceil(coreInstBytes))).squeeze
 
     val taken = scanInsns(0, s2_partial_insn_valid, s2_partial_insn, false.B)
     when (useRAS) {

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -16,6 +16,7 @@ import freechips.rocketchip.tilelink.{TLWidthWidget, TLEdgeOut}
 import freechips.rocketchip.util.{ClockGate, ShiftQueue, property}
 
 import freechips.rocketchip.util.UIntToAugmentedUInt
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 class FrontendReq(implicit p: Parameters) extends CoreBundle()(p) {
   val pc = UInt(vaddrBitsExtended.W)
@@ -171,10 +172,10 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   tlb.io.kill := !s2_valid || s2_kill_speculative_tlb_refill
 
   icache.io.req.valid := s0_valid
-  icache.io.req.bits.addr :<= io.cpu.npc.squeeze
+  icache.io.req.bits.addr :%= io.cpu.npc
   icache.io.invalidate := io.cpu.flush_icache
   icache.io.s1_paddr := tlb.io.resp.paddr
-  icache.io.s2_vaddr :<= s2_pc.squeeze
+  icache.io.s2_vaddr :%= s2_pc
   icache.io.s1_kill := s2_redirect || tlb.io.resp.miss || s2_replay
   val s2_can_speculatively_refill = s2_tlb_resp.cacheable && !io.ptw.customCSRs.asInstanceOf[RocketCustomCSRs].disableSpeculativeICacheRefill
   icache.io.s2_kill := s2_speculative && !s2_can_speculatively_refill || s2_xcpt
@@ -183,10 +184,10 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 
   fq.io.enq.valid := RegNext(s1_valid) && s2_valid && (icache.io.resp.valid || (s2_kill_speculative_tlb_refill && s2_tlb_resp.miss) || (!s2_tlb_resp.miss && icache.io.s2_kill))
   fq.io.enq.bits.pc := s2_pc
-  io.cpu.npc :<= alignPC(Mux(io.cpu.req.valid, io.cpu.req.bits.pc, npc)).squeeze
+  io.cpu.npc :%= alignPC(Mux(io.cpu.req.valid, io.cpu.req.bits.pc, npc))
 
   fq.io.enq.bits.data := icache.io.resp.bits.data
-  fq.io.enq.bits.mask :<= (((1 << fetchWidth)-1).U << s2_pc.extract(log2Ceil(fetchWidth)+log2Ceil(coreInstBytes)-1, log2Ceil(coreInstBytes))).squeeze
+  fq.io.enq.bits.mask :%= (((1 << fetchWidth)-1).U << s2_pc.extract(log2Ceil(fetchWidth)+log2Ceil(coreInstBytes)-1, log2Ceil(coreInstBytes)))
   fq.io.enq.bits.replay := (icache.io.resp.bits.replay || icache.io.s2_kill && !icache.io.resp.valid && !s2_xcpt) || (s2_kill_speculative_tlb_refill && s2_tlb_resp.miss)
   fq.io.enq.bits.btb := s2_btb_resp_bits
   fq.io.enq.bits.btb.taken := s2_btb_taken
@@ -198,7 +199,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
     val btb = Module(new BTB)
     btb.io.flush := false.B
     btb.io.req.valid := false.B
-    btb.io.req.bits.addr :<= s1_pc.squeeze
+    btb.io.req.bits.addr :%= s1_pc
     btb.io.btb_update := io.cpu.btb_update
     btb.io.bht_update := io.cpu.bht_update
     btb.io.ras_update.valid := false.B
@@ -320,11 +321,11 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
       btb.io.btb_update.bits.prediction.entry := tileParams.btb.get.nEntries.U
       btb.io.btb_update.bits.isValid := true.B
       btb.io.btb_update.bits.cfiType := btb.io.ras_update.bits.cfiType
-      btb.io.btb_update.bits.br_pc :<= (s2_base_pc | (taken_idx << log2Ceil(coreInstBytes))).squeeze
-      btb.io.btb_update.bits.pc :<= s2_base_pc.squeeze
+      btb.io.btb_update.bits.br_pc :%= (s2_base_pc | (taken_idx << log2Ceil(coreInstBytes)))
+      btb.io.btb_update.bits.pc :%= s2_base_pc
     }
 
-    btb.io.ras_update.bits.returnAddr :<= (s2_base_pc + (after_idx << log2Ceil(coreInstBytes))).squeeze
+    btb.io.ras_update.bits.returnAddr :%= (s2_base_pc + (after_idx << log2Ceil(coreInstBytes)))
 
     val taken = scanInsns(0, s2_partial_insn_valid, s2_partial_insn, false.B)
     when (useRAS) {

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -303,7 +303,7 @@ class L1Metadata(implicit p: Parameters) extends L1HellaCacheBundle()(p) {
 object L1Metadata {
   def apply(tag: Bits, coh: ClientMetadata)(implicit p: Parameters) = {
     val meta = Wire(new L1Metadata)
-    meta.tag := tag
+    meta.tag :<= tag.asUInt.squeeze
     meta.coh := coh
     meta
   }

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -17,6 +17,7 @@ import freechips.rocketchip.tilelink.{TLMasterParameters, TLClientNode, TLMaster
 import freechips.rocketchip.util.{Code, RandomReplacement, ParameterizedBundle}
 
 import freechips.rocketchip.util.{BooleanToAugmentedBoolean, IntToAugmentedInt}
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 import scala.collection.mutable.ListBuffer
 
@@ -303,7 +304,7 @@ class L1Metadata(implicit p: Parameters) extends L1HellaCacheBundle()(p) {
 object L1Metadata {
   def apply(tag: Bits, coh: ClientMetadata)(implicit p: Parameters) = {
     val meta = Wire(new L1Metadata)
-    meta.tag :<= tag.asUInt.squeeze
+    meta.tag :%= tag.asUInt
     meta.coh := coh
     meta
   }

--- a/src/main/scala/rocket/HellaCacheArbiter.scala
+++ b/src/main/scala/rocket/HellaCacheArbiter.scala
@@ -31,7 +31,7 @@ class HellaCacheArbiter(n: Int)(implicit p: Parameters) extends Module
       val req = io.requestor(i).req
       def connect_s0() = {
         io.mem.req.bits := req.bits
-        io.mem.req.bits.tag := Cat(req.bits.tag, i.U(log2Up(n).W))
+        io.mem.req.bits.tag :<= Cat(req.bits.tag, i.U(log2Up(n).W)).squeeze
         s1_id := i.U
       }
       def connect_s1() = {

--- a/src/main/scala/rocket/HellaCacheArbiter.scala
+++ b/src/main/scala/rocket/HellaCacheArbiter.scala
@@ -7,6 +7,8 @@ import chisel3._
 import chisel3.util.{Cat,log2Up}
 import org.chipsalliance.cde.config.Parameters
 
+import freechips.rocketchip.util.ConnectableBitsOpExtension
+
 class HellaCacheArbiter(n: Int)(implicit p: Parameters) extends Module
 {
   val io = IO(new Bundle {
@@ -31,7 +33,7 @@ class HellaCacheArbiter(n: Int)(implicit p: Parameters) extends Module
       val req = io.requestor(i).req
       def connect_s0() = {
         io.mem.req.bits := req.bits
-        io.mem.req.bits.tag :<= Cat(req.bits.tag, i.U(log2Up(n).W)).squeeze
+        io.mem.req.bits.tag :%= Cat(req.bits.tag, i.U(log2Up(n).W))
         s1_id := i.U
       }
       def connect_s1() = {

--- a/src/main/scala/rocket/IBuf.scala
+++ b/src/main/scala/rocket/IBuf.scala
@@ -45,7 +45,7 @@ class IBuf(implicit p: Parameters) extends CoreModule {
 
   if (n > 0) {
     when (io.inst(0).ready) {
-      nBufValid :<= Mux(nReady >== nBufValid, 0.U, nBufValid - nReady).squeeze
+      nBufValid :%= Mux(nReady >== nBufValid, 0.U, nBufValid - nReady)
       if (n > 1) when (nReady > 0.U && nReady < nBufValid) {
         val shiftedBuf = shiftInsnRight(buf.data(n*coreInstBits-1, coreInstBits), (nReady-1.U)(log2Ceil(n-1)-1,0))
         buf.data := Cat(buf.data(n*coreInstBits-1, (n-1)*coreInstBits), shiftedBuf((n-1)*coreInstBits-1, 0))
@@ -53,7 +53,7 @@ class IBuf(implicit p: Parameters) extends CoreModule {
       }
       when (io.imem.valid && nReady >= nBufValid && nICReady < nIC && n.U >= nIC - nICReady) {
         val shamt = pcWordBits + nICReady
-        nBufValid :<= (nIC - nICReady).squeeze
+        nBufValid :%= (nIC - nICReady)
         buf := io.imem.bits
         buf.data := shiftInsnRight(io.imem.bits.data, shamt)(n*coreInstBits-1,0)
         buf.pc := io.imem.bits.pc & ~pcWordMask | (io.imem.bits.pc + (nICReady << log2Ceil(coreInstBytes))) & pcWordMask

--- a/src/main/scala/rocket/IBuf.scala
+++ b/src/main/scala/rocket/IBuf.scala
@@ -45,7 +45,7 @@ class IBuf(implicit p: Parameters) extends CoreModule {
 
   if (n > 0) {
     when (io.inst(0).ready) {
-      nBufValid := Mux(nReady >== nBufValid, 0.U, nBufValid - nReady)
+      nBufValid :<= Mux(nReady >== nBufValid, 0.U, nBufValid - nReady).squeeze
       if (n > 1) when (nReady > 0.U && nReady < nBufValid) {
         val shiftedBuf = shiftInsnRight(buf.data(n*coreInstBits-1, coreInstBits), (nReady-1.U)(log2Ceil(n-1)-1,0))
         buf.data := Cat(buf.data(n*coreInstBits-1, (n-1)*coreInstBits), shiftedBuf((n-1)*coreInstBits-1, 0))
@@ -53,7 +53,7 @@ class IBuf(implicit p: Parameters) extends CoreModule {
       }
       when (io.imem.valid && nReady >= nBufValid && nICReady < nIC && n.U >= nIC - nICReady) {
         val shamt = pcWordBits + nICReady
-        nBufValid := nIC - nICReady
+        nBufValid :<= (nIC - nICReady).squeeze
         buf := io.imem.bits
         buf.data := shiftInsnRight(io.imem.bits.data, shamt)(n*coreInstBits-1,0)
         buf.pc := io.imem.bits.pc & ~pcWordMask | (io.imem.bits.pc + (nICReady << log2Ceil(coreInstBytes))) & pcWordMask

--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -71,7 +71,7 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
     FN_DIVU   -> List(N, N, N, N),
     FN_REMU   -> List(N, Y, N, N))
   val cmdMul :: cmdHi :: lhsSigned :: rhsSigned :: Nil =
-    DecodeLogic(io.req.bits.fn, List(X, X, X, X),
+    DecodeLogic(io.req.bits.fn(2, 0), List(X, X, X, X),
       (if (cfg.divUnroll != 0) divDecode else Nil) ++ (if (cfg.mulUnroll != 0) mulDecode else Nil)).map(_.asBool)
 
   require(w == 32 || w == 64)
@@ -197,7 +197,7 @@ class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Modu
     FN_MULHU  -> List(Y, N, N),
     FN_MULHSU -> List(Y, Y, N))
   val cmdHi :: lhsSigned :: rhsSigned :: Nil =
-    DecodeLogic(in.bits.fn, List(X, X, X), decode).map(_.asBool)
+    DecodeLogic(in.bits.fn(1, 0), List(X, X, X), decode).map(_.asBool)
   val cmdHalf = (width > 32).B && in.bits.dw === DW_32
 
   val lhs = Cat(lhsSigned && in.bits.in1(width-1), in.bits.in1).asSInt

--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -209,5 +209,5 @@ class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Modu
   io.resp.valid := resp.valid
   io.resp.bits.tag := resp.bits.tag
   io.resp.bits.data := Pipe(in.valid, muxed, latency-1).bits
-  io.resp.bits.full_data := Pipe(in.valid, prod, latency-1).bits.asUInt
+  io.resp.bits.full_data :<= Pipe(in.valid, prod, latency-1).bits.asUInt.squeeze
 }

--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -209,5 +209,5 @@ class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Modu
   io.resp.valid := resp.valid
   io.resp.bits.tag := resp.bits.tag
   io.resp.bits.data := Pipe(in.valid, muxed, latency-1).bits
-  io.resp.bits.full_data :<= Pipe(in.valid, prod, latency-1).bits.asUInt.squeeze
+  io.resp.bits.full_data :%= Pipe(in.valid, prod, latency-1).bits.asUInt
 }

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -24,7 +24,7 @@ object PMP {
     val pmp = Wire(new PMP()(reg.p))
     pmp.cfg := reg.cfg
     pmp.addr := reg.addr
-    pmp.mask := pmp.computeMask
+    pmp.mask :<= pmp.computeMask.squeeze
     pmp
   }
 }

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -24,7 +24,7 @@ object PMP {
     val pmp = Wire(new PMP()(reg.p))
     pmp.cfg := reg.cfg
     pmp.addr := reg.addr
-    pmp.mask :<= pmp.computeMask.squeeze
+    pmp.mask :%= pmp.computeMask
     pmp
   }
 }

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -428,7 +428,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     val r_l2_plru_way = Reg(UInt(log2Ceil(coreParams.nL2TLBWays max 1).W))
     r_valid_vec_q := r_valid_vec
     // replacement way
-    r_l2_plru_way := (if (coreParams.nL2TLBWays > 1) l2_plru.way(r_idx) else 0.U)
+    r_l2_plru_way :<= (if (coreParams.nL2TLBWays > 1) l2_plru.way(r_idx) else 0.U(0.W))
     // refill with r_pte(leaf pte)
     when (l2_refill && !invalidated) {
       val entry = Wire(new L2TLBEntry(nL2TLBSets))

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -369,8 +369,8 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     when (mem_resp_valid && traverse && can_refill && !hits.orR && !invalidated) {
       val r = Mux(valid.andR, plru.way, PriorityEncoder(~valid))
       valid := valid | UIntToOH(r)
-      tags(r) :<= tag.squeeze
-      data(r) :<= pte.ppn.squeeze
+      tags(r) :%= tag
+      data(r) :%= pte.ppn
       plru.access(r)
     }
     // replace
@@ -432,14 +432,14 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     // refill with r_pte(leaf pte)
     when (l2_refill && !invalidated) {
       val entry = Wire(new L2TLBEntry(nL2TLBSets))
-      entry.ppn :<= r_pte.ppn.squeeze
+      entry.ppn :%= r_pte.ppn
       entry.d := r_pte.d
       entry.a := r_pte.a
       entry.u := r_pte.u
       entry.x := r_pte.x
       entry.w := r_pte.w
       entry.r := r_pte.r
-      entry.tag :<= r_tag.squeeze
+      entry.tag :%= r_tag
       // if all the way are valid, use plru to select one way to be replaced,
       // otherwise use PriorityEncoderOH to select one
       val wmask = if (coreParams.nL2TLBWays > 1) Mux(r_valid_vec_q.andR, UIntToOH(r_l2_plru_way, coreParams.nL2TLBWays), PriorityEncoderOH(~r_valid_vec_q)) else 1.U(1.W)
@@ -562,7 +562,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     io.requestor(i).resp.bits.homogeneous := homogeneous || pageGranularityPMPs.B
     io.requestor(i).resp.bits.fragmented_superpage := resp_fragmented_superpage && pageGranularityPMPs.B
     io.requestor(i).resp.bits.gpa.valid := r_req.need_gpa
-    io.requestor(i).resp.bits.gpa.bits :<=
+    io.requestor(i).resp.bits.gpa.bits :%=
       Mux(
         r_req.vstage1,
         Cat(
@@ -574,7 +574,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
           gpa_pgoff,
         ),
         r_req.addr,
-      ).squeeze
+      )
     io.requestor(i).resp.bits.gpa_is_pte := !stage2_final
     io.requestor(i).ptbr := io.dpath.ptbr
     io.requestor(i).hgatp := io.dpath.hgatp
@@ -604,8 +604,8 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
         next_state := Mux(arb.io.out.bits.valid, s_req, s_ready)
         stage2       := arb.io.out.bits.bits.stage2
         stage2_final := arb.io.out.bits.bits.stage2 && !arb.io.out.bits.bits.vstage1
-        count       :<= Mux(arb.io.out.bits.bits.stage2, hgatp_initial_count, satp_initial_count).squeeze
-        aux_count   :<= Mux(arb.io.out.bits.bits.vstage1, vsatp_initial_count, 0.U).squeeze
+        count       :%= Mux(arb.io.out.bits.bits.stage2, hgatp_initial_count, satp_initial_count)
+        aux_count   :%= Mux(arb.io.out.bits.bits.vstage1, vsatp_initial_count, 0.U)
         aux_pte.ppn := aux_ppn
         aux_pte.reserved_for_future := 0.U
         resp_ae_ptw := false.B
@@ -623,7 +623,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     }
     is (s_req) {
       when(stage2 && count === r_hgatp_initial_count) {
-        gpa_pgoff :<= Mux(aux_count === (pgLevels-1).U, r_req.addr << (xLen/8).log2, stage2_pte_cache_addr).squeeze
+        gpa_pgoff :%= Mux(aux_count === (pgLevels-1).U, r_req.addr << (xLen/8).log2, stage2_pte_cache_addr)
       }
       // pte_cache hit
       when (stage2_pte_cache_hit) {
@@ -703,10 +703,10 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     assert(state === s_wait3)
     next_state := s_req
     when (do_both_stages && !stage2) {
-      gpa_pgoff :<= {
+      gpa_pgoff :%= {
         val vpn_idxs = (0 until pgLevels).map(i => vpn >> ((pgLevels - i - 1) * pgLevelBits))
         val vpn_idx  = vpn_idxs(count + 1.U)
-        (vpn_idx << log2Ceil(xLen / 8)).squeeze
+        (vpn_idx << log2Ceil(xLen / 8))
       }
     }
 
@@ -759,7 +759,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
 
   when (do_switch) {
     aux_count := Mux(traverse, count + 1.U, count)
-    count :<= r_hgatp_initial_count.squeeze
+    count :%= r_hgatp_initial_count
     aux_pte := Mux(traverse, pte, {
       val s1_ppns = (0 until pgLevels-1).map(i => Cat(pte.ppn(pte.ppn.getWidth-1, (pgLevels-i-1)*pgLevelBits), r_req.addr(((pgLevels-i-1)*pgLevelBits min vpnBits)-1,0).padTo((pgLevels-i-1)*pgLevelBits))) :+ pte.ppn
       makePTE(s1_ppns(count), pte)

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -369,8 +369,8 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     when (mem_resp_valid && traverse && can_refill && !hits.orR && !invalidated) {
       val r = Mux(valid.andR, plru.way, PriorityEncoder(~valid))
       valid := valid | UIntToOH(r)
-      tags(r) := tag
-      data(r) := pte.ppn
+      tags(r) :<= tag.squeeze
+      data(r) :<= pte.ppn.squeeze
       plru.access(r)
     }
     // replace
@@ -432,14 +432,14 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     // refill with r_pte(leaf pte)
     when (l2_refill && !invalidated) {
       val entry = Wire(new L2TLBEntry(nL2TLBSets))
-      entry.ppn := r_pte.ppn
+      entry.ppn :<= r_pte.ppn.squeeze
       entry.d := r_pte.d
       entry.a := r_pte.a
       entry.u := r_pte.u
       entry.x := r_pte.x
       entry.w := r_pte.w
       entry.r := r_pte.r
-      entry.tag := r_tag
+      entry.tag :<= r_tag.squeeze
       // if all the way are valid, use plru to select one way to be replaced,
       // otherwise use PriorityEncoderOH to select one
       val wmask = if (coreParams.nL2TLBWays > 1) Mux(r_valid_vec_q.andR, UIntToOH(r_l2_plru_way, coreParams.nL2TLBWays), PriorityEncoderOH(~r_valid_vec_q)) else 1.U(1.W)
@@ -562,7 +562,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     io.requestor(i).resp.bits.homogeneous := homogeneous || pageGranularityPMPs.B
     io.requestor(i).resp.bits.fragmented_superpage := resp_fragmented_superpage && pageGranularityPMPs.B
     io.requestor(i).resp.bits.gpa.valid := r_req.need_gpa
-    io.requestor(i).resp.bits.gpa.bits :=
+    io.requestor(i).resp.bits.gpa.bits :<=
       Mux(
         r_req.vstage1,
         Cat(
@@ -574,7 +574,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
           gpa_pgoff,
         ),
         r_req.addr,
-      )
+      ).squeeze
     io.requestor(i).resp.bits.gpa_is_pte := !stage2_final
     io.requestor(i).ptbr := io.dpath.ptbr
     io.requestor(i).hgatp := io.dpath.hgatp
@@ -604,8 +604,8 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
         next_state := Mux(arb.io.out.bits.valid, s_req, s_ready)
         stage2       := arb.io.out.bits.bits.stage2
         stage2_final := arb.io.out.bits.bits.stage2 && !arb.io.out.bits.bits.vstage1
-        count       := Mux(arb.io.out.bits.bits.stage2, hgatp_initial_count, satp_initial_count)
-        aux_count   := Mux(arb.io.out.bits.bits.vstage1, vsatp_initial_count, 0.U)
+        count       :<= Mux(arb.io.out.bits.bits.stage2, hgatp_initial_count, satp_initial_count).squeeze
+        aux_count   :<= Mux(arb.io.out.bits.bits.vstage1, vsatp_initial_count, 0.U).squeeze
         aux_pte.ppn := aux_ppn
         aux_pte.reserved_for_future := 0.U
         resp_ae_ptw := false.B
@@ -623,7 +623,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     }
     is (s_req) {
       when(stage2 && count === r_hgatp_initial_count) {
-        gpa_pgoff := Mux(aux_count === (pgLevels-1).U, r_req.addr << (xLen/8).log2, stage2_pte_cache_addr)
+        gpa_pgoff :<= Mux(aux_count === (pgLevels-1).U, r_req.addr << (xLen/8).log2, stage2_pte_cache_addr).squeeze
       }
       // pte_cache hit
       when (stage2_pte_cache_hit) {
@@ -703,10 +703,10 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     assert(state === s_wait3)
     next_state := s_req
     when (do_both_stages && !stage2) {
-      gpa_pgoff := {
+      gpa_pgoff :<= {
         val vpn_idxs = (0 until pgLevels).map(i => vpn >> ((pgLevels - i - 1) * pgLevelBits))
         val vpn_idx  = vpn_idxs(count + 1.U)
-        vpn_idx << log2Ceil(xLen / 8)
+        (vpn_idx << log2Ceil(xLen / 8)).squeeze
       }
     }
 
@@ -759,7 +759,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
 
   when (do_switch) {
     aux_count := Mux(traverse, count + 1.U, count)
-    count := r_hgatp_initial_count
+    count :<= r_hgatp_initial_count.squeeze
     aux_pte := Mux(traverse, pte, {
       val s1_ppns = (0 until pgLevels-1).map(i => Cat(pte.ppn(pte.ppn.getWidth-1, (pgLevels-i-1)*pgLevelBits), r_req.addr(((pgLevels-i-1)*pgLevelBits min vpnBits)-1,0).padTo((pgLevels-i-1)*pgLevelBits))) :+ pte.ppn
       makePTE(s1_ppns(count), pte)

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -796,7 +796,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   private def makeHypervisorRootPTE(hgatp: PTBR, vpn: UInt, default: PTE) = {
     val count = pgLevels.U - minPgLevels.U - hgatp.additionalPgLevels
     val idxs = (0 to pgLevels-minPgLevels).map(i => (vpn >> (pgLevels-i)*pgLevelBits))
-    val lsbs = WireDefault(UInt(maxHypervisorExtraAddrBits.W), idxs(count))
+    val lsbs = WireDefault(UInt(maxHypervisorExtraAddrBits.W), idxs(count).pad(maxHypervisorExtraAddrBits)(maxHypervisorExtraAddrBits - 1, 0))
     val pte = WireDefault(default)
     pte.ppn := Cat(hgatp.ppn >> maxHypervisorExtraAddrBits, lsbs)
     pte

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -421,8 +421,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val bpu = Module(new BreakpointUnit(nBreakpoints))
   bpu.io.status := csr.io.status
   bpu.io.bp := csr.io.bp
-  bpu.io.pc := ibuf.io.pc
-  bpu.io.ea := mem_reg_wdata
+  bpu.io.pc :<= ibuf.io.pc.squeeze
+  bpu.io.ea :<= mem_reg_wdata.squeeze
   bpu.io.mcontext := csr.io.mcontext
   bpu.io.scontext := csr.io.scontext
 
@@ -512,7 +512,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   alu.io.dw := ex_ctrl.alu_dw
   alu.io.fn := ex_ctrl.alu_fn
   alu.io.in2 := ex_op2.asUInt
-  alu.io.in1 := ex_op1.asUInt
+  alu.io.in1 :<= ex_op1.asUInt.squeeze
 
   // multiplier and divider
   val div = Module(new MulDiv(if (pipelinedMul) mulDivParams.copy(mulUnroll = 0) else mulDivParams, width = xLen))
@@ -926,7 +926,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     }
   }
 
-  csr.io.htval := htval
+  csr.io.htval :<= htval.squeeze
   csr.io.mhtinst_read_pseudo := mhtinst_read_pseudo
   io.ptw.ptbr := csr.io.ptbr
   io.ptw.hgatp := csr.io.hgatp
@@ -1090,8 +1090,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   io.imem.sfence.valid := wb_reg_valid && wb_reg_sfence
   io.imem.sfence.bits.rs1 := wb_reg_mem_size(0)
   io.imem.sfence.bits.rs2 := wb_reg_mem_size(1)
-  io.imem.sfence.bits.addr := wb_reg_wdata
-  io.imem.sfence.bits.asid := wb_reg_rs2
+  io.imem.sfence.bits.addr :<= wb_reg_wdata.squeeze
+  io.imem.sfence.bits.asid :<= wb_reg_rs2.squeeze
   io.imem.sfence.bits.hv := wb_reg_hfence_v
   io.imem.sfence.bits.hg := wb_reg_hfence_g
   io.ptw.sfence := io.imem.sfence
@@ -1105,8 +1105,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     Mux(mem_ctrl.jalr && (mem_reg_inst(19,15) & regAddrMask.U) === BitPat("b00?01"), CFIType.ret,
     Mux(mem_ctrl.jal || mem_ctrl.jalr, CFIType.jump,
     CFIType.branch)))
-  io.imem.btb_update.bits.target := io.imem.req.bits.pc
-  io.imem.btb_update.bits.br_pc := (if (usingCompressed) mem_reg_pc + Mux(mem_reg_rvc, 0.U, 2.U) else mem_reg_pc)
+  io.imem.btb_update.bits.target :<= io.imem.req.bits.pc.squeeze
+  io.imem.btb_update.bits.br_pc :<= (if (usingCompressed) mem_reg_pc + Mux(mem_reg_rvc, 0.U, 2.U) else mem_reg_pc).squeeze
   io.imem.btb_update.bits.pc := ~(~io.imem.btb_update.bits.br_pc | (coreInstBytes*fetchWidth-1).U)
   io.imem.btb_update.bits.prediction := mem_reg_btb_resp
   io.imem.btb_update.bits.taken := DontCare

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -421,8 +421,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   val bpu = Module(new BreakpointUnit(nBreakpoints))
   bpu.io.status := csr.io.status
   bpu.io.bp := csr.io.bp
-  bpu.io.pc :<= ibuf.io.pc.squeeze
-  bpu.io.ea :<= mem_reg_wdata.squeeze
+  bpu.io.pc :%= ibuf.io.pc
+  bpu.io.ea :%= mem_reg_wdata
   bpu.io.mcontext := csr.io.mcontext
   bpu.io.scontext := csr.io.scontext
 
@@ -512,7 +512,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   alu.io.dw := ex_ctrl.alu_dw
   alu.io.fn := ex_ctrl.alu_fn
   alu.io.in2 := ex_op2.asUInt
-  alu.io.in1 :<= ex_op1.asUInt.squeeze
+  alu.io.in1 :%= ex_op1.asUInt
 
   // multiplier and divider
   val div = Module(new MulDiv(if (pipelinedMul) mulDivParams.copy(mulUnroll = 0) else mulDivParams, width = xLen))
@@ -926,7 +926,7 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     }
   }
 
-  csr.io.htval :<= htval.squeeze
+  csr.io.htval :%= htval
   csr.io.mhtinst_read_pseudo := mhtinst_read_pseudo
   io.ptw.ptbr := csr.io.ptbr
   io.ptw.hgatp := csr.io.hgatp
@@ -1090,8 +1090,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   io.imem.sfence.valid := wb_reg_valid && wb_reg_sfence
   io.imem.sfence.bits.rs1 := wb_reg_mem_size(0)
   io.imem.sfence.bits.rs2 := wb_reg_mem_size(1)
-  io.imem.sfence.bits.addr :<= wb_reg_wdata.squeeze
-  io.imem.sfence.bits.asid :<= wb_reg_rs2.squeeze
+  io.imem.sfence.bits.addr :%= wb_reg_wdata
+  io.imem.sfence.bits.asid :%= wb_reg_rs2
   io.imem.sfence.bits.hv := wb_reg_hfence_v
   io.imem.sfence.bits.hg := wb_reg_hfence_g
   io.ptw.sfence := io.imem.sfence
@@ -1105,8 +1105,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
     Mux(mem_ctrl.jalr && (mem_reg_inst(19,15) & regAddrMask.U) === BitPat("b00?01"), CFIType.ret,
     Mux(mem_ctrl.jal || mem_ctrl.jalr, CFIType.jump,
     CFIType.branch)))
-  io.imem.btb_update.bits.target :<= io.imem.req.bits.pc.squeeze
-  io.imem.btb_update.bits.br_pc :<= (if (usingCompressed) mem_reg_pc + Mux(mem_reg_rvc, 0.U, 2.U) else mem_reg_pc).squeeze
+  io.imem.btb_update.bits.target :%= io.imem.req.bits.pc
+  io.imem.btb_update.bits.br_pc :%= (if (usingCompressed) mem_reg_pc + Mux(mem_reg_rvc, 0.U, 2.U) else mem_reg_pc)
   io.imem.btb_update.bits.pc := ~(~io.imem.btb_update.bits.br_pc | (coreInstBytes*fetchWidth-1).U)
   io.imem.btb_update.bits.prediction := mem_reg_btb_resp
   io.imem.btb_update.bits.taken := DontCare

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -22,6 +22,7 @@ import freechips.rocketchip.util.UIntToAugmentedUInt
 import freechips.rocketchip.util.UIntIsOneOf
 import freechips.rocketchip.util.SeqToAugmentedSeq
 import freechips.rocketchip.util.SeqBoolBitwiseOps
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 case object ASIdBits extends Field[Int](0)
 case object VMIdBits extends Field[Int](0)
@@ -414,10 +415,10 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   val mpu_physaddr = Cat(mpu_ppn, io.req.bits.vaddr(pgIdxBits-1, 0))
   val mpu_priv = Mux[UInt](usingVM.B && (do_refill || io.req.bits.passthrough /* PTW */), PRV.S.U, Cat(io.ptw.status.debug, priv))
   val pmp = Module(new PMPChecker(lgMaxSize))
-  pmp.io.addr :<= mpu_physaddr.squeeze
+  pmp.io.addr :%= mpu_physaddr
   pmp.io.size := io.req.bits.size
   pmp.io.pmp := (io.ptw.pmp: Seq[PMP])
-  pmp.io.prv :<= mpu_priv.squeeze
+  pmp.io.prv :%= mpu_priv
 
   val pma = Module(new PMAChecker(edge.manager)(p))
   pma.io.paddr := mpu_physaddr
@@ -447,7 +448,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
     val pte = io.ptw.resp.bits.pte
     val refill_v = r_vstage1_en || r_stage2_en
     val newEntry = Wire(new TLBEntryData)
-    newEntry.ppn :<= pte.ppn.squeeze
+    newEntry.ppn :%= pte.ppn
     newEntry.c := cacheable
     newEntry.u := pte.u
     newEntry.g := pte.g && pte.v
@@ -653,11 +654,11 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   io.resp.size := io.req.bits.size
   io.resp.cmd := io.req.bits.cmd
   io.resp.gpa_is_pte := vstage1_en && r_gpa_is_pte
-  io.resp.gpa :<= {
+  io.resp.gpa :%= {
     val page = Mux(!vstage1_en, Cat(bad_gpa, vpn), r_gpa >> pgIdxBits)
     val offset = Mux(io.resp.gpa_is_pte, r_gpa(pgIdxBits-1, 0), io.req.bits.vaddr(pgIdxBits-1, 0))
     Cat(page, offset)
-  }.squeeze
+  }
 
   io.ptw.req.valid := state === s_request
   io.ptw.req.bits.valid := !io.kill

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -414,10 +414,10 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   val mpu_physaddr = Cat(mpu_ppn, io.req.bits.vaddr(pgIdxBits-1, 0))
   val mpu_priv = Mux[UInt](usingVM.B && (do_refill || io.req.bits.passthrough /* PTW */), PRV.S.U, Cat(io.ptw.status.debug, priv))
   val pmp = Module(new PMPChecker(lgMaxSize))
-  pmp.io.addr := mpu_physaddr
+  pmp.io.addr :<= mpu_physaddr.squeeze
   pmp.io.size := io.req.bits.size
   pmp.io.pmp := (io.ptw.pmp: Seq[PMP])
-  pmp.io.prv := mpu_priv
+  pmp.io.prv :<= mpu_priv.squeeze
 
   val pma = Module(new PMAChecker(edge.manager)(p))
   pma.io.paddr := mpu_physaddr
@@ -447,7 +447,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
     val pte = io.ptw.resp.bits.pte
     val refill_v = r_vstage1_en || r_stage2_en
     val newEntry = Wire(new TLBEntryData)
-    newEntry.ppn := pte.ppn
+    newEntry.ppn :<= pte.ppn.squeeze
     newEntry.c := cacheable
     newEntry.u := pte.u
     newEntry.g := pte.g && pte.v
@@ -653,11 +653,11 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   io.resp.size := io.req.bits.size
   io.resp.cmd := io.req.bits.cmd
   io.resp.gpa_is_pte := vstage1_en && r_gpa_is_pte
-  io.resp.gpa := {
+  io.resp.gpa :<= {
     val page = Mux(!vstage1_en, Cat(bad_gpa, vpn), r_gpa >> pgIdxBits)
     val offset = Mux(io.resp.gpa_is_pte, r_gpa(pgIdxBits-1, 0), io.req.bits.vaddr(pgIdxBits-1, 0))
     Cat(page, offset)
-  }
+  }.squeeze
 
   io.ptw.req.valid := state === s_request
   io.ptw.req.bits.valid := !io.kill

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -721,9 +721,9 @@ class FPUFMAPipe(val latency: Int, val t: FType)
   fma.io.op := in.fmaCmd
   fma.io.roundingMode := in.rm
   fma.io.detectTininess := hardfloat.consts.tininess_afterRounding
-  fma.io.a := in.in1
-  fma.io.b := in.in2
-  fma.io.c := in.in3
+  fma.io.a :<= in.in1.squeeze
+  fma.io.b :<= in.in2.squeeze
+  fma.io.c :<= in.in3.squeeze
 
   val res = Wire(new FPResult)
   res.data := sanitizeNaN(fma.io.out, t)
@@ -887,7 +887,7 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
   val ifpu = Module(new IntToFP(cfg.ifpuLatency))
   ifpu.io.in.valid := req_valid && ex_ctrl.fromint
   ifpu.io.in.bits := fpiu.io.in.bits
-  ifpu.io.in.bits.in1 := Mux(ex_cp_valid, io.cp_req.bits.in1, io.fromint_data)
+  ifpu.io.in.bits.in1 :<= Mux(ex_cp_valid, io.cp_req.bits.in1, io.fromint_data).squeeze
 
   val fpmu = Module(new FPToFP(cfg.fpmuLatency))
   fpmu.io.in.valid := req_valid && ex_ctrl.fastpipe
@@ -954,7 +954,7 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
     for (i <- 0 until maxLatency-1) {
       when (!write_port_busy && memLatencyMask(i)) {
         wbInfo(i).cp := mem_cp_valid
-        wbInfo(i).typeTag := mem_ctrl.typeTagOut
+        wbInfo(i).typeTag :<= mem_ctrl.typeTagOut.squeeze
         wbInfo(i).pipeid := pipeid(mem_ctrl)
         wbInfo(i).rd := mem_reg_inst(11,7)
       }

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -886,7 +886,7 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
 
   val ifpu = Module(new IntToFP(cfg.ifpuLatency))
   ifpu.io.in.valid := req_valid && ex_ctrl.fromint
-  ifpu.io.in.bits := fpiu.io.in.bits
+  (ifpu.io.in.bits: Data).unsafe :<= (fpiu.io.in.bits: Data).unsafe
   ifpu.io.in.bits.in1 :<= Mux(ex_cp_valid, io.cp_req.bits.in1, io.fromint_data).squeeze
 
   val fpmu = Module(new FPToFP(cfg.fpmuLatency))

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -721,9 +721,9 @@ class FPUFMAPipe(val latency: Int, val t: FType)
   fma.io.op := in.fmaCmd
   fma.io.roundingMode := in.rm
   fma.io.detectTininess := hardfloat.consts.tininess_afterRounding
-  fma.io.a :<= in.in1.squeeze
-  fma.io.b :<= in.in2.squeeze
-  fma.io.c :<= in.in3.squeeze
+  fma.io.a :%= in.in1
+  fma.io.b :%= in.in2
+  fma.io.c :%= in.in3
 
   val res = Wire(new FPResult)
   res.data := sanitizeNaN(fma.io.out, t)
@@ -887,7 +887,7 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
   val ifpu = Module(new IntToFP(cfg.ifpuLatency))
   ifpu.io.in.valid := req_valid && ex_ctrl.fromint
   (ifpu.io.in.bits: Data).unsafe :<= (fpiu.io.in.bits: Data).unsafe
-  ifpu.io.in.bits.in1 :<= Mux(ex_cp_valid, io.cp_req.bits.in1, io.fromint_data).squeeze
+  ifpu.io.in.bits.in1 :%= Mux(ex_cp_valid, io.cp_req.bits.in1, io.fromint_data)
 
   val fpmu = Module(new FPToFP(cfg.fpmuLatency))
   fpmu.io.in.valid := req_valid && ex_ctrl.fastpipe
@@ -954,7 +954,7 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
     for (i <- 0 until maxLatency-1) {
       when (!write_port_busy && memLatencyMask(i)) {
         wbInfo(i).cp := mem_cp_valid
-        wbInfo(i).typeTag :<= mem_ctrl.typeTagOut.squeeze
+        wbInfo(i).typeTag :%= mem_ctrl.typeTagOut
         wbInfo(i).pipeid := pipeid(mem_ctrl)
         wbInfo(i).rd := mem_reg_inst(11,7)
       }

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -139,7 +139,7 @@ class TLCacheCork(params: TLCacheCorkParams = TLCacheCorkParams())(implicit p: P
 
         // Take responses from D and transform them
         val d_d = Wire(chiselTypeOf(in.d))
-        d_d <> out.d
+        d_d :<>= out.d.squeezeAll
         d_d.bits.source := out.d.bits.source >> 1
 
         // Record if a target was writable and auto-promote toT if it was

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -348,7 +348,7 @@ class TLEdgeOut(
     a.param   := growPermissions
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -365,7 +365,7 @@ class TLEdgeOut(
     a.param   := growPermissions
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -462,7 +462,7 @@ class TLEdgeOut(
     a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -482,7 +482,7 @@ class TLEdgeOut(
     a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -502,10 +502,10 @@ class TLEdgeOut(
     a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
-    a.mask    := mask
+    a.mask    :<= mask.squeeze
     a.data    := data
     a.corrupt := corrupt
     (legal, a)
@@ -519,7 +519,7 @@ class TLEdgeOut(
     a.param   := atomic
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -536,7 +536,7 @@ class TLEdgeOut(
     a.param   := atomic
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -553,7 +553,7 @@ class TLEdgeOut(
     a.param   := param
     a.size    := lgSize
     a.source  := fromSource
-    a.address := toAddress
+    a.address :<= toAddress.squeeze
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -645,7 +645,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.Grant
     d.param   := capPermissions
-    d.size    := lgSize
+    d.size    :<= lgSize.squeeze
     d.source  := toSource
     d.sink    := fromSink
     d.denied  := denied
@@ -661,7 +661,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.GrantData
     d.param   := capPermissions
-    d.size    := lgSize
+    d.size    :<= lgSize.squeeze
     d.source  := toSource
     d.sink    := fromSink
     d.denied  := denied
@@ -677,7 +677,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.ReleaseAck
     d.param   := 0.U
-    d.size    := lgSize
+    d.size    :<= lgSize.squeeze
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied
@@ -792,7 +792,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.AccessAck
     d.param   := 0.U
-    d.size    := lgSize
+    d.size    :<= lgSize.squeeze
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied
@@ -810,7 +810,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.AccessAckData
     d.param   := 0.U
-    d.size    := lgSize
+    d.size    :<= lgSize.squeeze
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied
@@ -828,7 +828,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.HintAck
     d.param   := 0.U
-    d.size    := lgSize
+    d.size    :<= lgSize.squeeze
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -348,7 +348,7 @@ class TLEdgeOut(
     a.param   := growPermissions
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -365,7 +365,7 @@ class TLEdgeOut(
     a.param   := growPermissions
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -462,7 +462,7 @@ class TLEdgeOut(
     a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -482,7 +482,7 @@ class TLEdgeOut(
     a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -502,10 +502,10 @@ class TLEdgeOut(
     a.param   := 0.U
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
-    a.mask    :<= mask.squeeze
+    a.mask    :%= mask
     a.data    := data
     a.corrupt := corrupt
     (legal, a)
@@ -519,7 +519,7 @@ class TLEdgeOut(
     a.param   := atomic
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -536,7 +536,7 @@ class TLEdgeOut(
     a.param   := atomic
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -553,7 +553,7 @@ class TLEdgeOut(
     a.param   := param
     a.size    := lgSize
     a.source  := fromSource
-    a.address :<= toAddress.squeeze
+    a.address :%= toAddress
     a.user    := DontCare
     a.echo    := DontCare
     a.mask    := mask(toAddress, lgSize)
@@ -645,7 +645,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.Grant
     d.param   := capPermissions
-    d.size    :<= lgSize.squeeze
+    d.size    :%= lgSize
     d.source  := toSource
     d.sink    := fromSink
     d.denied  := denied
@@ -661,7 +661,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.GrantData
     d.param   := capPermissions
-    d.size    :<= lgSize.squeeze
+    d.size    :%= lgSize
     d.source  := toSource
     d.sink    := fromSink
     d.denied  := denied
@@ -677,7 +677,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.ReleaseAck
     d.param   := 0.U
-    d.size    :<= lgSize.squeeze
+    d.size    :%= lgSize
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied
@@ -792,7 +792,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.AccessAck
     d.param   := 0.U
-    d.size    :<= lgSize.squeeze
+    d.size    :%= lgSize
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied
@@ -810,7 +810,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.AccessAckData
     d.param   := 0.U
-    d.size    :<= lgSize.squeeze
+    d.size    :%= lgSize
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied
@@ -828,7 +828,7 @@ class TLEdgeIn(
     val d = Wire(new TLBundleD(bundle))
     d.opcode  := TLMessages.HintAck
     d.param   := 0.U
-    d.size    :<= lgSize.squeeze
+    d.size    :%= lgSize
     d.source  := toSource
     d.sink    := 0.U
     d.denied  := denied

--- a/src/main/scala/tilelink/FIFOFixer.scala
+++ b/src/main/scala/tilelink/FIFOFixer.scala
@@ -117,10 +117,10 @@ class TLFIFOFixer(policy: TLFIFOFixer.Policy = TLFIFOFixer.all)(implicit p: Para
       val SourceIdClear = WireDefault(0.U(edgeIn.client.endSourceId.W))
 
       when (a_first && in.a.fire && !a_notFIFO)  {
-        SourceIdSet := UIntToOH(in.a.bits.source)
+        SourceIdSet :<= UIntToOH(in.a.bits.source, edgeIn.client.endSourceId)
       }
       when (d_first && in.d.fire)  {
-        SourceIdClear := UIntToOH(in.d.bits.source)
+        SourceIdClear :<= UIntToOH(in.d.bits.source, edgeIn.client.endSourceId)
       }
 
       SourceIdFIFOed := SourceIdFIFOed | SourceIdSet

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -15,6 +15,7 @@ import freechips.rocketchip.util.{Repeater, OH1ToUInt, UIntToOH1}
 import scala.math.min
 
 import freechips.rocketchip.util.DataToAugmentedData
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 object EarlyAck {
   sealed trait T
@@ -315,7 +316,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         out.a :<>= in_a.squeezeAll
         out.a.bits.address := in_a.bits.address | ~(old_gennum1 << log2Ceil(beatBytes) | ~aOrigOH1 | aFragOH1 | (minSize-1).U)
         out.a.bits.source := Cat(Seq(in_a.bits.source) ++ aFull ++ Seq(aToggle.asUInt, aFragnum))
-        out.a.bits.size :<= aFrag.squeeze
+        out.a.bits.size :%= aFrag
 
         // Optimize away some of the Repeater's registers
         assert (!repeater.io.full || !aHasData)

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -234,7 +234,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         val drop = !dHasData && !Mux(doEarlyAck, dFirst, dLast)
         out.d.ready := in.d.ready || drop
         in.d.valid  := out.d.valid && !drop
-        in.d.bits   := out.d.bits // pass most stuff unchanged
+        in.d.bits   :<= out.d.bits.squeezeAll // pass most stuff unchanged
         in.d.bits.source := out.d.bits.source >> addedBits
         in.d.bits.size   := Mux(dFirst, dFirst_size, dOrig)
 
@@ -312,10 +312,10 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         when (out.a.fire) { gennum := new_gennum }
 
         repeater.io.repeat := !aHasData && aFragnum =/= 0.U
-        out.a <> in_a
+        out.a :<>= in_a.squeezeAll
         out.a.bits.address := in_a.bits.address | ~(old_gennum1 << log2Ceil(beatBytes) | ~aOrigOH1 | aFragOH1 | (minSize-1).U)
         out.a.bits.source := Cat(Seq(in_a.bits.source) ++ aFull ++ Seq(aToggle.asUInt, aFragnum))
-        out.a.bits.size := aFrag
+        out.a.bits.size :<= aFrag.squeeze
 
         // Optimize away some of the Repeater's registers
         assert (!repeater.io.full || !aHasData)

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -633,11 +633,11 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     val a_opcode_lookup = WireInit(0.U((a_opcode_bus_size - 1).W))
     a_opcode_lookup.suggestName("a_opcode_lookup")
-    a_opcode_lookup := ((inflight_opcodes) >> (bundle.d.bits.source << log_a_opcode_bus_size.U) & size_to_numfullbits(1.U << log_a_opcode_bus_size.U)) >> 1.U
+    a_opcode_lookup :<= (((inflight_opcodes) >> (bundle.d.bits.source << log_a_opcode_bus_size) & size_to_numfullbits(1.U << log_a_opcode_bus_size)) >> 1).squeeze
 
     val a_size_lookup = WireInit(0.U((1 << log_a_size_bus_size).W))
     a_size_lookup.suggestName("a_size_lookup")
-    a_size_lookup := ((inflight_sizes) >> (bundle.d.bits.source << log_a_size_bus_size.U) & size_to_numfullbits(1.U << log_a_size_bus_size.U)) >> 1.U
+    a_size_lookup :<= (((inflight_sizes) >> (bundle.d.bits.source << log_a_size_bus_size) & size_to_numfullbits(1.U << log_a_size_bus_size)) >> 1).squeeze
 
     val responseMap             = VecInit(Seq(TLMessages.AccessAck, TLMessages.AccessAck, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.HintAck, TLMessages.Grant,     TLMessages.Grant))
     val responseMapSecondOption = VecInit(Seq(TLMessages.AccessAck, TLMessages.AccessAck, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.HintAck, TLMessages.GrantData, TLMessages.Grant))
@@ -655,8 +655,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       a_set                :<= UIntToOH(bundle.a.bits.source, edge.client.endSourceId)
       a_opcodes_set_interm := (bundle.a.bits.opcode << 1.U) | 1.U
       a_sizes_set_interm   := (bundle.a.bits.size << 1.U) | 1.U
-      a_opcodes_set        := (a_opcodes_set_interm) << (bundle.a.bits.source << log_a_opcode_bus_size.U)
-      a_sizes_set          := (a_sizes_set_interm) << (bundle.a.bits.source << log_a_size_bus_size.U)
+      a_opcodes_set        :<= ((a_opcodes_set_interm) << (bundle.a.bits.source << log_a_opcode_bus_size)).squeeze
+      a_sizes_set          :<= ((a_sizes_set_interm) << (bundle.a.bits.source << log_a_size_bus_size)).squeeze
       monAssert(!inflight(bundle.a.bits.source), "'A' channel re-used a source ID" + extra)
     }
 
@@ -676,8 +676,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     when (bundle.d.fire && d_first && edge.isResponse(bundle.d.bits) && !d_release_ack) {
       d_clr         :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
-      d_opcodes_clr := size_to_numfullbits(1.U << log_a_opcode_bus_size.U) << (bundle.d.bits.source << log_a_opcode_bus_size.U)
-      d_sizes_clr   := size_to_numfullbits(1.U << log_a_size_bus_size.U) << (bundle.d.bits.source << log_a_size_bus_size.U)
+      d_opcodes_clr :<= (size_to_numfullbits(1.U << log_a_opcode_bus_size) << (bundle.d.bits.source << log_a_opcode_bus_size)).squeeze
+      d_sizes_clr   :<= (size_to_numfullbits(1.U << log_a_size_bus_size) << (bundle.d.bits.source << log_a_size_bus_size)).squeeze
     }
     when (bundle.d.valid && d_first && edge.isResponse(bundle.d.bits) && !d_release_ack) {
       val same_cycle_resp = bundle.a.valid && a_first && edge.isRequest(bundle.a.bits) && (bundle.a.bits.source === bundle.d.bits.source)
@@ -745,8 +745,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     val c_opcode_lookup = WireInit(0.U((1 << log_c_opcode_bus_size).W))
     val c_size_lookup   = WireInit(0.U((1 << log_c_size_bus_size).W))
-    c_opcode_lookup := ((inflight_opcodes) >> (bundle.d.bits.source << log_c_opcode_bus_size.U) & size_to_numfullbits(1.U << log_c_opcode_bus_size.U)) >> 1.U
-    c_size_lookup   := ((inflight_sizes) >> (bundle.d.bits.source << log_c_size_bus_size.U) & size_to_numfullbits(1.U << log_c_size_bus_size.U)) >> 1.U
+    c_opcode_lookup :<= (((inflight_opcodes) >> (bundle.d.bits.source << log_c_opcode_bus_size) & size_to_numfullbits(1.U << log_c_opcode_bus_size)) >> 1).squeeze
+    c_size_lookup   :<= (((inflight_sizes) >> (bundle.d.bits.source << log_c_size_bus_size) & size_to_numfullbits(1.U << log_c_size_bus_size)) >> 1).squeeze
     c_opcode_lookup.suggestName("c_opcode_lookup")
     c_size_lookup.suggestName("c_size_lookup")
 
@@ -763,8 +763,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       c_set                :<= UIntToOH(bundle.c.bits.source, edge.client.endSourceId)
       c_opcodes_set_interm := (bundle.c.bits.opcode << 1.U) | 1.U
       c_sizes_set_interm   := (bundle.c.bits.size << 1.U) | 1.U
-      c_opcodes_set        := (c_opcodes_set_interm) << (bundle.c.bits.source << log_c_opcode_bus_size.U)
-      c_sizes_set          := (c_sizes_set_interm) << (bundle.c.bits.source << log_c_size_bus_size.U)
+      c_opcodes_set        :<= ((c_opcodes_set_interm) << (bundle.c.bits.source << log_c_opcode_bus_size)).squeeze
+      c_sizes_set          :<= ((c_sizes_set_interm) << (bundle.c.bits.source << log_c_size_bus_size)).squeeze
       monAssert(!inflight(bundle.c.bits.source), "'C' channel re-used a source ID" + extra)
     }
 
@@ -786,8 +786,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     when (bundle.d.fire && d_first && edge.isResponse(bundle.d.bits) && d_release_ack) {
       d_clr         :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
-      d_opcodes_clr := size_to_numfullbits(1.U << log_c_opcode_bus_size.U) << (bundle.d.bits.source << log_c_opcode_bus_size.U)
-      d_sizes_clr   := size_to_numfullbits(1.U << log_c_size_bus_size.U) << (bundle.d.bits.source << log_c_size_bus_size.U)
+      d_opcodes_clr :<= (size_to_numfullbits(1.U << log_c_opcode_bus_size) << (bundle.d.bits.source << log_c_opcode_bus_size)).squeeze
+      d_sizes_clr   :<= (size_to_numfullbits(1.U << log_c_size_bus_size) << (bundle.d.bits.source << log_c_size_bus_size)).squeeze
     }
 
     when (bundle.d.valid && d_first && edge.isResponse(bundle.d.bits) && d_release_ack) {

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -648,11 +648,11 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     a_sizes_set_interm.suggestName("a_sizes_set_interm")
 
     when (bundle.a.valid && a_first && edge.isRequest(bundle.a.bits)) {
-      a_set_wo_ready := UIntToOH(bundle.a.bits.source)
+      a_set_wo_ready :<= UIntToOH(bundle.a.bits.source, edge.client.endSourceId)
     }
 
     when (bundle.a.fire && a_first && edge.isRequest(bundle.a.bits)) {
-      a_set                := UIntToOH(bundle.a.bits.source)
+      a_set                :<= UIntToOH(bundle.a.bits.source, edge.client.endSourceId)
       a_opcodes_set_interm := (bundle.a.bits.opcode << 1.U) | 1.U
       a_sizes_set_interm   := (bundle.a.bits.size << 1.U) | 1.U
       a_opcodes_set        := (a_opcodes_set_interm) << (bundle.a.bits.source << log_a_opcode_bus_size.U)
@@ -671,11 +671,11 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     val d_release_ack = bundle.d.bits.opcode === TLMessages.ReleaseAck
     when (bundle.d.valid && d_first && edge.isResponse(bundle.d.bits) && !d_release_ack) {
-      d_clr_wo_ready := UIntToOH(bundle.d.bits.source)
+      d_clr_wo_ready :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
     }
 
     when (bundle.d.fire && d_first && edge.isResponse(bundle.d.bits) && !d_release_ack) {
-      d_clr         := UIntToOH(bundle.d.bits.source)
+      d_clr         :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
       d_opcodes_clr := size_to_numfullbits(1.U << log_a_opcode_bus_size.U) << (bundle.d.bits.source << log_a_opcode_bus_size.U)
       d_sizes_clr   := size_to_numfullbits(1.U << log_a_size_bus_size.U) << (bundle.d.bits.source << log_a_size_bus_size.U)
     }
@@ -756,11 +756,11 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
     c_sizes_set_interm.suggestName("c_sizes_set_interm")
 
     when (bundle.c.valid && c_first && edge.isRequest(bundle.c.bits)) {
-      c_set_wo_ready := UIntToOH(bundle.c.bits.source)
+      c_set_wo_ready :<= UIntToOH(bundle.c.bits.source, edge.client.endSourceId)
     }
 
     when (bundle.c.fire && c_first && edge.isRequest(bundle.c.bits)) {
-      c_set                := UIntToOH(bundle.c.bits.source)
+      c_set                :<= UIntToOH(bundle.c.bits.source, edge.client.endSourceId)
       c_opcodes_set_interm := (bundle.c.bits.opcode << 1.U) | 1.U
       c_sizes_set_interm   := (bundle.c.bits.size << 1.U) | 1.U
       c_opcodes_set        := (c_opcodes_set_interm) << (bundle.c.bits.source << log_c_opcode_bus_size.U)
@@ -781,11 +781,11 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     val d_release_ack = bundle.d.bits.opcode === TLMessages.ReleaseAck
     when (bundle.d.valid && d_first && edge.isResponse(bundle.d.bits) && d_release_ack) {
-      d_clr_wo_ready := UIntToOH(bundle.d.bits.source)
+      d_clr_wo_ready :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
     }
 
     when (bundle.d.fire && d_first && edge.isResponse(bundle.d.bits) && d_release_ack) {
-      d_clr         := UIntToOH(bundle.d.bits.source)
+      d_clr         :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
       d_opcodes_clr := size_to_numfullbits(1.U << log_c_opcode_bus_size.U) << (bundle.d.bits.source << log_c_opcode_bus_size.U)
       d_sizes_clr   := size_to_numfullbits(1.U << log_c_size_bus_size.U) << (bundle.d.bits.source << log_c_size_bus_size.U)
     }
@@ -831,13 +831,13 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     val d_set = WireInit(0.U(edge.manager.endSinkId.W))
     when (bundle.d.fire && d_first && edge.isRequest(bundle.d.bits)) {
-      d_set := UIntToOH(bundle.d.bits.sink)
+      d_set :<= UIntToOH(bundle.d.bits.sink, edge.manager.endSinkId)
       assume(!inflight(bundle.d.bits.sink), "'D' channel re-used a sink ID" + extra)
     }
 
     val e_clr = WireInit(0.U(edge.manager.endSinkId.W))
     when (bundle.e.fire && e_first && edge.isResponse(bundle.e.bits)) {
-      e_clr := UIntToOH(bundle.e.bits.sink)
+      e_clr :<= UIntToOH(bundle.e.bits.sink, edge.manager.endSinkId)
       monAssert((d_set | inflight)(bundle.e.bits.sink), "'E' channel acknowledged for nothing inflight" + extra)
     }
 

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -11,6 +11,7 @@ import org.chipsalliance.diplomacy._
 import org.chipsalliance.diplomacy.EnableMonitors
 import freechips.rocketchip.formal.{MonitorDirection, IfThen, Property, PropertyClass, TestplanTestType, TLMonitorStrictMode}
 import freechips.rocketchip.util.PlusArg
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 case class TLMonitorArgs(edge: TLEdge)
 
@@ -633,11 +634,11 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     val a_opcode_lookup = WireInit(0.U((a_opcode_bus_size - 1).W))
     a_opcode_lookup.suggestName("a_opcode_lookup")
-    a_opcode_lookup :<= (((inflight_opcodes) >> (bundle.d.bits.source << log_a_opcode_bus_size) & size_to_numfullbits(1.U << log_a_opcode_bus_size)) >> 1).squeeze
+    a_opcode_lookup :%= (((inflight_opcodes) >> (bundle.d.bits.source << log_a_opcode_bus_size) & size_to_numfullbits(1.U << log_a_opcode_bus_size)) >> 1)
 
     val a_size_lookup = WireInit(0.U((1 << log_a_size_bus_size).W))
     a_size_lookup.suggestName("a_size_lookup")
-    a_size_lookup :<= (((inflight_sizes) >> (bundle.d.bits.source << log_a_size_bus_size) & size_to_numfullbits(1.U << log_a_size_bus_size)) >> 1).squeeze
+    a_size_lookup :%= (((inflight_sizes) >> (bundle.d.bits.source << log_a_size_bus_size) & size_to_numfullbits(1.U << log_a_size_bus_size)) >> 1)
 
     val responseMap             = VecInit(Seq(TLMessages.AccessAck, TLMessages.AccessAck, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.HintAck, TLMessages.Grant,     TLMessages.Grant))
     val responseMapSecondOption = VecInit(Seq(TLMessages.AccessAck, TLMessages.AccessAck, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.AccessAckData, TLMessages.HintAck, TLMessages.GrantData, TLMessages.Grant))
@@ -655,8 +656,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       a_set                :<= UIntToOH(bundle.a.bits.source, edge.client.endSourceId)
       a_opcodes_set_interm := (bundle.a.bits.opcode << 1.U) | 1.U
       a_sizes_set_interm   := (bundle.a.bits.size << 1.U) | 1.U
-      a_opcodes_set        :<= ((a_opcodes_set_interm) << (bundle.a.bits.source << log_a_opcode_bus_size)).squeeze
-      a_sizes_set          :<= ((a_sizes_set_interm) << (bundle.a.bits.source << log_a_size_bus_size)).squeeze
+      a_opcodes_set        :%= ((a_opcodes_set_interm) << (bundle.a.bits.source << log_a_opcode_bus_size))
+      a_sizes_set          :%= ((a_sizes_set_interm) << (bundle.a.bits.source << log_a_size_bus_size))
       monAssert(!inflight(bundle.a.bits.source), "'A' channel re-used a source ID" + extra)
     }
 
@@ -676,8 +677,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     when (bundle.d.fire && d_first && edge.isResponse(bundle.d.bits) && !d_release_ack) {
       d_clr         :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
-      d_opcodes_clr :<= (size_to_numfullbits(1.U << log_a_opcode_bus_size) << (bundle.d.bits.source << log_a_opcode_bus_size)).squeeze
-      d_sizes_clr   :<= (size_to_numfullbits(1.U << log_a_size_bus_size) << (bundle.d.bits.source << log_a_size_bus_size)).squeeze
+      d_opcodes_clr :%= (size_to_numfullbits(1.U << log_a_opcode_bus_size) << (bundle.d.bits.source << log_a_opcode_bus_size))
+      d_sizes_clr   :%= (size_to_numfullbits(1.U << log_a_size_bus_size) << (bundle.d.bits.source << log_a_size_bus_size))
     }
     when (bundle.d.valid && d_first && edge.isResponse(bundle.d.bits) && !d_release_ack) {
       val same_cycle_resp = bundle.a.valid && a_first && edge.isRequest(bundle.a.bits) && (bundle.a.bits.source === bundle.d.bits.source)
@@ -745,8 +746,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     val c_opcode_lookup = WireInit(0.U((1 << log_c_opcode_bus_size).W))
     val c_size_lookup   = WireInit(0.U((1 << log_c_size_bus_size).W))
-    c_opcode_lookup :<= (((inflight_opcodes) >> (bundle.d.bits.source << log_c_opcode_bus_size) & size_to_numfullbits(1.U << log_c_opcode_bus_size)) >> 1).squeeze
-    c_size_lookup   :<= (((inflight_sizes) >> (bundle.d.bits.source << log_c_size_bus_size) & size_to_numfullbits(1.U << log_c_size_bus_size)) >> 1).squeeze
+    c_opcode_lookup :%= (((inflight_opcodes) >> (bundle.d.bits.source << log_c_opcode_bus_size) & size_to_numfullbits(1.U << log_c_opcode_bus_size)) >> 1)
+    c_size_lookup   :%= (((inflight_sizes) >> (bundle.d.bits.source << log_c_size_bus_size) & size_to_numfullbits(1.U << log_c_size_bus_size)) >> 1)
     c_opcode_lookup.suggestName("c_opcode_lookup")
     c_size_lookup.suggestName("c_size_lookup")
 
@@ -763,8 +764,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       c_set                :<= UIntToOH(bundle.c.bits.source, edge.client.endSourceId)
       c_opcodes_set_interm := (bundle.c.bits.opcode << 1.U) | 1.U
       c_sizes_set_interm   := (bundle.c.bits.size << 1.U) | 1.U
-      c_opcodes_set        :<= ((c_opcodes_set_interm) << (bundle.c.bits.source << log_c_opcode_bus_size)).squeeze
-      c_sizes_set          :<= ((c_sizes_set_interm) << (bundle.c.bits.source << log_c_size_bus_size)).squeeze
+      c_opcodes_set        :%= ((c_opcodes_set_interm) << (bundle.c.bits.source << log_c_opcode_bus_size))
+      c_sizes_set          :%= ((c_sizes_set_interm) << (bundle.c.bits.source << log_c_size_bus_size))
       monAssert(!inflight(bundle.c.bits.source), "'C' channel re-used a source ID" + extra)
     }
 
@@ -786,8 +787,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
 
     when (bundle.d.fire && d_first && edge.isResponse(bundle.d.bits) && d_release_ack) {
       d_clr         :<= UIntToOH(bundle.d.bits.source, edge.client.endSourceId)
-      d_opcodes_clr :<= (size_to_numfullbits(1.U << log_c_opcode_bus_size) << (bundle.d.bits.source << log_c_opcode_bus_size)).squeeze
-      d_sizes_clr   :<= (size_to_numfullbits(1.U << log_c_size_bus_size) << (bundle.d.bits.source << log_c_size_bus_size)).squeeze
+      d_opcodes_clr :%= (size_to_numfullbits(1.U << log_c_opcode_bus_size) << (bundle.d.bits.source << log_c_opcode_bus_size))
+      d_sizes_clr   :%= (size_to_numfullbits(1.U << log_c_size_bus_size) << (bundle.d.bits.source << log_c_size_bus_size))
     }
 
     when (bundle.d.valid && d_first && edge.isResponse(bundle.d.bits) && d_release_ack) {

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -72,7 +72,7 @@ case class TLRegisterNode(
     val params = RegMapperParams(log2Up(size/beatBytes), beatBytes, fields)
     val in = Wire(Decoupled(new RegMapperInput(params)))
     in.bits.read  := a.bits.opcode === TLMessages.Get
-    in.bits.index := edge.addr_hi(a.bits)
+    in.bits.index :<= edge.addr_hi(a.bits).squeeze
     in.bits.data  := a.bits.data
     in.bits.mask  := a.bits.mask
     Connectable.waiveUnmatched(in.bits.extra, a.bits.echo) match {

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -14,6 +14,7 @@ import freechips.rocketchip.resources.{Device, Resource, ResourceBindings}
 import freechips.rocketchip.prci.{NoCrossing}
 import freechips.rocketchip.regmapper.{RegField, RegMapper, RegMapperParams, RegMapperInput, RegisterRouter}
 import freechips.rocketchip.util.{BundleField, ControlKey, ElaborationArtefacts, GenRegDescsAnno}
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 import scala.math.min
 
@@ -72,7 +73,7 @@ case class TLRegisterNode(
     val params = RegMapperParams(log2Up(size/beatBytes), beatBytes, fields)
     val in = Wire(Decoupled(new RegMapperInput(params)))
     in.bits.read  := a.bits.opcode === TLMessages.Get
-    in.bits.index :<= edge.addr_hi(a.bits).squeeze
+    in.bits.index :%= edge.addr_hi(a.bits)
     in.bits.data  := a.bits.data
     in.bits.mask  := a.bits.mask
     Connectable.waiveUnmatched(in.bits.extra, a.bits.echo) match {

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -57,7 +57,7 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
         // State tracking
         val sourceIdMap = Mem(maxInFlight, UInt(edgeIn.bundle.sourceBits.W))
         val allocated = RegInit(0.U(maxInFlight.W))
-        val nextFreeOH = ~(leftOR(~allocated) << 1) & ~allocated
+        val nextFreeOH = (~(leftOR(~allocated) << 1) & ~allocated)(maxInFlight-1, 0)
         val nextFree = OHToUInt(nextFreeOH)
         val full = allocated.andR
 
@@ -68,7 +68,7 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
         in.a.ready := out.a.ready && !block
         out.a.valid := in.a.valid && !block
         out.a.bits :<= in.a.bits.squeezeAll
-        out.a.bits.source := nextFree holdUnless a_first
+        out.a.bits.source :<= nextFree holdUnless a_first
 
         val bypass = (edgeOut.manager.minLatency == 0).B && in.a.valid && !full && a_first && nextFree === out.d.bits.source
         in.d <> out.d
@@ -82,7 +82,7 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
         val free = d_last && in.d.fire
         val alloc_id = Mux(alloc, nextFreeOH, 0.U)
         val free_id = Mux(free, UIntToOH(out.d.bits.source), 0.U)
-        allocated := (allocated | alloc_id) & ~free_id
+        allocated :<= (allocated | alloc_id) & ~free_id
       }
     }
   }

--- a/src/main/scala/tilelink/SourceShrinker.scala
+++ b/src/main/scala/tilelink/SourceShrinker.scala
@@ -67,7 +67,7 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
         val block = a_first && full
         in.a.ready := out.a.ready && !block
         out.a.valid := in.a.valid && !block
-        out.a.bits := in.a.bits
+        out.a.bits :<= in.a.bits.squeezeAll
         out.a.bits.source := nextFree holdUnless a_first
 
         val bypass = (edgeOut.manager.minLatency == 0).B && in.a.valid && !full && a_first && nextFree === out.d.bits.source

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -15,6 +15,7 @@ import freechips.rocketchip.amba.ahb.{AHBImpMaster, AHBParameters, AHBMasterPara
 import freechips.rocketchip.amba.ahb.AHBParameters.{BURST_INCR, BURST_SINGLE, TRANS_NONSEQ, TRANS_SEQ, TRANS_IDLE, TRANS_BUSY, PROT_DEFAULT}
 import freechips.rocketchip.diplomacy.TransferSizes
 import freechips.rocketchip.util.{BundleMap, UIntToOH1}
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImpMaster)(
   dFn = { cp =>
@@ -116,7 +117,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
         step.first := false.B
         step.last  := (if (lgBytes + 1 >= lgMax) true.B else
                        !((UIntToOH1(send.size, lgMax) & ~send.addr) >> (lgBytes + 1)).orR)
-        step.addr  :<= Cat(send.addr(edgeIn.bundle.addressBits-1, lgMax), send.addr(lgMax-1, 0) + beatBytes.U).squeeze
+        step.addr  :%= Cat(send.addr(edgeIn.bundle.addressBits-1, lgMax), send.addr(lgMax-1, 0) + beatBytes.U)
       } .otherwise /* new burst */ {
         step.full  := false.B
         step.send  := false.B

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -116,7 +116,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true, val 
         step.first := false.B
         step.last  := (if (lgBytes + 1 >= lgMax) true.B else
                        !((UIntToOH1(send.size, lgMax) & ~send.addr) >> (lgBytes + 1)).orR)
-        step.addr  := Cat(send.addr(edgeIn.bundle.addressBits-1, lgMax), send.addr(lgMax-1, 0) + beatBytes.U)
+        step.addr  :<= Cat(send.addr(edgeIn.bundle.addressBits-1, lgMax), send.addr(lgMax-1, 0) + beatBytes.U).squeeze
       } .otherwise /* new burst */ {
         step.full  := false.B
         step.send  := false.B

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -16,6 +16,7 @@ import freechips.rocketchip.diplomacy.{IdMap, IdMapEntry, IdRange}
 import freechips.rocketchip.util.{BundleField, ControlKey, ElaborationArtefacts, UIntToOH1}
 
 import freechips.rocketchip.util.DataToAugmentedData
+import freechips.rocketchip.util.ConnectableBitsOpExtension
 
 class AXI4TLStateBundle(val sourceBits: Int) extends Bundle {
   val size   = UInt(4.W)
@@ -172,7 +173,7 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       arw.id    := sourceTable(a_source)
       arw.addr  := a_address
       arw.len   := UIntToOH1(a_size, AXI4Parameters.lenBits + log2Ceil(beatBytes)) >> log2Ceil(beatBytes)
-      arw.size  :<= Mux(a_size >= maxSize, maxSize, a_size).squeeze
+      arw.size  :%= Mux(a_size >= maxSize, maxSize, a_size)
       arw.burst := AXI4Parameters.BURST_INCR
       arw.lock  := 0.U // not exclusive (LR/SC unsupported b/c no forward progress guarantee)
       arw.cache := 0.U // do not allow AXI to modify our transactions

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -172,7 +172,7 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       arw.id    := sourceTable(a_source)
       arw.addr  := a_address
       arw.len   := UIntToOH1(a_size, AXI4Parameters.lenBits + log2Ceil(beatBytes)) >> log2Ceil(beatBytes)
-      arw.size  := Mux(a_size >= maxSize, maxSize, a_size)
+      arw.size  :<= Mux(a_size >= maxSize, maxSize, a_size).squeeze
       arw.burst := AXI4Parameters.BURST_INCR
       arw.lock  := 0.U // not exclusive (LR/SC unsupported b/c no forward progress guarantee)
       arw.cache := 0.U // do not allow AXI to modify our transactions

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -129,7 +129,7 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
         mux(index)
       }
 
-      out.bits := in.bits
+      out.bits :<= in.bits.squeezeAll
       out.valid := in.valid
       in.ready := out.ready
 

--- a/src/main/scala/util/Counters.scala
+++ b/src/main/scala/util/Counters.scala
@@ -44,7 +44,7 @@ case class WideCounter(width: Int, inc: UInt = 1.U, reset: Boolean = true, inhib
   private val smallWidth = if (isWide) inc.getWidth max log2Up(width) else width
   private val small = if (reset) RegInit(0.U(smallWidth.W)) else Reg(UInt(smallWidth.W))
   private val nextSmall = small +& inc
-  when (!inhibit) { small :<= nextSmall.squeeze }
+  when (!inhibit) { small :%= nextSmall }
 
   private val large = if (isWide) {
     val r = if (reset) RegInit(0.U((width - smallWidth).W)) else Reg(UInt((width - smallWidth).W))
@@ -64,7 +64,7 @@ case class WideCounter(width: Int, inc: UInt = 1.U, reset: Boolean = true, inhib
   }
 
   def := (x: UInt) = {
-    small :<= x.squeeze
+    small :%= x
     if (isWide) large := x >> smallWidth
   }
 }

--- a/src/main/scala/util/Counters.scala
+++ b/src/main/scala/util/Counters.scala
@@ -44,7 +44,7 @@ case class WideCounter(width: Int, inc: UInt = 1.U, reset: Boolean = true, inhib
   private val smallWidth = if (isWide) inc.getWidth max log2Up(width) else width
   private val small = if (reset) RegInit(0.U(smallWidth.W)) else Reg(UInt(smallWidth.W))
   private val nextSmall = small +& inc
-  when (!inhibit) { small := nextSmall }
+  when (!inhibit) { small :<= nextSmall.squeeze }
 
   private val large = if (isWide) {
     val r = if (reset) RegInit(0.U((width - smallWidth).W)) else Reg(UInt((width - smallWidth).W))
@@ -64,7 +64,7 @@ case class WideCounter(width: Int, inc: UInt = 1.U, reset: Boolean = true, inhib
   }
 
   def := (x: UInt) = {
-    small := x
+    small :<= x.squeeze
     if (isWide) large := x >> smallWidth
   }
 }

--- a/src/main/scala/util/PlusArg.scala
+++ b/src/main/scala/util/PlusArg.scala
@@ -86,7 +86,7 @@ object PlusArg
     */
   def timeout(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32)(count: UInt): Unit = {
     PlusArgArtefacts.append(name, Some(default), docstring)
-    Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count :<= count.squeeze
+    Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count :%= count
   }
 }
 

--- a/src/main/scala/util/PlusArg.scala
+++ b/src/main/scala/util/PlusArg.scala
@@ -86,7 +86,7 @@ object PlusArg
     */
   def timeout(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32)(count: UInt): Unit = {
     PlusArgArtefacts.append(name, Some(default), docstring)
-    Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count := count
+    Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count :<= count.squeeze
   }
 }
 

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -305,7 +305,7 @@ class SetAssocLRU(n_sets: Int, n_ways: Int, policy: String) extends SetAssocRepl
     else RegInit(VecInit(Seq.fill(n_sets)(0.U(logic.nBits.W))))
 
   def access(set: UInt, touch_way: UInt) = {
-    state_vec(set) :<= logic.get_next_state(state_vec(set), touch_way).squeeze
+    state_vec(set) :%= logic.get_next_state(state_vec(set), touch_way)
   }
 
   def access(sets: Seq[UInt], touch_ways: Seq[Valid[UInt]]) = {

--- a/src/main/scala/util/Replacement.scala
+++ b/src/main/scala/util/Replacement.scala
@@ -305,7 +305,7 @@ class SetAssocLRU(n_sets: Int, n_ways: Int, policy: String) extends SetAssocRepl
     else RegInit(VecInit(Seq.fill(n_sets)(0.U(logic.nBits.W))))
 
   def access(set: UInt, touch_way: UInt) = {
-    state_vec(set) := logic.get_next_state(state_vec(set), touch_way)
+    state_vec(set) :<= logic.get_next_state(state_vec(set), touch_way).squeeze
   }
 
   def access(sets: Seq[UInt], touch_ways: Seq[Valid[UInt]]) = {

--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -4,6 +4,7 @@ package freechips.rocketchip
 
 import chisel3._
 import chisel3.util._
+import chisel3.experimental.SourceInfo
 import scala.language.implicitConversions
 import scala.math.min
 import scala.collection.{immutable, mutable}
@@ -217,6 +218,15 @@ package object util {
 
     // Like >=, but prevents x-prop for ('x >= 0)
     def >== (y: UInt): Bool = x >= y || y === 0.U
+  }
+
+  // Backport of `chisel3.connectable.Connectable.ConnectableBitsOpExtension`'s `:%=`. This arrived
+  // in Chisel 7.14.0, so once rocket-chip's minimum supported Chisel version reaches that, we can
+  // drop this.
+  implicit class ConnectableBitsOpExtension[T <: Bits](private val x: T) extends AnyVal {
+    def :%=[S <: Bits](y: => S)(implicit evidence: T =:= S, sourceInfo: SourceInfo): Unit = {
+      x :#= y.squeeze
+    }
   }
 
   implicit class OptionUIntToAugmentedOptionUInt(private val x: Option[UInt]) extends AnyVal {


### PR DESCRIPTION
firtool-1.154.0 and later warn on all implicit width truncations (https://github.com/llvm/circt/pull/10621). These width truncations were flagged in stock Chipyard builds.

The commits in this PR are separated by the type of truncation fix, and the commit messages describe why the fix was made, and why the resulting RTL is equivalent to the existing design.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Resolve implicit-width-truncation warnings